### PR TITLE
fix(sorters): return -1 or 1 for invalid dates

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/sorters/dateIsoSorter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/sorters/dateIsoSorter.ts
@@ -1,15 +1,8 @@
 import { mapMomentDateFormatWithFieldType } from './../services/utilities';
 import { FieldType, Sorter } from './../models/index';
-import * as moment from 'moment';
+import { compareDates } from './sorterUtilities';
 const FORMAT = mapMomentDateFormatWithFieldType(FieldType.dateIso);
 
 export const dateIsoSorter: Sorter = (value1, value2, sortDirection) => {
-  if (!moment(value1, FORMAT, true).isValid() || !moment(value2, FORMAT, true).isValid()) {
-    return 0;
-  }
-  const date1 = moment(value1, FORMAT, true);
-  const date2 = moment(value2, FORMAT, true);
-  const diff = parseInt(date1.format('X'), 10) - parseInt(date2.format('X'), 10);
-
-  return sortDirection * (diff === 0 ? 0 : (diff > 0 ? 1 : -1));
+  return compareDates(sortDirection, value1, value2, FORMAT, true);
 };

--- a/aurelia-slickgrid/src/aurelia-slickgrid/sorters/dateSorter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/sorters/dateSorter.ts
@@ -1,13 +1,7 @@
 import * as moment from 'moment';
 import { Sorter } from './../models/sorter.interface';
+import { compareDates } from './sorterUtilities';
 
 export const dateSorter: Sorter = (value1, value2, sortDirection) => {
-  if (!moment(value1, moment.ISO_8601).isValid() || !moment(value2, moment.ISO_8601, true).isValid()) {
-    return 0;
-  }
-  const date1 = moment(value1);
-  const date2 = moment(value2);
-  const diff = parseInt(date1.format('X'), 10) - parseInt(date2.format('X'), 10);
-
-  return sortDirection * (diff === 0 ? 0 : (diff > 0 ? 1 : -1));
+  return compareDates(sortDirection, value1, value2, moment.ISO_8601);
 };

--- a/aurelia-slickgrid/src/aurelia-slickgrid/sorters/dateUsShortSorter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/sorters/dateUsShortSorter.ts
@@ -1,15 +1,8 @@
 import { mapMomentDateFormatWithFieldType } from './../services/utilities';
 import { FieldType, Sorter } from './../models/index';
-import * as moment from 'moment';
+import { compareDates } from './sorterUtilities';
 const FORMAT = mapMomentDateFormatWithFieldType(FieldType.dateUsShort);
 
 export const dateUsShortSorter: Sorter = (value1, value2, sortDirection) => {
-  if (!moment(value1, FORMAT, true).isValid() || !moment(value2, FORMAT, true).isValid()) {
-    return 0;
-  }
-  const date1 = moment(value1, FORMAT, true);
-  const date2 = moment(value2, FORMAT, true);
-  const diff = parseInt(date1.format('X'), 10) - parseInt(date2.format('X'), 10);
-
-  return sortDirection * (diff === 0 ? 0 : (diff > 0 ? 1 : -1));
+  return compareDates(sortDirection, value1, value2, FORMAT, true);
 };

--- a/aurelia-slickgrid/src/aurelia-slickgrid/sorters/dateUsSorter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/sorters/dateUsSorter.ts
@@ -1,15 +1,8 @@
 import { mapMomentDateFormatWithFieldType } from './../services/utilities';
 import { FieldType, Sorter } from './../models/index';
-import * as moment from 'moment';
+import { compareDates } from './sorterUtilities';
 const FORMAT = mapMomentDateFormatWithFieldType(FieldType.dateUs);
 
 export const dateUsSorter: Sorter = (value1, value2, sortDirection) => {
-  if (!moment(value1, FORMAT, true).isValid() || !moment(value2, FORMAT, true).isValid()) {
-    return 0;
-  }
-  const date1 = moment(value1, FORMAT, true);
-  const date2 = moment(value2, FORMAT, true);
-  const diff = parseInt(date1.format('X'), 10) - parseInt(date2.format('X'), 10);
-
-  return sortDirection * (diff === 0 ? 0 : (diff > 0 ? 1 : -1));
+  return compareDates(sortDirection, value1, value2, FORMAT, true);
 };

--- a/aurelia-slickgrid/src/aurelia-slickgrid/sorters/sorterUtilities.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/sorters/sorterUtilities.ts
@@ -32,9 +32,9 @@ export function sortByFieldType(value1: any, value2: any, fieldType: FieldType, 
 export function compareDates(sortDirection, value1, value2, format, strict?: boolean) {
   let diff = 0;
 
-  if (!moment(value1, format, strict).isValid()) {
+  if (value1 === null || value1 === '' || !moment(value1, format, strict).isValid()) {
     diff = -1;
-  } else if (!moment(value2, format, strict).isValid()) {
+  } else if (value2 === null || value2 === '' || !moment(value2, format, strict).isValid()) {
     diff = 1;
   } else {
     const date1 = moment(value1, format, strict);

--- a/aurelia-slickgrid/src/aurelia-slickgrid/sorters/sorterUtilities.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/sorters/sorterUtilities.ts
@@ -1,5 +1,6 @@
 import { FieldType } from './../models/fieldType.enum';
 import { Sorters } from './index';
+import * as moment from 'moment';
 
 export function sortByFieldType(value1: any, value2: any, fieldType: FieldType, sortDirection: number) {
   let sortResult = 0;
@@ -26,4 +27,20 @@ export function sortByFieldType(value1: any, value2: any, fieldType: FieldType, 
   }
 
   return sortResult;
+}
+
+export function compareDates(sortDirection, value1, value2, format, strict?: boolean) {
+  let diff = 0;
+
+  if (!moment(value1, format, strict).isValid()) {
+    diff = -1;
+  } else if (!moment(value2, format, strict).isValid()) {
+    diff = 1;
+  } else {
+    const date1 = moment(value1, format, strict);
+    const date2 = moment(value2, format, strict);
+    diff = parseInt(date1.format('X'), 10) - parseInt(date2.format('X'), 10);
+  }
+
+  return sortDirection * (diff === 0 ? 0 : (diff > 0 ? 1 : -1));
 }

--- a/aurelia-slickgrid/src/examples/slickgrid/example4.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example4.ts
@@ -172,7 +172,7 @@ export class Example4 {
         duration: randomDuration,
         percentComplete: randomPercent,
         percentCompleteNumber: randomPercent,
-        start: new Date(randomYear, randomMonth, randomDay),          // provide a Date format
+        start: (i % 4) ? null : new Date(randomYear, randomMonth, randomDay),          // provide a Date format
         usDateShort: `${randomMonth}/${randomDay}/${randomYearShort}`, // provide a date US Short in the dataset
         utcDate: `${randomYear}-${randomMonthStr}-${randomDay}T${randomHour}:${randomTime}:${randomTime}Z`,
         effortDriven: (i % 3 === 0)


### PR DESCRIPTION
Returning zero every time value1 or value 2 is invalid will result in an incorrect sort because it would not sort one value higher than the other (e.g if value1 was 2018-05-24 and value2 was null, these would be sorted as equals). We want invalid dates to be grouped together in the sort and this accomplishes that.

We could add additional logic such that if both were invalid that we return 0, but this commit does the job just fine. Since the logic was the same for every sorter, with the exception of format and strict, I created a utility function that took all the parameters

closes #68
associates to PR #69