### PR TITLE
fix(eventService): use grid.getOptions for gridDefinition

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -342,8 +342,8 @@ export class AureliaSlickgridCustomElement {
     });
 
     // on cell click, mainly used with the columnDef.action callback
-    this.gridEventService.attachOnCellChange(grid, this.gridOptions, dataView);
-    this.gridEventService.attachOnClick(grid, this.gridOptions, dataView);
+    this.gridEventService.attachOnCellChange(grid, dataView);
+    this.gridEventService.attachOnClick(grid, dataView);
 
     this._eventHandler.subscribe(dataView.onRowCountChanged, (e: any, args: any) => {
       grid.updateRowCount();

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/gridEvent.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/gridEvent.service.ts
@@ -22,7 +22,7 @@ export class GridEventService {
           row: args.row,
           cell: args.cell,
           dataView,
-          gridDefinition: gridOptions,
+          gridDefinition: grid.getOptions(),
           grid,
           columnDef: column,
           dataContext: args.grid.getDataItem(args.row)
@@ -49,7 +49,7 @@ export class GridEventService {
           row: args.row,
           cell: args.cell,
           dataView,
-          gridDefinition: gridOptions,
+          gridDefinition: grid.getOptions(),
           grid,
           columnDef: column,
           dataContext: args.grid.getDataItem(args.row)

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/gridEvent.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/gridEvent.service.ts
@@ -7,13 +7,13 @@ export class GridEventService {
   private _eventHandler: any = new Slick.EventHandler();
 
   /* OnCellChange Event */
-  attachOnCellChange(grid: any, gridOptions: GridOption, dataView: any) {
+  attachOnCellChange(grid: any, dataView: any) {
     // subscribe to this Slickgrid event of onCellChange
     this._eventHandler.subscribe(grid.onCellChange, (e: Event, args: CellArgs) => {
-      if (!e || !args || !args.grid || args.cell === undefined || !args.grid.getColumns || !args.grid.getDataItem) {
+      if (!e || !args || !grid || args.cell === undefined || !grid.getColumns || !grid.getDataItem) {
         return;
       }
-      const column = args.grid.getColumns()[args.cell];
+      const column = grid.getColumns()[args.cell];
 
       // if the column definition has a onCellChange property (a callback function), then run it
       if (typeof column.onCellChange === 'function') {
@@ -25,7 +25,7 @@ export class GridEventService {
           gridDefinition: grid.getOptions(),
           grid,
           columnDef: column,
-          dataContext: args.grid.getDataItem(args.row)
+          dataContext: grid.getDataItem(args.row)
         };
 
         // finally call up the Slick.column.onCellChanges.... function
@@ -35,12 +35,12 @@ export class GridEventService {
     });
   }
   /* OnClick Event */
-  attachOnClick(grid: any, gridOptions: GridOption, dataView: any) {
+  attachOnClick(grid: any, dataView: any) {
     this._eventHandler.subscribe(grid.onClick, (e: Event, args: CellArgs) => {
-      if (!e || !args || !args.grid || args.cell === undefined || !args.grid.getColumns || !args.grid.getDataItem) {
+      if (!e || !args || !grid || args.cell === undefined || !grid.getColumns || !grid.getDataItem) {
         return;
       }
-      const column = args.grid.getColumns()[args.cell];
+      const column = grid.getColumns()[args.cell];
 
       // if the column definition has a onCellClick property (a callback function), then run it
       if (typeof column.onCellClick === 'function') {
@@ -52,7 +52,7 @@ export class GridEventService {
           gridDefinition: grid.getOptions(),
           grid,
           columnDef: column,
-          dataContext: args.grid.getDataItem(args.row)
+          dataContext: grid.getDataItem(args.row)
         };
 
         // finally call up the Slick.column.onCellClick.... function

--- a/aurelia-slickgrid/src/examples/slickgrid/example3.html
+++ b/aurelia-slickgrid/src/examples/slickgrid/example3.html
@@ -25,7 +25,7 @@
 
   <div class="col-sm-8">
     <div class="alert alert-info" show.bind="updatedObject">
-      <strong>Update Object:</strong> ${updatedObject | stringify}
+      <strong>Updated Item:</strong> ${updatedObject | stringify}
     </div>
     <div class="alert alert-warning" show.bind="alertWarning">
       <strong></strong> ${alertWarning}

--- a/aurelia-slickgrid/src/examples/slickgrid/example3.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example3.ts
@@ -85,13 +85,13 @@ export class Example3 {
       formatter: Formatters.deleteIcon,
       minWidth: 30,
       maxWidth: 30,
-      // use onCellClick OR grid.onClick.subscribe which you can see down below
-      /*
-      onCellClick: (args: OnEventArgs) => {
-        console.log(args);
-        this.alertWarning = `Deleting: ${args.dataContext.title}`;
-      }
-      */
+    // use onCellClick OR grid.onClick.subscribe which you can see down below
+    /*
+    onCellClick: (args: OnEventArgs) => {
+      console.log(args);
+      this.alertWarning = `Deleting: ${args.dataContext.title}`;
+    }
+    */
     }, {
       id: 'title',
       name: 'Title',
@@ -99,7 +99,11 @@ export class Example3 {
       sortable: true,
       type: FieldType.string,
       editor: Editors.longText,
-      minWidth: 100
+      minWidth: 100,
+      onCellChange: (args: OnEventArgs) => {
+        console.log(args);
+        this.alertWarning = `Updated Title: ${args.dataContext.title}`;
+      }
     }, {
       id: 'duration',
       name: 'Duration (days)',


### PR DESCRIPTION
This fixes a potential problem where the grid options as a parameter in the method are different than grid.getOptions. Users are allowed to change options after the grid is created by calling, for example, `grid.getOptions().showHeaderValue = false`. To make sure the options are up to date we need to call `grid.getOptions` when passing it as event args. 

Looking over `AureliaSlickgridCustomElement`, it should be fine to use `this.gridOptions` because most of the configuration is happening when the custom element is being created. The only potential issue I could see is if the `datasetChanged` fires after the grid is created. Then any call to `this.gridOptions` could potentially be out of data if the developer allows the user to change options later on. You can see this bug in example3 when you switch `autoEdit` off and click the "edit" button. The gridDefinition has `autoEdit=true` when it should be false

I was not sure if you wanted to use `args.grid` or just the `grid` param because I see you use both so I just picked one.

closes #49