### PR TITLE
fix(editors): fix serialization/deserilization in editors

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/dateEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/dateEditor.ts
@@ -91,14 +91,22 @@ export class DateEditor implements Editor {
   }
 
   serializeValue() {
+    const domValue: string = this.$input.val();
+
+    if (!domValue) return '';
+
     const outputFormat = mapMomentDateFormatWithFieldType(this.args.column.type || FieldType.dateIso);
-    const value = moment(this.defaultDate).format(outputFormat);
+    const value = moment(domValue).format(outputFormat);
 
     return value;
   }
 
   applyValue(item: any, state: any) {
-    item[this.args.column.field] = state;
+    if (!state) return;
+
+    const outputFormat = mapMomentDateFormatWithFieldType(this.args.column.type || FieldType.dateIso);
+
+    item[this.args.column.field] = moment(state, outputFormat).toDate();
   }
 
   isValueChanged() {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/multipleSelectEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/multipleSelectEditor.ts
@@ -118,7 +118,9 @@ export class MultipleSelectEditor implements Editor {
   }
 
   applyValue(item: any, state: any): void {
-    item[this.args.column.field] = state;
+     item[this.args.column.field] = this.collection
+      .filter(c => state.indexOf(c[this.valueName].toString()) !== -1)
+      .map(c => c[this.valueName]);
   }
 
   destroy() {
@@ -141,7 +143,7 @@ export class MultipleSelectEditor implements Editor {
   }
 
   serializeValue(): any {
-    return this.currentValues;
+    return this.$editorElm.val();
   }
 
   focus() {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/singleSelectEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/singleSelectEditor.ts
@@ -110,7 +110,8 @@ export class SingleSelectEditor implements Editor {
   }
 
   applyValue(item: any, state: any): void {
-    item[this.args.column.field] = state;
+    item[this.args.column.field] = findOrDefault(this.collection, (c: any) =>
+      c[this.valueName].toString() === state)[this.valueName];
   }
 
   destroy() {
@@ -119,7 +120,8 @@ export class SingleSelectEditor implements Editor {
 
   loadValue(item: any): void {
     // convert to string because that is how the DOM will return these values
-    this.defaultValue = item[this.columnDef.field].toString();
+    // make sure the prop exists first
+    this.defaultValue = item[this.columnDef.field] && item[this.columnDef.field].toString();
 
     this.$editorElm.find('option').each((i: number, $e: any) => {
       if (this.defaultValue === $e.value) {
@@ -133,7 +135,7 @@ export class SingleSelectEditor implements Editor {
   }
 
   serializeValue(): any {
-    return this.currentValue;
+    return this.$editorElm.val();
   }
 
   focus() {


### PR DESCRIPTION
`dateEditor` was serializing/deserializing wrong value. Also need to check for empty date value because moment will throw an error. `singleSelect` and `multipleSelectEditor` were serializing the actual value (e.g number type) when it should be serializing to a string and `applyValue` should be deserializing from string to actual type (e.g. number).

closes #56