### PR TITLE
fix(grid): gridHeight & gridWidth not set, closes #35

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.html
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.html
@@ -1,6 +1,6 @@
 <template>
-  <div id="slickGridContainer-${gridId}" class="gridPane">
-    <div id.bind="gridId" class="slickgrid-container" style.bind="style">
+  <div id="slickGridContainer-${gridId}" class="gridPane" css.bind="gridStyleWidth">
+    <div id.bind="gridId" class="slickgrid-container" style="width: 100%" css.bind="gridStyleHeight">
     </div>
 
     <slick-pagination id="slickPagingContainer-${gridId}" if.bind="showPagination" asg-on-pagination-changed.delegate="paginationChanged($event.detail)"

--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -61,11 +61,10 @@ export class AureliaSlickgridCustomElement {
   private _dataset: any[];
   private _eventHandler: any = new Slick.EventHandler();
   gridStateSubscriber: Subscription;
-  gridHeightString: string;
-  gridWidthString: string;
+  gridStyleHeight: { height: string; };
+  gridStyleWidth: { width: string; };
   localeChangedSubscriber: Subscription;
   showPagination = false;
-  style: any;
 
   @bindable({ defaultBindingMode: bindingMode.twoWay }) element: Element;
   @bindable({ defaultBindingMode: bindingMode.twoWay }) dataset: any[];
@@ -75,7 +74,7 @@ export class AureliaSlickgridCustomElement {
   @bindable() gridId: string;
   @bindable() columnDefinitions: Column[];
   @bindable() gridOptions: GridOption;
-  @bindable() gridHeight = 100;
+  @bindable() gridHeight = 200;
   @bindable() gridWidth = 600;
   @bindable() pickerOptions: any;
 
@@ -186,10 +185,14 @@ export class AureliaSlickgridCustomElement {
     // get the grid options (priority is Global Options first, then user option which could overwrite the Global options)
     this.gridOptions = { ...GlobalGridOptions, ...binding.gridOptions };
 
-    this.style = {
-      height: `${binding.gridHeight}px`,
-      width: `${binding.gridWidth}px`
-    };
+    if (!this.gridOptions.enableAutoResize) {
+      this.gridStyleWidth = {
+        width: `${this.gridWidth}px`
+      };
+      this.gridStyleHeight = {
+        height: `${this.gridHeight}px`
+      };
+    }
 
     // Wrap each editor class in the Factory resolver so consumers of this library can use
     // dependency injection. Aurelia will resolve all dependencies when we pass the container
@@ -395,8 +398,6 @@ export class AureliaSlickgridCustomElement {
       if (options.autoFitColumnsOnFirstLoad && typeof grid.autosizeColumns === 'function') {
         grid.autosizeColumns();
       }
-    } else {
-      this.resizer.resizeGrid(0, { height: this.gridHeight, width: this.gridWidth });
     }
   }
 


### PR DESCRIPTION
@jmzagorski 
I would like like a review on this, grid height and width fix. I found this good [article](https://ilikekillnerds.com/2016/02/binding-with-style-in-aurelia/) on `css.bind` and I switched to that. I also found why I was resizing the grid at later point with `gridHeight` and `gridWidth`, it was because of the Pagination component that I use with Backend Service, it was taking 100% width of the screen instead of the grid size, unless I resized it. I found that if I put the width on the grid container, then set the grid to `width: 100%`, like it is shown in the [SlickGrid example](https://github.com/6pac/SlickGrid/blob/master/examples/example4-model.html#L37), that fixes my issue and the pagination still have a width 100%. 

So it all seems to work for me now, but I would really like if you could take 5-10min to review and possibly test it. 