### PR TITLE
fix(dataview): preserve any previous sort when resetting items

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -455,6 +455,7 @@ export class AureliaSlickgridCustomElement {
   refreshGridData(dataset: any[], totalCount?: number) {
     if (dataset && this.grid && this.dataview && typeof this.dataview.setItems === 'function') {
       this.dataview.setItems(dataset, this.gridOptions.datasetIdPropertyName);
+      this.dataview.reSort();
 
       // this.grid.setData(dataset);
       this.grid.invalidate();


### PR DESCRIPTION
`this.dataview.setItems`  will remove any sorts that were on the grid. I found this when `datasetChanged` was called and refreshed the grid. You can duplicate this bug in example3 as such:
```
dataviewChanged(dataview) {
    this.dataview = dataview;
    const data = [ ...this.dataview.getItems() ]
    // you have 6 seconds to sort the grid and then watch it go back to the original
    setTimeout(() => this.dataset = data, 6000);
  }
```