### PR TITLE
feat(rowSelect): add preselectedRows and expose all Plugin

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/models/gridOption.interface.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/models/gridOption.interface.ts
@@ -265,6 +265,9 @@ export interface GridOption {
   /** Query presets before grid load (filters, sorters, pagination) */
   presets?: GridState;
 
+  /** Preselect certain rows by their row index ("enableCheckboxSelector" must be enabled) */
+  preselectedRows?: number[];
+
   /** Register 1 or more Slick Plugins */
   registerPlugins?: any | any[];
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/controlAndPlugin.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/controlAndPlugin.service.ts
@@ -31,14 +31,17 @@ export class ControlAndPluginService {
   private _grid: any;
   visibleColumns: Column[];
   areVisibleColumnDifferent = false;
+  pluginList: { name: string; plugin: any }[] = [];
 
   // controls & plugins
   autoTooltipPlugin: any;
+  cellExternalCopyManagerPlugin: any;
   checkboxSelectorPlugin: any;
   columnPickerControl: any;
   headerButtonsPlugin: any;
   headerMenuPlugin: any;
   gridMenuControl: any;
+  groupItemMetaProviderPlugin: any;
   rowSelectionPlugin: any;
   undoRedoBuffer: any;
 
@@ -64,6 +67,13 @@ export class ControlAndPluginService {
     this._grid.autosizeColumns();
   }
 
+  getPlugin(name?: string) {
+    if (name) {
+      return this.pluginList.find((p) => p.name === name);
+    }
+    return this.pluginList;
+  }
+
   /**
    * Attach/Create different Controls or Plugins after the Grid is created
    * @param grid
@@ -75,38 +85,50 @@ export class ControlAndPluginService {
     this._dataView = dataView;
     this.visibleColumns = this._columnDefinitions;
 
-    // Column Picker Plugin
+    // Column Picker Control
     if (this._gridOptions.enableColumnPicker) {
       this.columnPickerControl = this.createColumnPicker(grid, this._columnDefinitions);
+      this.pluginList.push({ name: 'ColumnPicker', plugin: this.columnPickerControl });
     }
 
-    // Grid Menu Plugin
+    // Grid Menu Control
     if (this._gridOptions.enableGridMenu) {
       this.gridMenuControl = this.createGridMenu(grid, this._columnDefinitions);
+      this.pluginList.push({ name: 'GridMenu', plugin: this.gridMenuControl });
     }
 
     // Auto Tooltip Plugin
     if (this._gridOptions.enableAutoTooltip) {
       this.autoTooltipPlugin = new Slick.AutoTooltips(this._gridOptions.autoTooltipOptions || {});
       grid.registerPlugin(this.autoTooltipPlugin);
+      this.pluginList.push({ name: 'AutoTooltip', plugin: this.autoTooltipPlugin });
     }
 
     // Grouping Plugin
     // register the group item metadata provider to add expand/collapse group handlers
     if (this._gridOptions.enableGrouping) {
-      grid.registerPlugin(groupItemMetadataProvider);
+      this.groupItemMetaProviderPlugin = groupItemMetadataProvider || {};
+      this._grid.registerPlugin(this.groupItemMetaProviderPlugin);
+      this.pluginList.push({ name: 'GroupItemMetaProvider', plugin: this.groupItemMetaProviderPlugin });
     }
 
     // Checkbox Selector Plugin
     if (this._gridOptions.enableCheckboxSelector) {
       // when enabling the Checkbox Selector Plugin, we need to also watch onClick events to perform certain actions
-      // the selector column has to be create BEFORE the grid (else it behaves oddly), but we can only watch grid events AFTER the grid is created
+      // the selector column has to be created BEFORE the grid (else it behaves oddly), but we can only watch grid events AFTER the grid is created
       grid.registerPlugin(this.checkboxSelectorPlugin);
+      this.pluginList.push({ name: 'CheckboxSelector', plugin: this.checkboxSelectorPlugin });
 
       // this also requires the Row Selection Model to be registered as well
-      if (!this.rowSelectionPlugin) {
+      if (!this.rowSelectionPlugin || !grid.getSelectionModel()) {
         this.rowSelectionPlugin = new Slick.RowSelectionModel(this._gridOptions.rowSelectionOptions || {});
         grid.setSelectionModel(this.rowSelectionPlugin);
+      }
+
+      // user might want to pre-select some rows
+      // the setTimeout is because of timing issue with styling (row selection happen but rows aren't highlighted properly)
+      if (this._gridOptions.preselectedRows && this.rowSelectionPlugin && grid.getSelectionModel()) {
+        setTimeout(() => this.checkboxSelectorPlugin.selectRows(this._gridOptions.preselectedRows), 0);
       }
     }
 
@@ -120,6 +142,8 @@ export class ControlAndPluginService {
     if (this._gridOptions.enableHeaderButton) {
       this.headerButtonsPlugin = new Slick.Plugins.HeaderButtons(this._gridOptions.headerButton || {});
       grid.registerPlugin(this.headerButtonsPlugin);
+      this.pluginList.push({ name: 'HeaderButtons', plugin: this.headerButtonsPlugin });
+
       this.headerButtonsPlugin.onCommand.subscribe((e: Event, args: HeaderButtonOnCommandArgs) => {
         if (this._gridOptions.headerButton && typeof this._gridOptions.headerButton.onCommand === 'function') {
           this._gridOptions.headerButton.onCommand(e, args);
@@ -144,9 +168,11 @@ export class ControlAndPluginService {
       if (Array.isArray(this._gridOptions.registerPlugins)) {
         this._gridOptions.registerPlugins.forEach((plugin) => {
           grid.registerPlugin(plugin);
+          this.pluginList.push({ name: 'generic', plugin });
         });
       } else {
         grid.registerPlugin(this._gridOptions.registerPlugins);
+        this.pluginList.push({ name: 'generic', plugin: this._gridOptions.registerPlugins });
       }
     }
   }
@@ -207,7 +233,9 @@ export class ControlAndPluginService {
     };
 
     grid.setSelectionModel(new Slick.CellSelectionModel());
-    grid.registerPlugin(new Slick.CellExternalCopyManager(pluginOptions));
+    this.cellExternalCopyManagerPlugin = new Slick.CellExternalCopyManager(pluginOptions);
+    grid.registerPlugin(this.cellExternalCopyManagerPlugin);
+    this.pluginList.push({ name: 'CellExternalCopyManager', plugin: this.cellExternalCopyManagerPlugin });
   }
 
   /**
@@ -232,6 +260,8 @@ export class ControlAndPluginService {
         }
       });
     }
+
+    return this.columnPickerControl;
   }
 
   /**
@@ -367,34 +397,13 @@ export class ControlAndPluginService {
     this._dataView = null;
     this.visibleColumns = [];
 
-    if (this.columnPickerControl) {
-      this.columnPickerControl.destroy();
-      this.columnPickerControl = null;
-    }
-    if (this.gridMenuControl) {
-      this.gridMenuControl.destroy();
-      this.gridMenuControl = null;
-    }
-    if (this.rowSelectionPlugin) {
-      this.rowSelectionPlugin.destroy();
-      this.rowSelectionPlugin = null;
-    }
-    if (this.checkboxSelectorPlugin) {
-      this.checkboxSelectorPlugin.destroy();
-      this.checkboxSelectorPlugin = null;
-    }
-    if (this.autoTooltipPlugin) {
-      this.autoTooltipPlugin.destroy();
-      this.autoTooltipPlugin = null;
-    }
-    if (this.headerButtonsPlugin) {
-      this.headerButtonsPlugin.destroy();
-      this.headerButtonsPlugin = null;
-    }
-    if (this.headerMenuPlugin) {
-      this.headerMenuPlugin.destroy();
-      this.headerMenuPlugin = null;
-    }
+    // dispose of each control/plugin if it has a destroy method
+    this.pluginList.forEach((item) => {
+      if (item && item.plugin && item.plugin.destroy) {
+        item.plugin.destroy();
+      }
+    });
+    this.pluginList = [];
   }
 
   /**

--- a/aurelia-slickgrid/src/examples/slickgrid/example10.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example10.ts
@@ -7,6 +7,9 @@ export class Example2 {
   title = 'Example 10: Grid with Row Selection';
   subTitle = `
     Row selection, single or multi-select (<a href="https://github.com/ghiscoding/aurelia-slickgrid/wiki/Row-Selection" target="_blank">Wiki docs</a>).
+    <ul>
+      <li>Note that "enableExcelCopyBuffer" cannot be used at the same time as Row Selection because there can exist only 1 SelectionModel at a time</li>
+    </ul>
   `;
 
   columnDefinitions: Column[];
@@ -49,7 +52,8 @@ export class Example2 {
       },
       enableAutoResize: true,
       enableCellNavigation: false,
-      enableCheckboxSelector: true
+      enableCheckboxSelector: true,
+      preselectedRows: [0, 2]
     };
   }
 

--- a/aurelia-slickgrid/src/examples/slickgrid/example3.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example3.ts
@@ -178,7 +178,7 @@ export class Example3 {
         },
         collectionFilterBy: {
           property: 'label',
-          value: [ 'Task 1', 'Task 2', 'Task 3', 'Task 4', 'Task 5', 'Task 6' ],
+          value: ['Task 1', 'Task 2', 'Task 3', 'Task 4', 'Task 5', 'Task 6'],
           operator: OperatorType.contains
         }
       }
@@ -193,13 +193,13 @@ export class Example3 {
       },
       editable: true,
       enableCellNavigation: true,
-      enableCheckboxSelector: true,
+      enableCheckboxSelector: false,
       rowSelectionOptions: {
         // True (Single Selection), False (Multiple Selections)
         // Default to True when no "rowSelectionOptions" provided
         selectActiveRow: true
       },
-      enableExcelCopyBuffer: false,
+      enableExcelCopyBuffer: true,
       editCommandHandler: (item, column, editCommand) => {
         this._commandQueue.push(editCommand);
         editCommand.execute();


### PR DESCRIPTION
This PR brings 2 in 1 features
- Add a way to Preselect Row Selection through Grid Options
- Expose and Dispose of all Controls/Plugins through an array for easier logic
   - also add a Getter for all or by name
