### PR TITLE
fix(editors): use indexOf in multiple select editor to load value

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/multipleSelectEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/multipleSelectEditor.ts
@@ -106,7 +106,7 @@ export class MultipleSelectEditor implements Editor {
     }
 
     // user might want to sort the collection
-    if (this.gridOptions && this.gridOptions.params && this.columnDef.params.collectionSortBy) {
+    if (this.columnDef.params && this.columnDef.params.collectionSortBy) {
       const sortBy = this.columnDef.params.collectionSortBy;
       newCollection = this.collectionService.sortCollection(newCollection, sortBy, this.enableTranslateLabel);
     }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/multipleSelectEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/multipleSelectEditor.ts
@@ -130,7 +130,7 @@ export class MultipleSelectEditor implements Editor {
     this.defaultValue = item[this.columnDef.field].map((i: any) => i.toString());
 
     this.$editorElm.find('option').each((i: number, $e: any) => {
-      if (this.defaultValue === $e.value) {
+      if (this.defaultValue.indexOf($e.value) !== -1) {
         $e.selected = true;
       } else {
         $e.selected = false;

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/singleSelectEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/singleSelectEditor.ts
@@ -98,7 +98,7 @@ export class SingleSelectEditor implements Editor {
     }
 
     // user might want to sort the collection
-    if (this.gridOptions.params && this.columnDef.params.collectionSortBy) {
+    if (this.columnDef.params && this.columnDef.params.collectionSortBy) {
       const sortBy = this.columnDef.params.collectionSortBy;
       newCollection = this.collectionService.sortCollection(newCollection, sortBy, this.enableTranslateLabel);
     }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/multipleSelectFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/multipleSelectFilter.ts
@@ -92,7 +92,7 @@ export class MultipleSelectFilter implements Filter {
     }
 
     // user might want to sort the collection
-    if (this.gridOptions.params && this.columnDef.filter.collectionSortBy) {
+    if (this.columnDef.filter && this.columnDef.filter.collectionSortBy) {
       const sortBy = this.columnDef.filter.collectionSortBy;
       newCollection = this.collectionService.sortCollection(newCollection, sortBy, this.enableTranslateLabel);
     }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/singleSelectFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/singleSelectFilter.ts
@@ -84,7 +84,7 @@ export class SingleSelectFilter implements Filter {
     }
 
     // user might want to sort the collection
-    if (this.gridOptions.params && this.columnDef.filter.collectionSortBy) {
+    if (this.columnDef.filter && this.columnDef.filter.collectionSortBy) {
       const sortBy = this.columnDef.filter.collectionSortBy;
       newCollection = this.collectionService.sortCollection(newCollection, sortBy, this.enableTranslateLabel);
     }

--- a/aurelia-slickgrid/src/examples/slickgrid/example12.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example12.ts
@@ -79,7 +79,8 @@ export class Example12 {
         filter: {
           collection: [{ value: '', label: '' }, { value: 'TRUE', labelKey: 'TRUE' }, { value: 'FALSE', labelKey: 'FALSE' }],
           collectionSortBy: {
-            property: 'labelKey' // will sort by translated value since "enableTranslateLabel" is true
+            property: 'labelKey', // will sort by translated value since "enableTranslateLabel" is true
+            sortDesc: true
           },
           type: FilterType.singleSelect,
           enableTranslateLabel: true,

--- a/aurelia-slickgrid/src/examples/slickgrid/example3.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example3.ts
@@ -159,7 +159,7 @@ export class Example3 {
       type: FieldType.string,
       editor: Editors.multipleSelect,
       params: {
-        collection: Array.from(Array(10).keys()).map(k => ({ value: `Task ${k}`, label: `Task ${k}` })),
+        collection: Array.from(Array(12).keys()).map(k => ({ value: `Task ${k}`, label: `Task ${k}` })),
         collectionSortBy: {
           property: 'label',
           sortDesc: true
@@ -213,7 +213,7 @@ export class Example3 {
         start: new Date(randomYear, randomMonth, randomDay),
         finish: new Date(randomYear, (randomMonth + 1), randomDay),
         effortDriven: (i % 5 === 0),
-        prerequisites: (i % 5 === 0) && i > 0 ? [`Task ${i}`, `Task ${i - 1}`] : []
+        prerequisites: (i % 2 === 0) && i !== 0 && i < 12 ? [`Task ${i}`, `Task ${i - 1}`] : []
       };
     }
     this.dataset = mockedDataset;

--- a/aurelia-slickgrid/src/examples/slickgrid/example4.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example4.ts
@@ -129,7 +129,6 @@ export class Example4 {
     ];
 
     this.gridOptions = {
-      params: {},
       autoResize: {
         containerId: 'demo-container',
         sidePadding: 15

--- a/aurelia-slickgrid/src/examples/slickgrid/example4.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example4.ts
@@ -81,6 +81,11 @@ export class Example4 {
         filterable: true,
         filter: {
           collection: multiSelectFilterArray,
+          collectionSortBy: {
+            property: 'value',
+            sortDesc: true,
+            fieldType: FieldType.number
+          },
           type: FilterType.multipleSelect,
           searchTerms: [1, 33, 50], // default selection
           // we could add certain option(s) to the "multiple-select" plugin
@@ -124,6 +129,7 @@ export class Example4 {
     ];
 
     this.gridOptions = {
+      params: {},
       autoResize: {
         containerId: 'demo-container',
         sidePadding: 15


### PR DESCRIPTION
`indexOf` must be used because `defaultValue` is an array for the `multipleSelectEditor`. the current `multipleSelectEditor` is broken and values are not loaded when the multiple select list is opened.

This reverts part of this [commit](https://github.com/ghiscoding/aurelia-slickgrid/commit/71916dc8bd80e257c310fa89485fc8a2e534a5d1) for the `multipleSelectEditor`.

The excel export and the sort still works with numbers. However, the current state of sorters will not sort "Task 2" and "Task 10" correctly regardless of the editors because those values are strings and not numbers. A separate issue would have to be opened to that. I updated `Example3.ts` to show that problem by allowing in Tasks greater than 10 in the prerequisite column.

If I can figure out/have permission to release a hot fix (version 1.12.3) I will do that because I would imagine this is critical since it breaks inline editing.

