### PR TITLE
fix(grid): init dataset on attached if it has data

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -87,7 +87,7 @@ export class AureliaSlickgridCustomElement {
     this.ea.publish('onBeforeGridCreate', true);
 
     // make sure the dataset is initialized (if not it will throw an error that it cannot getLength of null)
-    this._dataset = this._dataset || [];
+    this._dataset = this._dataset || this.dataset || [];
     this._gridOptions = this.mergeGridOptions();
     this.createBackendApiInternalPostProcessCallback(this._gridOptions);
 


### PR DESCRIPTION
This pull requests ensures that the `AureliaSlickgridCustomElement` will use the `dataset` when it is created without relying on `datasetChanged`

**Current State**
The `_dataset` is set in two methods: `attached` and `datasetChanged`. However, what happens if the view model is created and the dataset already has the data locally in a service, cache etc? That would mean that `datasetChanged` would never fire and the grid will always be empty. I experienced this problem when navigating back and forth between view-models. The first time I navigate to the view model, the grid is populated because I fetch the data from an API. However, when I navigate away and then back to that view model the grid becomes empty because `dataset` already has the data when the custom element is reattached to the DOM. 

**Future State**
The simple change in this pull request will ensure the `_dataset` is initially set to the dataset in case the `datasetChanged` method is never fired:



