### PR TITLE
fix(filters): return false when invalid date

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/filter-conditions/dateFilterCondition.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filter-conditions/dateFilterCondition.ts
@@ -7,7 +7,7 @@ export const dateFilterCondition: FilterCondition = (options: FilterConditionOpt
   const filterSearchType = options.filterSearchType || FieldType.dateIso;
   const searchDateFormat = mapMomentDateFormatWithFieldType(filterSearchType);
   if (!moment(options.cellValue, moment.ISO_8601).isValid() || !moment(options.searchTerm, searchDateFormat, true).isValid()) {
-    return true;
+    return false;
   }
   const dateCell = moment(options.cellValue);
   const dateSearch = moment(options.searchTerm);

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filter-conditions/dateIsoFilterCondition.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filter-conditions/dateIsoFilterCondition.ts
@@ -6,7 +6,7 @@ const FORMAT = mapMomentDateFormatWithFieldType(FieldType.dateIso);
 
 export const dateIsoFilterCondition: FilterCondition = (options: FilterConditionOption) => {
   if (!moment(options.cellValue, FORMAT, true).isValid() || !moment(options.searchTerm, FORMAT, true).isValid()) {
-    return true;
+    return false;
   }
   const dateCell = moment(options.cellValue, FORMAT, true);
   const dateSearch = moment(options.searchTerm, FORMAT, true);

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filter-conditions/dateUsFilterCondition.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filter-conditions/dateUsFilterCondition.ts
@@ -6,7 +6,7 @@ const FORMAT = mapMomentDateFormatWithFieldType(FieldType.dateUs);
 
 export const dateUsFilterCondition: FilterCondition = (options: FilterConditionOption) => {
   if (!moment(options.cellValue, FORMAT, true).isValid() || !moment(options.searchTerm, FORMAT, true).isValid()) {
-    return true;
+    return false;
   }
   const dateCell = moment(options.cellValue, FORMAT, true);
   const dateSearch = moment(options.searchTerm, FORMAT, true);

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filter-conditions/dateUsShortFilterCondition.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filter-conditions/dateUsShortFilterCondition.ts
@@ -6,7 +6,7 @@ const FORMAT = mapMomentDateFormatWithFieldType(FieldType.dateUsShort);
 
 export const dateUsShortFilterCondition: FilterCondition = (options: FilterConditionOption) => {
   if (!moment(options.cellValue, FORMAT, true).isValid() || !moment(options.searchTerm, FORMAT, true).isValid()) {
-    return true;
+    return false;
   }
   const dateCell = moment(options.cellValue, FORMAT, true);
   const dateSearch = moment(options.searchTerm, FORMAT, true);

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filter-conditions/dateUtcFilterCondition.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filter-conditions/dateUtcFilterCondition.ts
@@ -6,7 +6,7 @@ import * as moment from 'moment';
 export const dateUtcFilterCondition: FilterCondition = (options: FilterConditionOption) => {
   const searchDateFormat = mapMomentDateFormatWithFieldType(options.filterSearchType || options.fieldType);
   if (!moment(options.cellValue, moment.ISO_8601).isValid() || !moment(options.searchTerm, searchDateFormat, true).isValid()) {
-    return true;
+    return false;
   }
   const dateCell = moment(options.cellValue, moment.ISO_8601, true);
   const dateSearch = moment(options.searchTerm, searchDateFormat, true);

--- a/aurelia-slickgrid/src/examples/slickgrid/example4.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example4.ts
@@ -172,7 +172,7 @@ export class Example4 {
         duration: randomDuration,
         percentComplete: randomPercent,
         percentCompleteNumber: randomPercent,
-        start: new Date(randomYear, randomMonth, randomDay),          // provide a Date format
+        start: (i % 4) ? null : new Date(randomYear, randomMonth, randomDay),          // provide a Date format
         usDateShort: `${randomMonth}/${randomDay}/${randomYearShort}`, // provide a date US Short in the dataset
         utcDate: `${randomYear}-${randomMonthStr}-${randomDay}T${randomHour}:${randomTime}:${randomTime}Z`,
         effortDriven: (i % 3 === 0)


### PR DESCRIPTION
Returning true on an invalid date will keep it on the grid when it should be filtered out.

associates #68
will be closed when sorting is fixed in a separate PR