### PR TITLE
refactor(services): remove gridOptions and columnDefinitions

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -132,7 +132,7 @@ export class AureliaSlickgridCustomElement {
     }
     this.controlAndPluginService.createPluginBeforeGridCreation(this.columnDefinitions, this.gridOptions);
     this.grid = new Slick.Grid(`#${this.gridId}`, this.dataview, this.columnDefinitions, this.gridOptions);
-    this.controlAndPluginService.attachDifferentControlOrPlugins(this.grid, this.columnDefinitions, this.gridOptions, this.dataview, this.groupItemMetadataProvider);
+    this.controlAndPluginService.attachDifferentControlOrPlugins(this.grid, this.dataview, this.groupItemMetadataProvider);
 
     this.attachDifferentHooks(this.grid, this.gridOptions, this.dataview);
 
@@ -162,7 +162,7 @@ export class AureliaSlickgridCustomElement {
     }
 
     // attach grid extra service
-    this.gridExtraService.init(this.grid, this.columnDefinitions, this.gridOptions, this.dataview);
+    this.gridExtraService.init(this.grid, this.dataview);
 
     // when user enables translation, we need to translate Headers on first pass & subsequently in the attachDifferentHooks
     if (this.gridOptions.enableTranslate) {
@@ -171,7 +171,7 @@ export class AureliaSlickgridCustomElement {
 
     // if Export is enabled, initialize the service with the necessary grid and other objects
     if (this.gridOptions.enableExport) {
-      this.exportService.init(this.grid, this.gridOptions, this.dataview);
+      this.exportService.init(this.grid, this.dataview);
     }
 
     // attach the Backend Service API callback functions only after the grid is initialized
@@ -278,13 +278,13 @@ export class AureliaSlickgridCustomElement {
 
     // attach external filter (backend) when available or default onFilter (dataView)
     if (gridOptions.enableFiltering) {
-      this.filterService.init(grid, gridOptions, this.columnDefinitions);
+      this.filterService.init(grid);
 
       // if user entered some "presets", we need to reflect them all in the DOM
       if (gridOptions.presets && gridOptions.presets.filters) {
-        this.filterService.populateColumnFilterSearchTerms(gridOptions, this.columnDefinitions);
+        this.filterService.populateColumnFilterSearchTerms(grid);
       }
-      (gridOptions.backendServiceApi || gridOptions.onBackendEventApi) ? this.filterService.attachBackendOnFilter(grid, gridOptions) : this.filterService.attachLocalOnFilter(grid, gridOptions, this.dataview);
+      (gridOptions.backendServiceApi || gridOptions.onBackendEventApi) ? this.filterService.attachBackendOnFilter(grid) : this.filterService.attachLocalOnFilter(grid, this.dataview);
     }
 
     // if user set an onInit Backend, we'll run it right away (and if so, we also need to run preProcess, internalPostProcess & postProcess)

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/controlAndPlugin.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/controlAndPlugin.service.ts
@@ -29,8 +29,6 @@ declare var Slick: any;
 export class ControlAndPluginService {
   private _dataView: any;
   private _grid: any;
-  private _gridOptions: GridOption;
-  private _columnDefinitions: Column[];
   visibleColumns: Column[];
   areVisibleColumnDifferent = false;
 
@@ -51,6 +49,16 @@ export class ControlAndPluginService {
     private sortService: SortService
   ) { }
 
+  /** Getter for the Grid Options pulled through the Grid Object */
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
+  /** Getter for the Column Definitions pulled through the Grid Object */
+  private get _columnDefinitions(): Column[] {
+    return (this._grid && this._grid.getColumns) ? this._grid.getColumns() : [];
+  }
+
   /** Auto-resize all the column in the grid to fit the grid width */
   autoResizeColumns() {
     this._grid.autosizeColumns();
@@ -59,15 +67,12 @@ export class ControlAndPluginService {
   /**
    * Attach/Create different Controls or Plugins after the Grid is created
    * @param grid
-   * @param columnDefinitions
-   * @param options
    * @param dataView
+   * @param groupItemMetadataProvider
    */
   attachDifferentControlOrPlugins(grid: any, dataView: any, groupItemMetadataProvider: any) {
     this._grid = grid;
     this._dataView = dataView;
-    this._gridOptions = (grid && grid.getOptions) ? grid.getOptions() : {};
-    this._columnDefinitions = (grid && grid.getColumns) ? grid.getColumns() : [];
     this.visibleColumns = this._columnDefinitions;
 
     // Column Picker Plugin

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/controlAndPlugin.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/controlAndPlugin.service.ts
@@ -213,7 +213,6 @@ export class ControlAndPluginService {
    * Create the Column Picker and expose all the available hooks that user can subscribe (onColumnsChanged)
    * @param grid
    * @param columnDefinitions
-   * @param _gridOptions
    */
   createColumnPicker(grid: any, columnDefinitions: Column[]) {
     // localization support for the picker
@@ -283,8 +282,8 @@ export class ControlAndPluginService {
   /**
    * Create the Header Menu and expose all the available hooks that user can subscribe (onCommand, onBeforeMenuShow, ...)
    * @param grid
+   * @param dataView
    * @param columnDefinitions
-   * @param _gridOptions
    */
   createHeaderMenu(grid: any, dataView: any, columnDefinitions: Column[]) {
     this._gridOptions.headerMenu = { ...this.getDefaultHeaderMenuOptions(), ...this._gridOptions.headerMenu };
@@ -400,7 +399,6 @@ export class ControlAndPluginService {
   /**
    * Create Grid Menu with Custom Commands if user has enabled Filters and/or uses a Backend Service (OData, GraphQL)
    * @param grid
-   * @param _gridOptions
    */
   private addGridMenuCustomCommands(grid: any) {
     const backendApi = this._gridOptions.backendServiceApi || this._gridOptions.onBackendEventApi || null;
@@ -580,7 +578,11 @@ export class ControlAndPluginService {
     }
   }
 
-  /** Remove a column from the grid by it's index in the grid */
+  /**
+   * Remove a column from the grid by it's index in the grid
+   * @param array input
+   * @param index
+   */
   removeColumnByIndex(array: any[], index: number) {
     return array.filter((el: any, i: number) => {
       return index !== i;
@@ -653,7 +655,6 @@ export class ControlAndPluginService {
    * Create Header Menu with Custom Commands if user has enabled Header Menu
    * @param grid
    * @param dataView
-   * @param _gridOptions
    * @param columnDefinitions
    * @return header menu
    */
@@ -778,7 +779,7 @@ export class ControlAndPluginService {
 
   /**
    * Reset all the Grid Menu options which have text to translate
-   * @param grid menu object
+   * @param gridMenu object
    */
   private resetGridMenuTranslations(gridMenu: GridMenu): GridMenu {
     // we will reset the custom items array since the commands title have to be translated too (no worries, we will re-create it later)
@@ -794,7 +795,7 @@ export class ControlAndPluginService {
 
   /**
    * Reset all the Grid Menu options which have text to translate
-   * @param grid menu object
+   * @param columnDefinitions
    */
   private resetHeaderMenuTranslations(columnDefinitions: Column[]) {
     columnDefinitions.forEach((columnDef: Column) => {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/controlAndPlugin.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/controlAndPlugin.service.ts
@@ -63,85 +63,85 @@ export class ControlAndPluginService {
    * @param options
    * @param dataView
    */
-  attachDifferentControlOrPlugins(grid: any, columnDefinitions: Column[], options: GridOption, dataView: any, groupItemMetadataProvider: any) {
+  attachDifferentControlOrPlugins(grid: any, dataView: any, groupItemMetadataProvider: any) {
     this._grid = grid;
-    this._gridOptions = options;
     this._dataView = dataView;
-    this._columnDefinitions = columnDefinitions;
-    this.visibleColumns = columnDefinitions;
+    this._gridOptions = (grid && grid.getOptions) ? grid.getOptions() : {};
+    this._columnDefinitions = (grid && grid.getColumns) ? grid.getColumns() : [];
+    this.visibleColumns = this._columnDefinitions;
 
     // Column Picker Plugin
-    if (options.enableColumnPicker) {
-      this.columnPickerControl = this.createColumnPicker(grid, columnDefinitions, options);
+    if (this._gridOptions.enableColumnPicker) {
+      this.columnPickerControl = this.createColumnPicker(grid, this._columnDefinitions, this._gridOptions);
     }
 
     // Grid Menu Plugin
-    if (options.enableGridMenu) {
-      this.gridMenuControl = this.createGridMenu(grid, columnDefinitions, options);
+    if (this._gridOptions.enableGridMenu) {
+      this.gridMenuControl = this.createGridMenu(grid, this._columnDefinitions, this._gridOptions);
     }
 
     // Auto Tooltip Plugin
-    if (options.enableAutoTooltip) {
-      this.autoTooltipPlugin = new Slick.AutoTooltips(options.autoTooltipOptions || {});
+    if (this._gridOptions.enableAutoTooltip) {
+      this.autoTooltipPlugin = new Slick.AutoTooltips(this._gridOptions.autoTooltipOptions || {});
       grid.registerPlugin(this.autoTooltipPlugin);
     }
 
     // Grouping Plugin
     // register the group item metadata provider to add expand/collapse group handlers
-    if (options.enableGrouping) {
+    if (this._gridOptions.enableGrouping) {
       grid.registerPlugin(groupItemMetadataProvider);
     }
 
     // Checkbox Selector Plugin
-    if (options.enableCheckboxSelector) {
+    if (this._gridOptions.enableCheckboxSelector) {
       // when enabling the Checkbox Selector Plugin, we need to also watch onClick events to perform certain actions
       // the selector column has to be create BEFORE the grid (else it behaves oddly), but we can only watch grid events AFTER the grid is created
       grid.registerPlugin(this.checkboxSelectorPlugin);
 
       // this also requires the Row Selection Model to be registered as well
       if (!this.rowSelectionPlugin) {
-        this.rowSelectionPlugin = new Slick.RowSelectionModel(options.rowSelectionOptions || {});
+        this.rowSelectionPlugin = new Slick.RowSelectionModel(this._gridOptions.rowSelectionOptions || {});
         grid.setSelectionModel(this.rowSelectionPlugin);
       }
     }
 
     // Row Selection Plugin
-    if (!options.enableCheckboxSelector && options.enableRowSelection) {
-      this.rowSelectionPlugin = new Slick.RowSelectionModel(options.rowSelectionOptions || {});
+    if (!this._gridOptions.enableCheckboxSelector && this._gridOptions.enableRowSelection) {
+      this.rowSelectionPlugin = new Slick.RowSelectionModel(this._gridOptions.rowSelectionOptions || {});
       grid.setSelectionModel(this.rowSelectionPlugin);
     }
 
     // Header Button Plugin
-    if (options.enableHeaderButton) {
-      this.headerButtonsPlugin = new Slick.Plugins.HeaderButtons(options.headerButton || {});
+    if (this._gridOptions.enableHeaderButton) {
+      this.headerButtonsPlugin = new Slick.Plugins.HeaderButtons(this._gridOptions.headerButton || {});
       grid.registerPlugin(this.headerButtonsPlugin);
       this.headerButtonsPlugin.onCommand.subscribe((e: Event, args: HeaderButtonOnCommandArgs) => {
-        if (options.headerButton && typeof options.headerButton.onCommand === 'function') {
-          options.headerButton.onCommand(e, args);
+        if (this._gridOptions.headerButton && typeof this._gridOptions.headerButton.onCommand === 'function') {
+          this._gridOptions.headerButton.onCommand(e, args);
         }
       });
     }
 
     // Header Menu Plugin
-    if (options.enableHeaderMenu) {
+    if (this._gridOptions.enableHeaderMenu) {
       this.headerMenuPlugin = this.createHeaderMenu(this._grid, this._dataView, this._columnDefinitions, this._gridOptions);
     }
 
     // Cell External Copy Manager Plugin (Excel Like)
-    if (options.enableExcelCopyBuffer) {
+    if (this._gridOptions.enableExcelCopyBuffer) {
       this.createUndoRedoBuffer();
       this.hookUndoShortcutKey();
       this.createCellExternalCopyManagerPlugin(this._grid, this._gridOptions);
     }
 
     // manually register other plugins
-    if (options.registerPlugins !== undefined) {
-      if (Array.isArray(options.registerPlugins)) {
-        options.registerPlugins.forEach((plugin) => {
+    if (this._gridOptions.registerPlugins !== undefined) {
+      if (Array.isArray(this._gridOptions.registerPlugins)) {
+        this._gridOptions.registerPlugins.forEach((plugin) => {
           grid.registerPlugin(plugin);
         });
       } else {
-        grid.registerPlugin(options.registerPlugins);
+        grid.registerPlugin(this._gridOptions.registerPlugins);
       }
     }
   }
@@ -718,7 +718,7 @@ export class ControlAndPluginService {
                 if (options.backendServiceApi) {
                   this.sortService.onBackendSortChanged(e, { multiColumnSort: true, sortCols: cols, grid });
                 } else {
-                  this.sortService.onLocalSortChanged(grid, options, dataView, cols);
+                  this.sortService.onLocalSortChanged(grid, dataView, cols);
                 }
 
                 // update the this.gridObj sortColumns array which will at the same add the visual sort icon(s) on the UI

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/controlAndPlugin.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/controlAndPlugin.service.ts
@@ -77,12 +77,12 @@ export class ControlAndPluginService {
 
     // Column Picker Plugin
     if (this._gridOptions.enableColumnPicker) {
-      this.columnPickerControl = this.createColumnPicker(grid, this._columnDefinitions, this._gridOptions);
+      this.columnPickerControl = this.createColumnPicker(grid, this._columnDefinitions);
     }
 
     // Grid Menu Plugin
     if (this._gridOptions.enableGridMenu) {
-      this.gridMenuControl = this.createGridMenu(grid, this._columnDefinitions, this._gridOptions);
+      this.gridMenuControl = this.createGridMenu(grid, this._columnDefinitions);
     }
 
     // Auto Tooltip Plugin
@@ -129,14 +129,14 @@ export class ControlAndPluginService {
 
     // Header Menu Plugin
     if (this._gridOptions.enableHeaderMenu) {
-      this.headerMenuPlugin = this.createHeaderMenu(this._grid, this._dataView, this._columnDefinitions, this._gridOptions);
+      this.headerMenuPlugin = this.createHeaderMenu(this._grid, this._dataView, this._columnDefinitions);
     }
 
     // Cell External Copy Manager Plugin (Excel Like)
     if (this._gridOptions.enableExcelCopyBuffer) {
       this.createUndoRedoBuffer();
       this.hookUndoShortcutKey();
-      this.createCellExternalCopyManagerPlugin(this._grid, this._gridOptions);
+      this.createCellExternalCopyManagerPlugin(this._grid);
     }
 
     // manually register other plugins
@@ -168,7 +168,7 @@ export class ControlAndPluginService {
   }
 
   /** Create the Excel like copy manager */
-  createCellExternalCopyManagerPlugin(grid: any, gridOptions: GridOption) {
+  createCellExternalCopyManagerPlugin(grid: any) {
     let newRowIds = 0;
     const pluginOptions = {
       clipboardCommandHandler: (editCommand: any) => {
@@ -177,12 +177,12 @@ export class ControlAndPluginService {
       dataItemColumnValueExtractor: (item: any, columnDef: Column) => {
         // when grid or cell is not editable, we will possibly evaluate the Formatter if it was passed
         // to decide if we evaluate the Formatter, we will use the same flag from Export which is "exportWithFormatter"
-        if (gridOptions && (!gridOptions.editable || !columnDef.editor)) {
-          const exportOptionWithFormatter = (gridOptions && gridOptions.exportOptions) ? gridOptions.exportOptions.exportWithFormatter : false;
+        if (this._gridOptions && (!this._gridOptions.editable || !columnDef.editor)) {
+          const exportOptionWithFormatter = (this._gridOptions && this._gridOptions.exportOptions) ? this._gridOptions.exportOptions.exportWithFormatter : false;
           const isEvaluatingFormatter = (columnDef.exportWithFormatter !== undefined) ? columnDef.exportWithFormatter : exportOptionWithFormatter;
           if (columnDef.formatter && isEvaluatingFormatter) {
             const formattedOutput = columnDef.formatter(0, 0, item[columnDef.field], columnDef, item, this._grid);
-            if (columnDef.sanitizeDataExport || (gridOptions.exportOptions && gridOptions.exportOptions.sanitizeDataExport)) {
+            if (columnDef.sanitizeDataExport || (this._gridOptions.exportOptions && this._gridOptions.exportOptions.sanitizeDataExport)) {
               return sanitizeHtmlToText(formattedOutput);
             }
             return formattedOutput;
@@ -213,22 +213,22 @@ export class ControlAndPluginService {
    * Create the Column Picker and expose all the available hooks that user can subscribe (onColumnsChanged)
    * @param grid
    * @param columnDefinitions
-   * @param options
+   * @param _gridOptions
    */
-  createColumnPicker(grid: any, columnDefinitions: Column[], options: GridOption) {
+  createColumnPicker(grid: any, columnDefinitions: Column[]) {
     // localization support for the picker
-    const forceFitTitle = options.enableTranslate ? this.i18n.tr('FORCE_FIT_COLUMNS') : 'Force fit columns';
-    const syncResizeTitle = options.enableTranslate ? this.i18n.tr('SYNCHRONOUS_RESIZE') : 'Synchronous resize';
+    const forceFitTitle = this._gridOptions.enableTranslate ? this.i18n.tr('FORCE_FIT_COLUMNS') : 'Force fit columns';
+    const syncResizeTitle = this._gridOptions.enableTranslate ? this.i18n.tr('SYNCHRONOUS_RESIZE') : 'Synchronous resize';
 
-    options.columnPicker = options.columnPicker || {};
-    options.columnPicker.forceFitTitle = options.columnPicker.forceFitTitle || forceFitTitle;
-    options.columnPicker.syncResizeTitle = options.columnPicker.syncResizeTitle || syncResizeTitle;
+    this._gridOptions.columnPicker = this._gridOptions.columnPicker || {};
+    this._gridOptions.columnPicker.forceFitTitle = this._gridOptions.columnPicker.forceFitTitle || forceFitTitle;
+    this._gridOptions.columnPicker.syncResizeTitle = this._gridOptions.columnPicker.syncResizeTitle || syncResizeTitle;
 
-    this.columnPickerControl = new Slick.Controls.ColumnPicker(columnDefinitions, grid, options);
-    if (grid && options.enableColumnPicker) {
+    this.columnPickerControl = new Slick.Controls.ColumnPicker(columnDefinitions, grid, this._gridOptions);
+    if (grid && this._gridOptions.enableColumnPicker) {
       this.columnPickerControl.onColumnsChanged.subscribe((e: Event, args: CellArgs) => {
-        if (options.columnPicker && typeof options.columnPicker.onColumnsChanged === 'function') {
-          options.columnPicker.onColumnsChanged(e, args);
+        if (this._gridOptions.columnPicker && typeof this._gridOptions.columnPicker.onColumnsChanged === 'function') {
+          this._gridOptions.columnPicker.onColumnsChanged(e, args);
         }
       });
     }
@@ -238,33 +238,32 @@ export class ControlAndPluginService {
    * Create (or re-create) Grid Menu and expose all the available hooks that user can subscribe (onCommand, onMenuClose, ...)
    * @param grid
    * @param columnDefinitions
-   * @param options
    */
-  createGridMenu(grid: any, columnDefinitions: Column[], options: GridOption) {
-    options.gridMenu = { ...this.getDefaultGridMenuOptions(), ...options.gridMenu };
-    this.addGridMenuCustomCommands(grid, options);
+  createGridMenu(grid: any, columnDefinitions: Column[]) {
+    this._gridOptions.gridMenu = { ...this.getDefaultGridMenuOptions(), ...this._gridOptions.gridMenu };
+    this.addGridMenuCustomCommands(grid);
 
-    const gridMenuControl = new Slick.Controls.GridMenu(columnDefinitions, grid, options);
-    if (grid && options.gridMenu) {
+    const gridMenuControl = new Slick.Controls.GridMenu(columnDefinitions, grid, this._gridOptions);
+    if (grid && this._gridOptions.gridMenu) {
       gridMenuControl.onBeforeMenuShow.subscribe((e: Event, args: CellArgs) => {
-        if (options.gridMenu && typeof options.gridMenu.onBeforeMenuShow === 'function') {
-          options.gridMenu.onBeforeMenuShow(e, args);
+        if (this._gridOptions.gridMenu && typeof this._gridOptions.gridMenu.onBeforeMenuShow === 'function') {
+          this._gridOptions.gridMenu.onBeforeMenuShow(e, args);
         }
       });
       gridMenuControl.onColumnsChanged.subscribe((e: Event, args: CellArgs) => {
         this.areVisibleColumnDifferent = true;
-        if (options.gridMenu && typeof options.gridMenu.onColumnsChanged === 'function') {
-          options.gridMenu.onColumnsChanged(e, args);
+        if (this._gridOptions.gridMenu && typeof this._gridOptions.gridMenu.onColumnsChanged === 'function') {
+          this._gridOptions.gridMenu.onColumnsChanged(e, args);
         }
       });
       gridMenuControl.onCommand.subscribe((e: Event, args: CellArgs) => {
-        if (options.gridMenu && typeof options.gridMenu.onCommand === 'function') {
-          options.gridMenu.onCommand(e, args);
+        if (this._gridOptions.gridMenu && typeof this._gridOptions.gridMenu.onCommand === 'function') {
+          this._gridOptions.gridMenu.onCommand(e, args);
         }
       });
       gridMenuControl.onMenuClose.subscribe((e: Event, args: CellArgs) => {
-        if (options.gridMenu && typeof options.gridMenu.onMenuClose === 'function') {
-          options.gridMenu.onMenuClose(e, args);
+        if (this._gridOptions.gridMenu && typeof this._gridOptions.gridMenu.onMenuClose === 'function') {
+          this._gridOptions.gridMenu.onMenuClose(e, args);
         }
 
         // we also want to resize the columns if the user decided to hide certain column(s)
@@ -285,25 +284,25 @@ export class ControlAndPluginService {
    * Create the Header Menu and expose all the available hooks that user can subscribe (onCommand, onBeforeMenuShow, ...)
    * @param grid
    * @param columnDefinitions
-   * @param options
+   * @param _gridOptions
    */
-  createHeaderMenu(grid: any, dataView: any, columnDefinitions: Column[], options: GridOption) {
-    options.headerMenu = { ...this.getDefaultHeaderMenuOptions(), ...options.headerMenu };
-    if (options.enableHeaderMenu) {
-      options.headerMenu = this.addHeaderMenuCustomCommands(grid, dataView, options, columnDefinitions);
+  createHeaderMenu(grid: any, dataView: any, columnDefinitions: Column[]) {
+    this._gridOptions.headerMenu = { ...this.getDefaultHeaderMenuOptions(), ...this._gridOptions.headerMenu };
+    if (this._gridOptions.enableHeaderMenu) {
+      this._gridOptions.headerMenu = this.addHeaderMenuCustomCommands(grid, dataView, columnDefinitions);
     }
 
-    const headerMenuPlugin = new Slick.Plugins.HeaderMenu(options.headerMenu);
+    const headerMenuPlugin = new Slick.Plugins.HeaderMenu(this._gridOptions.headerMenu);
 
     grid.registerPlugin(headerMenuPlugin);
     headerMenuPlugin.onCommand.subscribe((e: Event, args: HeaderMenuOnCommandArgs) => {
-      if (options.headerMenu && typeof options.headerMenu.onCommand === 'function') {
-        options.headerMenu.onCommand(e, args);
+      if (this._gridOptions.headerMenu && typeof this._gridOptions.headerMenu.onCommand === 'function') {
+        this._gridOptions.headerMenu.onCommand(e, args);
       }
     });
     headerMenuPlugin.onCommand.subscribe((e: Event, args: HeaderMenuOnBeforeMenuShowArgs) => {
-      if (options.headerMenu && typeof options.headerMenu.onBeforeMenuShow === 'function') {
-        options.headerMenu.onBeforeMenuShow(e, args);
+      if (this._gridOptions.headerMenu && typeof this._gridOptions.headerMenu.onBeforeMenuShow === 'function') {
+        this._gridOptions.headerMenu.onBeforeMenuShow(e, args);
       }
     });
 
@@ -401,18 +400,18 @@ export class ControlAndPluginService {
   /**
    * Create Grid Menu with Custom Commands if user has enabled Filters and/or uses a Backend Service (OData, GraphQL)
    * @param grid
-   * @param options
+   * @param _gridOptions
    */
-  private addGridMenuCustomCommands(grid: any, options: GridOption) {
-    const backendApi = options.backendServiceApi || options.onBackendEventApi || null;
+  private addGridMenuCustomCommands(grid: any) {
+    const backendApi = this._gridOptions.backendServiceApi || this._gridOptions.onBackendEventApi || null;
 
-    if (options && options.enableFiltering) {
+    if (this._gridOptions && this._gridOptions.enableFiltering) {
       // show grid menu: clear all filters
-      if (options && options.gridMenu && options.gridMenu.showClearAllFiltersCommand && options.gridMenu.customItems && options.gridMenu.customItems.filter((item: CustomGridMenu) => item.command === 'clear-filter').length === 0) {
-        options.gridMenu.customItems.push(
+      if (this._gridOptions && this._gridOptions.gridMenu && this._gridOptions.gridMenu.showClearAllFiltersCommand && this._gridOptions.gridMenu.customItems && this._gridOptions.gridMenu.customItems.filter((item: CustomGridMenu) => item.command === 'clear-filter').length === 0) {
+        this._gridOptions.gridMenu.customItems.push(
           {
-            iconCssClass: options.gridMenu.iconClearAllFiltersCommand || 'fa fa-filter text-danger',
-            title: options.enableTranslate ? this.i18n.tr('CLEAR_ALL_FILTERS') : 'Clear All Filters',
+            iconCssClass: this._gridOptions.gridMenu.iconClearAllFiltersCommand || 'fa fa-filter text-danger',
+            title: this._gridOptions.enableTranslate ? this.i18n.tr('CLEAR_ALL_FILTERS') : 'Clear All Filters',
             disabled: false,
             command: 'clear-filter',
             positionOrder: 50
@@ -420,11 +419,11 @@ export class ControlAndPluginService {
         );
       }
       // show grid menu: toggle filter row
-      if (options && options.gridMenu && options.gridMenu.showToggleFilterCommand && options.gridMenu.customItems && options.gridMenu.customItems.filter((item: CustomGridMenu) => item.command === 'toggle-filter').length === 0) {
-        options.gridMenu.customItems.push(
+      if (this._gridOptions && this._gridOptions.gridMenu && this._gridOptions.gridMenu.showToggleFilterCommand && this._gridOptions.gridMenu.customItems && this._gridOptions.gridMenu.customItems.filter((item: CustomGridMenu) => item.command === 'toggle-filter').length === 0) {
+        this._gridOptions.gridMenu.customItems.push(
           {
-            iconCssClass: options.gridMenu.iconToggleFilterCommand || 'fa fa-random',
-            title: options.enableTranslate ? this.i18n.tr('TOGGLE_FILTER_ROW') : 'Toggle Filter Row',
+            iconCssClass: this._gridOptions.gridMenu.iconToggleFilterCommand || 'fa fa-random',
+            title: this._gridOptions.enableTranslate ? this.i18n.tr('TOGGLE_FILTER_ROW') : 'Toggle Filter Row',
             disabled: false,
             command: 'toggle-filter',
             positionOrder: 52
@@ -433,11 +432,11 @@ export class ControlAndPluginService {
       }
 
       // show grid menu: refresh dataset
-      if (options && options.gridMenu && options.gridMenu.showRefreshDatasetCommand && backendApi && options.gridMenu.customItems && options.gridMenu.customItems.filter((item: CustomGridMenu) => item.command === 'refresh-dataset').length === 0) {
-        options.gridMenu.customItems.push(
+      if (this._gridOptions && this._gridOptions.gridMenu && this._gridOptions.gridMenu.showRefreshDatasetCommand && backendApi && this._gridOptions.gridMenu.customItems && this._gridOptions.gridMenu.customItems.filter((item: CustomGridMenu) => item.command === 'refresh-dataset').length === 0) {
+        this._gridOptions.gridMenu.customItems.push(
           {
-            iconCssClass: options.gridMenu.iconRefreshDatasetCommand || 'fa fa-refresh',
-            title: options.enableTranslate ? this.i18n.tr('REFRESH_DATASET') : 'Refresh Dataset',
+            iconCssClass: this._gridOptions.gridMenu.iconRefreshDatasetCommand || 'fa fa-refresh',
+            title: this._gridOptions.enableTranslate ? this.i18n.tr('REFRESH_DATASET') : 'Refresh Dataset',
             disabled: false,
             command: 'refresh-dataset',
             positionOrder: 54
@@ -446,13 +445,13 @@ export class ControlAndPluginService {
       }
     }
 
-    if (options.enableSorting) {
+    if (this._gridOptions.enableSorting) {
       // show grid menu: clear all sorting
-      if (options && options.gridMenu && options.gridMenu.showClearAllSortingCommand && options.gridMenu.customItems && options.gridMenu.customItems.filter((item: CustomGridMenu) => item.command === 'clear-sorting').length === 0) {
-        options.gridMenu.customItems.push(
+      if (this._gridOptions && this._gridOptions.gridMenu && this._gridOptions.gridMenu.showClearAllSortingCommand && this._gridOptions.gridMenu.customItems && this._gridOptions.gridMenu.customItems.filter((item: CustomGridMenu) => item.command === 'clear-sorting').length === 0) {
+        this._gridOptions.gridMenu.customItems.push(
           {
-            iconCssClass: options.gridMenu.iconClearAllSortingCommand || 'fa fa-unsorted text-danger',
-            title: options.enableTranslate ? this.i18n.tr('CLEAR_ALL_SORTING') : 'Clear All Sorting',
+            iconCssClass: this._gridOptions.gridMenu.iconClearAllSortingCommand || 'fa fa-unsorted text-danger',
+            title: this._gridOptions.enableTranslate ? this.i18n.tr('CLEAR_ALL_SORTING') : 'Clear All Sorting',
             disabled: false,
             command: 'clear-sorting',
             positionOrder: 51
@@ -462,11 +461,11 @@ export class ControlAndPluginService {
     }
 
     // show grid menu: export to file
-    if (options && options.enableExport && options.gridMenu && options.gridMenu.showExportCsvCommand && options.gridMenu.customItems && options.gridMenu.customItems.filter((item: CustomGridMenu) => item.command === 'export-csv').length === 0) {
-      options.gridMenu.customItems.push(
+    if (this._gridOptions && this._gridOptions.enableExport && this._gridOptions.gridMenu && this._gridOptions.gridMenu.showExportCsvCommand && this._gridOptions.gridMenu.customItems && this._gridOptions.gridMenu.customItems.filter((item: CustomGridMenu) => item.command === 'export-csv').length === 0) {
+      this._gridOptions.gridMenu.customItems.push(
         {
-          iconCssClass: options.gridMenu.iconExportCsvCommand || 'fa fa-download',
-          title: options.enableTranslate ? this.i18n.tr('EXPORT_TO_CSV') : 'Export in CSV format',
+          iconCssClass: this._gridOptions.gridMenu.iconExportCsvCommand || 'fa fa-download',
+          title: this._gridOptions.enableTranslate ? this.i18n.tr('EXPORT_TO_CSV') : 'Export in CSV format',
           disabled: false,
           command: 'export-csv',
           positionOrder: 53
@@ -474,11 +473,11 @@ export class ControlAndPluginService {
       );
     }
     // show grid menu: export to text file as tab delimited
-    if (options && options.enableExport && options.gridMenu && options.gridMenu.showExportTextDelimitedCommand && options.gridMenu.customItems && options.gridMenu.customItems.filter((item: CustomGridMenu) => item.command === 'export-text-delimited').length === 0) {
-      options.gridMenu.customItems.push(
+    if (this._gridOptions && this._gridOptions.enableExport && this._gridOptions.gridMenu && this._gridOptions.gridMenu.showExportTextDelimitedCommand && this._gridOptions.gridMenu.customItems && this._gridOptions.gridMenu.customItems.filter((item: CustomGridMenu) => item.command === 'export-text-delimited').length === 0) {
+      this._gridOptions.gridMenu.customItems.push(
         {
-          iconCssClass: options.gridMenu.iconExportTextDelimitedCommand || 'fa fa-download',
-          title: options.enableTranslate ? this.i18n.tr('EXPORT_TO_TAB_DELIMITED') : 'Export in Text format (Tab delimited)',
+          iconCssClass: this._gridOptions.gridMenu.iconExportTextDelimitedCommand || 'fa fa-download',
+          title: this._gridOptions.enableTranslate ? this.i18n.tr('EXPORT_TO_TAB_DELIMITED') : 'Export in Text format (Tab delimited)',
           disabled: false,
           command: 'export-text-delimited',
           positionOrder: 54
@@ -487,8 +486,8 @@ export class ControlAndPluginService {
     }
 
     // Command callback, what will be executed after command is clicked
-    if (options && options.gridMenu && Array.isArray(options.gridMenu.customItems) && options.gridMenu.customItems.length > 0) {
-      options.gridMenu.onCommand = (e, args) => {
+    if (this._gridOptions && this._gridOptions.gridMenu && Array.isArray(this._gridOptions.gridMenu.customItems) && this._gridOptions.gridMenu.customItems.length > 0) {
+      this._gridOptions.gridMenu.onCommand = (e, args) => {
         if (args && args.command) {
           switch (args.command) {
             case 'clear-filter':
@@ -516,10 +515,10 @@ export class ControlAndPluginService {
               });
               break;
             case 'toggle-filter':
-              grid.setHeaderRowVisibility(!grid.getOptions().showHeaderRow);
+              grid.setHeaderRowVisibility(!this._gridOptions.showHeaderRow);
               break;
             case 'toggle-toppanel':
-              grid.setTopPanelVisibility(!grid.getOptions().showTopPanel);
+              grid.setTopPanelVisibility(!this._gridOptions.showTopPanel);
               break;
             case 'refresh-dataset':
               this.refreshBackendDataset();
@@ -533,12 +532,12 @@ export class ControlAndPluginService {
     }
 
     // add the custom "Commands" title if there are any commands
-    if (options && options.gridMenu && options.gridMenu.customItems && options.gridMenu.customItems.length > 0) {
-      const customTitle = options.enableTranslate ? this.i18n.tr('COMMANDS') : 'Commands';
-      options.gridMenu.customTitle = options.gridMenu.customTitle || customTitle;
+    if (this._gridOptions && this._gridOptions.gridMenu && this._gridOptions.gridMenu.customItems && this._gridOptions.gridMenu.customItems.length > 0) {
+      const customTitle = this._gridOptions.enableTranslate ? this.i18n.tr('COMMANDS') : 'Commands';
+      this._gridOptions.gridMenu.customTitle = this._gridOptions.gridMenu.customTitle || customTitle;
 
       // sort the custom items by their position in the list
-      options.gridMenu.customItems.sort((itemA, itemB) => {
+      this._gridOptions.gridMenu.customItems.sort((itemA, itemB) => {
         if (itemA && itemB && itemA.hasOwnProperty('positionOrder') && itemB.hasOwnProperty('positionOrder')) {
           return (itemA.positionOrder || 0) - (itemB.positionOrder || 0);
         }
@@ -601,7 +600,7 @@ export class ControlAndPluginService {
     }
 
     this._gridOptions.columnPicker = undefined;
-    this.createColumnPicker(this._grid, this.visibleColumns, this._gridOptions);
+    this.createColumnPicker(this._grid, this.visibleColumns);
   }
 
   /**
@@ -617,7 +616,7 @@ export class ControlAndPluginService {
     if (this._gridOptions && this._gridOptions.gridMenu) {
       this._gridOptions.gridMenu = this.resetGridMenuTranslations(this._gridOptions.gridMenu);
     }
-    this.createGridMenu(this._grid, this.visibleColumns, this._gridOptions);
+    this.createGridMenu(this._grid, this.visibleColumns);
   }
 
   /**
@@ -654,14 +653,14 @@ export class ControlAndPluginService {
    * Create Header Menu with Custom Commands if user has enabled Header Menu
    * @param grid
    * @param dataView
-   * @param options
+   * @param _gridOptions
    * @param columnDefinitions
    * @return header menu
    */
-  private addHeaderMenuCustomCommands(grid: any, dataView: any, options: GridOption, columnDefinitions: Column[]): HeaderMenu | undefined {
-    const headerMenuOptions = options.headerMenu;
+  private addHeaderMenuCustomCommands(grid: any, dataView: any, columnDefinitions: Column[]): HeaderMenu | undefined {
+    const headerMenuOptions = this._gridOptions.headerMenu;
 
-    if (columnDefinitions && Array.isArray(columnDefinitions) && options.enableHeaderMenu) {
+    if (columnDefinitions && Array.isArray(columnDefinitions) && this._gridOptions.enableHeaderMenu) {
       columnDefinitions.forEach((columnDef: Column) => {
         if (columnDef) {
           if (!columnDef.header || !columnDef.header.menu) {
@@ -675,18 +674,18 @@ export class ControlAndPluginService {
             const columnHeaderMenuItems: HeaderMenuItem[] = columnDef.header.menu.items || [];
 
             // Sorting Commands
-            if (options.enableSorting && columnDef.sortable && headerMenuOptions && headerMenuOptions.showSortCommands) {
+            if (this._gridOptions.enableSorting && columnDef.sortable && headerMenuOptions && headerMenuOptions.showSortCommands) {
               if (columnHeaderMenuItems.filter((item: HeaderMenuItem) => item.command === 'sort-asc').length === 0) {
                 columnHeaderMenuItems.push({
                   iconCssClass: headerMenuOptions.iconSortAscCommand || 'fa fa-sort-asc',
-                  title: options.enableTranslate ? this.i18n.tr('SORT_ASCENDING') : 'Sort Ascending',
+                  title: this._gridOptions.enableTranslate ? this.i18n.tr('SORT_ASCENDING') : 'Sort Ascending',
                   command: 'sort-asc'
                 });
               }
               if (columnHeaderMenuItems.filter((item: HeaderMenuItem) => item.command === 'sort-desc').length === 0) {
                 columnHeaderMenuItems.push({
                   iconCssClass: headerMenuOptions.iconSortDescCommand || 'fa fa-sort-desc',
-                  title: options.enableTranslate ? this.i18n.tr('SORT_DESCENDING') : 'Sort Descending',
+                  title: this._gridOptions.enableTranslate ? this.i18n.tr('SORT_DESCENDING') : 'Sort Descending',
                   command: 'sort-desc'
                 });
               }
@@ -696,7 +695,7 @@ export class ControlAndPluginService {
             if (headerMenuOptions && headerMenuOptions.showColumnHideCommand && columnHeaderMenuItems.filter((item: HeaderMenuItem) => item.command === 'hide').length === 0) {
               columnHeaderMenuItems.push({
                 iconCssClass: headerMenuOptions.iconColumnHideCommand || 'fa fa-times',
-                title: options.enableTranslate ? this.i18n.tr('HIDE_COLUMN') : 'Hide Column',
+                title: this._gridOptions.enableTranslate ? this.i18n.tr('HIDE_COLUMN') : 'Hide Column',
                 command: 'hide'
               });
             }
@@ -720,7 +719,7 @@ export class ControlAndPluginService {
 
                 // add to the column array, the column sorted by the header menu
                 cols.push({ sortCol: args.column, sortAsc: (args.command === 'sort-asc') });
-                if (options.backendServiceApi) {
+                if (this._gridOptions.backendServiceApi) {
                   this.sortService.onBackendSortChanged(e, { multiColumnSort: true, sortCols: cols, grid });
                 } else {
                   this.sortService.onLocalSortChanged(grid, dataView, cols);

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/export.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/export.service.ts
@@ -50,10 +50,10 @@ export class ExportService {
    * @param gridOptions
    * @param dataView
    */
-  init(grid: any, gridOptions: GridOption, dataView: any): void {
+  init(grid: any, dataView: any): void {
     this._grid = grid;
-    this._gridOptions = gridOptions;
     this._dataView = dataView;
+    this._gridOptions = (grid && grid.getOptions) ? grid.getOptions() : {};
     this.aureliaEventPrefix = (this._gridOptions && this._gridOptions.defaultAureliaEventPrefix) ? this._gridOptions.defaultAureliaEventPrefix : 'asg';
   }
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/export.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/export.service.ts
@@ -37,23 +37,25 @@ export class ExportService {
   private _exportQuoteWrapper: string;
   private _columnHeaders: ExportColumnHeader[];
   private _groupedHeaders: ExportColumnHeader[];
-  private _gridOptions: GridOption;
   private _hasGroupedItems = false;
   private _exportOptions: ExportOption;
   aureliaEventPrefix: string;
 
   constructor(private i18n: I18N, private ea: EventAggregator) { }
 
+  /** Getter for the Grid Options pulled through the Grid Object */
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
   /**
-   * Initialize the Export Service
+   * Initialize the Service
    * @param grid
-   * @param gridOptions
    * @param dataView
    */
   init(grid: any, dataView: any): void {
     this._grid = grid;
     this._dataView = dataView;
-    this._gridOptions = (grid && grid.getOptions) ? grid.getOptions() : {};
     this.aureliaEventPrefix = (this._gridOptions && this._gridOptions.defaultAureliaEventPrefix) ? this._gridOptions.defaultAureliaEventPrefix : 'asg';
   }
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/filter.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/filter.service.ts
@@ -31,20 +31,31 @@ export class FilterService {
   private _columnFilters: ColumnFilters = {};
   private _dataView: any;
   private _grid: any;
-  private _gridOptions: GridOption;
   private _onFilterChangedOptions: any;
 
   constructor(private ea: EventAggregator, private filterFactory: FilterFactory) { }
 
+  /** Getter for the Grid Options pulled through the Grid Object */
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
+  /** Getter for the Column Definitions pulled through the Grid Object */
+  private get _columnDefinitions(): Column[] {
+    return (this._grid && this._grid.getColumns) ? this._grid.getColumns() : [];
+  }
+
+  /**
+   * Initialize the Service
+   * @param grid
+   */
   init(grid: any): void {
     this._grid = grid;
-    this._gridOptions = (grid && grid.getOptions) ? grid.getOptions() : {};
   }
 
   /**
    * Attach a backend filter hook to the grid
    * @param grid SlickGrid Grid object
-   * @param gridOptions Grid Options object
    */
   attachBackendOnFilter(grid: any) {
     this._filters = [];
@@ -434,12 +445,9 @@ export class FilterService {
    * @param grid
    */
   populateColumnFilterSearchTerms(grid: any) {
-    const gridOptions: GridOption = (grid && grid.getOptions) ? grid.getOptions() : {};
-    const columnDefinitions: Column[] = (grid && grid.getColumns) ? grid.getColumns() : [];
-
-    if (gridOptions.presets && gridOptions.presets.filters) {
-      const filters = gridOptions.presets.filters;
-      columnDefinitions.forEach((columnDef: Column) => {
+    if (this._gridOptions.presets && this._gridOptions.presets.filters) {
+      const filters = this._gridOptions.presets.filters;
+      this._columnDefinitions.forEach((columnDef: Column) => {
         const columnPreset = filters.find((presetFilter: CurrentFilter) => {
           return presetFilter.columnId === columnDef.id;
         });
@@ -455,7 +463,7 @@ export class FilterService {
         }
       });
     }
-    return columnDefinitions;
+    return this._columnDefinitions;
   }
 
   private updateColumnFilters(searchTerm: SearchTerm | undefined, searchTerms: SearchTerm[] | undefined, columnDef: any) {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/filter.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/filter.service.ts
@@ -36,9 +36,9 @@ export class FilterService {
 
   constructor(private ea: EventAggregator, private filterFactory: FilterFactory) { }
 
-  init(grid: any, gridOptions: GridOption, columnDefinitions: Column[]): void {
+  init(grid: any): void {
     this._grid = grid;
-    this._gridOptions = gridOptions;
+    this._gridOptions = (grid && grid.getOptions) ? grid.getOptions() : {};
   }
 
   /**
@@ -46,7 +46,7 @@ export class FilterService {
    * @param grid SlickGrid Grid object
    * @param gridOptions Grid Options object
    */
-  attachBackendOnFilter(grid: any, options: GridOption) {
+  attachBackendOnFilter(grid: any) {
     this._filters = [];
     this._slickSubscriber = new Slick.Event();
 
@@ -101,7 +101,7 @@ export class FilterService {
    * @param gridOptions Grid Options object
    * @param dataView
    */
-  attachLocalOnFilter(grid: any, options: GridOption, dataView: any) {
+  attachLocalOnFilter(grid: any, dataView: any) {
     this._filters = [];
     this._dataView = dataView;
     this._slickSubscriber = new Slick.Event();
@@ -427,14 +427,16 @@ export class FilterService {
   }
 
   /**
-   * When user passes an array of preset filters, we need to pre-polulate each column filter searchTerm(s)
+   * When user passes an array of preset filters, we need to pre-populate each column filter searchTerm(s)
    * The process is to loop through the preset filters array, find the associated column from columnDefinitions and fill in the filter object searchTerm(s)
    * This is basically the same as if we would manually add searchTerm(s) to a column filter object in the column definition, but we do it programmatically.
    * At the end of the day, when creating the Filter (DOM Element), it will use these searchTerm(s) so we can take advantage of that without recoding each Filter type (DOM element)
-   * @param gridOptions
-   * @param columnDefinitions
+   * @param grid
    */
-  populateColumnFilterSearchTerms(gridOptions: GridOption, columnDefinitions: Column[]) {
+  populateColumnFilterSearchTerms(grid: any) {
+    const gridOptions: GridOption = (grid && grid.getOptions) ? grid.getOptions() : {};
+    const columnDefinitions: Column[] = (grid && grid.getColumns) ? grid.getColumns() : [];
+
     if (gridOptions.presets && gridOptions.presets.filters) {
       const filters = gridOptions.presets.filters;
       columnDefinitions.forEach((columnDef: Column) => {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/graphql.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/graphql.service.ts
@@ -39,8 +39,6 @@ export class GraphqlService implements BackendService {
   private _currentFilters: ColumnFilters | CurrentFilter[];
   private _currentPagination: CurrentPagination;
   private _currentSorters: CurrentSorter[];
-  private _columnDefinitions: Column[];
-  private _gridOptions: GridOption;
   private _grid: any;
 
   options: GraphqlServiceOption;
@@ -52,6 +50,16 @@ export class GraphqlService implements BackendService {
   };
 
   constructor(private i18n: I18N) { }
+
+  /** Getter for the Grid Options pulled through the Grid Object */
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
+  /** Getter for the Column Definitions pulled through the Grid Object */
+  private get _columnDefinitions(): Column[] {
+    return (this._grid && this._grid.getColumns) ? this._grid.getColumns() : [];
+  }
 
   /**
    * Build the GraphQL query, since the service include/exclude cursor, the output query will be different.
@@ -170,16 +178,17 @@ export class GraphqlService implements BackendService {
       .replace(/\}$/, '');
   }
 
+  /**
+   * Initialize the Service
+   * @param GraphQL Service Options
+   * @param pagination
+   * @param grid
+   */
   init(serviceOptions?: GraphqlServiceOption, pagination?: Pagination, grid?: any): void {
     this._grid = grid;
     this.options = serviceOptions || {};
     if (pagination) {
       this.pagination = pagination;
-    }
-
-    if (grid && grid.getColumns && grid.getOptions) {
-      this._columnDefinitions = grid.getColumns();
-      this._gridOptions = grid.getOptions();
     }
   }
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/grid-odata.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/grid-odata.service.ts
@@ -32,11 +32,10 @@ const DEFAULT_PAGE_SIZE = 20;
 
 @inject(OdataService)
 export class GridOdataService implements BackendService {
+  private _columnDefinitions: Column[];
   private _currentFilters: CurrentFilter[];
   private _currentPagination: CurrentPagination;
   private _currentSorters: CurrentSorter[];
-  private _columnDefinitions: Column[];
-  private _gridOptions: GridOption;
   private _grid: any;
   options: OdataOption;
   pagination: Pagination | undefined;
@@ -48,10 +47,21 @@ export class GridOdataService implements BackendService {
 
   constructor(private odataService: OdataService) { }
 
+  /** Getter for the Grid Options pulled through the Grid Object */
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
   buildQuery(): string {
     return this.odataService.buildQuery();
   }
 
+  /**
+   * Initialize the Service
+   * @param OData Options
+   * @param pagination
+   * @param grid
+   */
   init(options: OdataOption, pagination?: Pagination, grid?: any): void {
     this._grid = grid;
     const mergedOptions = { ...this.defaultOptions, ...options };
@@ -68,12 +78,8 @@ export class GridOdataService implements BackendService {
       pageSize: this.odataService.options.top || this.defaultOptions.top || DEFAULT_PAGE_SIZE
     };
 
-    if (grid && grid.getColumns && grid.getOptions) {
-      this._columnDefinitions = grid.getColumns() || options.columnDefinitions;
-      this._columnDefinitions = this._columnDefinitions.filter((column: Column) => !column.excludeFromQuery);
-
-      this._gridOptions = grid.getOptions();
-    }
+    this._columnDefinitions = this._gridOptions || options.columnDefinitions;
+    this._columnDefinitions = this._columnDefinitions.filter((column: Column) => !column.excludeFromQuery);
   }
 
   updateOptions(serviceOptions?: OdataOption) {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/grid-odata.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/grid-odata.service.ts
@@ -78,8 +78,10 @@ export class GridOdataService implements BackendService {
       pageSize: this.odataService.options.top || this.defaultOptions.top || DEFAULT_PAGE_SIZE
     };
 
-    this._columnDefinitions = this._gridOptions || options.columnDefinitions;
-    this._columnDefinitions = this._columnDefinitions.filter((column: Column) => !column.excludeFromQuery);
+    if (grid && grid.getColumns) {
+      this._columnDefinitions = grid.getColumns() || options.columnDefinitions || {};
+      this._columnDefinitions = this._columnDefinitions.filter((column: Column) => !column.excludeFromQuery);
+    }
   }
 
   updateOptions(serviceOptions?: OdataOption) {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/gridExtra.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/gridExtra.service.ts
@@ -7,13 +7,24 @@ declare var Slick: any;
 export class GridExtraService {
   private _grid: any;
   private _dataView: any;
-  private _columnDefinition: Column[];
-  private _gridOptions: GridOption;
 
+  /** Getter for the Grid Options pulled through the Grid Object */
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
+  /** Getter for the Column Definitions pulled through the Grid Object */
+  private get _columnDefinitions(): Column[] {
+    return (this._grid && this._grid.getColumns) ? this._grid.getColumns() : [];
+  }
+
+  /**
+   * Initialize the Service
+   * @param grid
+   * @param dataView
+   */
   init(grid: any, dataView: any): void {
     this._grid = grid;
-    this._gridOptions = (grid && grid.getOptions) ? grid.getOptions() : {};
-    this._columnDefinition = (grid && grid.getColumns) ? grid.getColumns() : [];
     this._dataView = dataView;
   }
 
@@ -67,10 +78,9 @@ export class GridExtraService {
     if (item && item.id) {
       item.rowClass = 'highlight';
       this._dataView.updateItem(item.id, item);
-      const gridOptions = this._grid.getOptions() as GridOption;
 
       // highlight the row for a user defined timeout
-      $(`#${gridOptions.gridId}`)
+      $(`#${this._gridOptions.gridId}`)
         .find(`.highlight.row${rowNumber}`)
         .first();
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/gridExtra.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/gridExtra.service.ts
@@ -10,10 +10,10 @@ export class GridExtraService {
   private _columnDefinition: Column[];
   private _gridOptions: GridOption;
 
-  init(grid: any, columnDefinition: Column[], gridOptions: GridOption, dataView: any): void {
+  init(grid: any, dataView: any): void {
     this._grid = grid;
-    this._columnDefinition = columnDefinition;
-    this._gridOptions = gridOptions;
+    this._gridOptions = (grid && grid.getOptions) ? grid.getOptions() : {};
+    this._columnDefinition = (grid && grid.getColumns) ? grid.getColumns() : [];
     this._dataView = dataView;
   }
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/gridState.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/gridState.service.ts
@@ -14,7 +14,6 @@ import * as $ from 'jquery';
 @inject(EventAggregator)
 export class GridStateService {
   private _grid: any;
-  private _gridOptions: GridOption;
   private _preset: GridState;
   private filterService: FilterService;
   private _filterSubcription: Subscription;
@@ -23,17 +22,21 @@ export class GridStateService {
 
   constructor(private ea: EventAggregator) { }
 
+  /** Getter for the Grid Options pulled through the Grid Object */
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
   /**
-   * Initialize the Export Service
+   * Initialize the Service
    * @param grid
-   * @param gridOptions
-   * @param dataView
+   * @param filterService
+   * @param sortService
    */
   init(grid: any, filterService: FilterService, sortService: SortService): void {
     this._grid = grid;
     this.filterService = filterService;
     this.sortService = sortService;
-    this._gridOptions = (grid && grid.getOptions) ? grid.getOptions() : {};
 
     // Subscribe to Event Emitter of Filter & Sort changed, go back to page 1 when that happen
     this._filterSubcription = this.ea.subscribe('filterService:filterChanged', (currentFilters: CurrentFilter[]) => {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/groupingAndColspan.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/groupingAndColspan.service.ts
@@ -14,19 +14,28 @@ export class GroupingAndColspanService {
   private _eventHandler = new Slick.EventHandler();
   private _dataView: any;
   private _grid: any;
-  private _gridOptions: GridOption;
-  private _columnDefinitions: Column[];
   aureliaEventPrefix: string;
 
   constructor(private ea: EventAggregator) { }
 
+  /** Getter for the Grid Options pulled through the Grid Object */
+  private get _gridOptions(): GridOption {
+    return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
+  }
+
+  /** Getter for the Column Definitions pulled through the Grid Object */
+  private get _columnDefinitions(): Column[] {
+    return (this._grid && this._grid.getColumns) ? this._grid.getColumns() : [];
+  }
+
+  /**
+   * Initialize the Service
+   * @param grid
+   * @param dataView
+   */
   init(grid: any, dataView: any) {
     this._grid = grid;
     this._dataView = dataView;
-    if (grid) {
-      this._gridOptions = grid.getOptions();
-      this._columnDefinitions = grid.getColumns();
-    }
 
     this.aureliaEventPrefix = (this._gridOptions && this._gridOptions.defaultAureliaEventPrefix) ? this._gridOptions.defaultAureliaEventPrefix : 'asg';
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/sort.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/sort.service.ts
@@ -33,15 +33,13 @@ export class SortService {
   /**
    * Attach a backend sort (single/multi) hook to the grid
    * @param grid SlickGrid Grid object
-   * @param gridOptions Grid Options object
+   * @param dataView SlickGrid DataView object
    */
   attachBackendOnSort(grid: any, dataView: any) {
     this._isBackendGrid = true;
     this._grid = grid;
     this._dataView = dataView;
-    if (grid) {
-      this._gridOptions = grid.getOptions();
-    }
+    this._gridOptions = (grid && grid.getOptions) ? grid.getOptions() : {};
     this._slickSubscriber = grid.onSort;
 
     // subscribe to the SlickGrid event and call the backend execution
@@ -114,7 +112,7 @@ export class SortService {
         });
       }
 
-      this.onLocalSortChanged(grid, this._gridOptions, dataView, sortColumns);
+      this.onLocalSortChanged(grid, dataView, sortColumns);
       this.emitSortChanged('local');
     });
 
@@ -148,7 +146,7 @@ export class SortService {
       } else {
         const columnDefinitions = this._grid.getColumns() as Column[];
         if (columnDefinitions && Array.isArray(columnDefinitions)) {
-          this.onLocalSortChanged(this._grid, this._gridOptions, this._dataView, new Array({ sortAsc: true, sortCol: columnDefinitions[0] }));
+          this.onLocalSortChanged(this._grid, this._dataView, new Array({ sortAsc: true, sortCol: columnDefinitions[0] }));
         }
       }
     }
@@ -211,13 +209,13 @@ export class SortService {
       });
 
       if (sortCols.length > 0) {
-        this.onLocalSortChanged(grid, gridOptions, dataView, sortCols);
+        this.onLocalSortChanged(grid, dataView, sortCols);
         grid.setSortColumns(sortCols); // add sort icon in UI
       }
     }
   }
 
-  onLocalSortChanged(grid: any, gridOptions: GridOption, dataView: any, sortColumns: ColumnSort[]) {
+  onLocalSortChanged(grid: any, dataView: any, sortColumns: ColumnSort[]) {
     dataView.sort((dataRow1: any, dataRow2: any) => {
       for (let i = 0, l = sortColumns.length; i < l; i++) {
         const columnSortObj = sortColumns[i];

--- a/aurelia-slickgrid/src/examples/slickgrid/example10.html
+++ b/aurelia-slickgrid/src/examples/slickgrid/example10.html
@@ -5,8 +5,8 @@
   <div class="row">
     <div class="col-sm-4">
       <div class="form-inline">
-        <label class="control-label" for="radioWithCursor">Multi-Select / Single</label>
-        <span id="radioWithCursor">
+        <label class="control-label" for="radioRowSelectionClick">Multi-Select / Single</label>
+        <span id="radioRowSelectionClick">
           <label class="radio-inline control-label" for="radioTrue">
             <input type="radio" name="inlineRadioOptions" id="radioTrue" checked value.bind="isMultiSelect" click.delegate="onChooseMultiSelectType(true)"> Multi-Select
           </label>

--- a/aurelia-slickgrid/src/examples/slickgrid/example8.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example8.ts
@@ -98,7 +98,7 @@ export class Example8 {
 
             // add to the column array, the column sorted by the header menu
             cols.push({ sortCol: args.column, sortAsc: (args.command === 'sort-asc') });
-            this.sortService.onLocalSortChanged(this.gridObj, this.gridOptions, this.dataview, cols);
+            this.sortService.onLocalSortChanged(this.gridObj, this.dataview, cols);
 
             // update the this.gridObj sortColumns array which will at the same add the visual sort icon(s) on the UI
             const newSortColumns: ColumnSort[] = cols.map((col) => {

--- a/client-cli/src/examples/slickgrid/example8.js
+++ b/client-cli/src/examples/slickgrid/example8.js
@@ -103,7 +103,7 @@ export class Example8 {
 
             // add to the column array, the column sorted by the header menu
             cols.push({ sortCol: args.column, sortAsc: (args.command === 'sort-asc') });
-            this.sortService.onLocalSortChanged(this.gridObj, this.gridOptions, this.dataview, cols);
+            this.sortService.onLocalSortChanged(this.gridObj, this.dataview, cols);
 
             // update the this.gridObj sortColumns array which will at the same add the visual sort icon(s) on the UI
             const newSortColumns = cols.map((col) => {

--- a/doc/github-demo/src/examples/slickgrid/example8.ts
+++ b/doc/github-demo/src/examples/slickgrid/example8.ts
@@ -98,7 +98,7 @@ export class Example8 {
 
             // add to the column array, the column sorted by the header menu
             cols.push({ sortCol: args.column, sortAsc: (args.command === 'sort-asc') });
-            this.sortService.onLocalSortChanged(this.gridObj, this.gridOptions, this.dataview, cols);
+            this.sortService.onLocalSortChanged(this.gridObj, this.dataview, cols);
 
             // update the this.gridObj sortColumns array which will at the same add the visual sort icon(s) on the UI
             const newSortColumns: ColumnSort[] = cols.map((col) => {


### PR DESCRIPTION
- removed all references from all init/attach Services

**Note** it does not include the refactoring of `gridEventService.attachOnCellChange` and `gridEventService.attachOnClick` since that was already done in a separate PR #51 

@jmzagorski 
It's a long time that I wanted to cleanup these arguments and only use `grid` and `dataView` objects. We can get `options` and `columnDefinitions` from the `grid` and so we should do that everywhere.

I tested all the grids with all features and everything seems to work as usual.
Hopefully this will help in issue #36 (multiple grids in one view)

Note, this PR has to be merged **only after** PR #51 , hopefully without conflicts afterward but it's possible and will address at that time if that happens.