### PR TITLE
fix(gridOptions): use this.gridOptions in bind fn

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -214,7 +214,7 @@ export class AureliaSlickgridCustomElement {
    */
   bind(binding: any, contexts: any) {
     // get the grid options (priority is Global Options first, then user option which could overwrite the Global options)
-    this.gridOptions = { ...GlobalGridOptions, ...binding.gridOptions };
+    this.gridOptions = { ...GlobalGridOptions, ...this.gridOptions };
 
     // Wrap each editor class in the Factory resolver so consumers of this library can use
     // dependency injection. Aurelia will resolve all dependencies when we pass the container


### PR DESCRIPTION
I know this is small pull request, but I like to break it out so you can see the change without having to go looking in master commits....

Using the first arg in the bind method looks at the parent context, which might not be the view-model with the `gridOptions`. For example in a `repeat.for`, the view-model properties are not available, which can be wrong if aurelia slickgrid is in a `repeat.for`. Using `this.gridOptions` assures us we are using the options that are bound