### PR TITLE
feature(resize): use gridHeight or gridWidth when provided on autoResize

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -424,7 +424,7 @@ export class AureliaSlickgridCustomElement {
     // auto-resize grid on browser resize
     this.resizer.init(grid);
     if (grid && options.enableAutoResize) {
-      this.resizer.attachAutoResizeDataGrid();
+      this.resizer.attachAutoResizeDataGrid({ height: this.gridHeight, width: this.gridWidth });
       if (options.autoFitColumnsOnFirstLoad && typeof grid.autosizeColumns === 'function') {
         grid.autosizeColumns();
       }
@@ -481,7 +481,7 @@ export class AureliaSlickgridCustomElement {
       }
       if (this.grid && this.gridOptions.enableAutoResize) {
         // resize the grid inside a slight timeout, in case other DOM element changed prior to the resize (like a filter/pagination changed)
-        this.resizer.resizeGrid(1);
+        this.resizer.resizeGrid(1, { height: this.gridHeight, width: this.gridWidth });
       }
     }
   }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/resizer.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/resizer.service.ts
@@ -37,7 +37,7 @@ export class ResizerService {
    * Attach an auto resize trigger on the datagrid, if that is enable then it will resize itself to the available space
    * Options: we could also provide a % factor to resize on each height/width independently
    */
-  attachAutoResizeDataGrid(): any | void {
+  attachAutoResizeDataGrid(newSizes?: GridDimension): any | void {
     // if we can't find the grid to resize, return without attaching anything
     const gridDomElm = $(`#${this._gridOptions && this._gridOptions.gridId ? this._gridOptions.gridId : 'grid1'}`);
     if (gridDomElm === undefined || gridDomElm.offset() === undefined) {
@@ -45,15 +45,15 @@ export class ResizerService {
     }
 
     // -- 1st resize the datagrid size at first load (we need this because the .on event is not triggered on first load)
-    this.resizeGrid();
+    this.resizeGrid(0, newSizes);
 
     // -- 2nd attach a trigger on the Window DOM element, so that it happens also when resizing after first load
     // -- attach auto-resize to Window object only if it exist
     $(window).on('resize.grid', () => {
       this.ea.publish(`${this.aureliaEventPrefix}:onBeforeResize`, true);
       // for some yet unknown reason, calling the resize twice removes any stuttering/flickering when changing the height and makes it much smoother
-      this.resizeGrid();
-      this.resizeGrid();
+      this.resizeGrid(0, newSizes);
+      this.resizeGrid(0, newSizes);
     });
   }
 
@@ -123,21 +123,31 @@ export class ResizerService {
 
     clearTimeout(timer);
     timer = setTimeout(() => {
-      // calculate new available sizes but with minimum height of 220px
-      newSizes = newSizes || this.calculateGridNewDimensions(this._gridOptions);
+      // calculate the available sizes with minimum height defined as a constant
+      const availableDimensions = this.calculateGridNewDimensions(this._gridOptions);
       const gridElm = $(`#${this._gridOptions.gridId}`);
       const gridContainerElm = $(`#${this._gridOptions.gridContainerId}`);
 
-      if (newSizes && gridElm.length > 0) {
+      if ((newSizes || availableDimensions) && gridElm.length > 0) {
+        // get the new sizes, if new sizes are passed (not 0), we will use them else use available space
+        // basically if user passes 1 of the dimension, let say he passes just the height,
+        // we will use the height as a fixed height but the width will be resized by it's available space
+        const newHeight = (newSizes && newSizes.height) ? newSizes.height : availableDimensions.height;
+        const newWidth = (newSizes && newSizes.width) ? newSizes.width : availableDimensions.width;
+
         // apply these new height/width to the datagrid
-        gridElm.height(newSizes.height);
-        gridElm.width(newSizes.width);
-        gridContainerElm.height(newSizes.height);
-        gridContainerElm.width(newSizes.width);
+        gridElm.height(newHeight);
+        gridElm.width(newWidth);
+        gridContainerElm.height(newHeight);
+        gridContainerElm.width(newWidth);
 
         // keep last resized dimensions
+        this._lastDimensions = {
+          height: newHeight,
+          width: newWidth
+        };
         this._lastDimensions = newSizes;
-        this._lastDimensions.heightWithPagination = newSizes.height;
+        this._lastDimensions.heightWithPagination = newHeight;
         if ((this._gridOptions.enablePagination || this._gridOptions.backendServiceApi)) {
           this._lastDimensions.heightWithPagination += DATAGRID_PAGINATION_HEIGHT;
         }


### PR DESCRIPTION
- if user pass any of the two, even when the grid option enableAutoResize is enabled, grid will be resized only on the argument not provided and not override provided one.
- Example, let say the user passes `gridHeight="300"` to the View, the `autoResize` Service will only resize the width and never the height because it is now a fixed height.