### PR TITLE
fix(sort): Presets & Sort caused unintended behavior w/dataview changed

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -359,13 +359,7 @@ export class AureliaSlickgridCustomElement {
     for (const prop in grid) {
       if (grid.hasOwnProperty(prop) && prop.startsWith('on')) {
         this._eventHandler.subscribe(grid[prop], (e: any, args: any) => {
-          this.elm.dispatchEvent(new CustomEvent(`${eventPrefix}-${toKebabCase(prop)}`, {
-            bubbles: true,
-            detail: {
-              eventData: e,
-              args
-            }
-          }));
+          this.dispatchCustomEvent(`${eventPrefix}-${toKebabCase(prop)}`, { eventData: e, args });
         });
       }
     }
@@ -374,13 +368,7 @@ export class AureliaSlickgridCustomElement {
     for (const prop in dataView) {
       if (dataView.hasOwnProperty(prop) && prop.startsWith('on')) {
         this._eventHandler.subscribe(dataView[prop], (e: any, args: any) => {
-          this.elm.dispatchEvent(new CustomEvent(`${eventPrefix}-${toKebabCase(prop)}`, {
-            bubbles: true,
-            detail: {
-              eventData: e,
-              args
-            }
-          }));
+          this.dispatchCustomEvent(`${eventPrefix}-${toKebabCase(prop)}`, { eventData: e, args });
         });
       }
     }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/sort.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/sort.service.ts
@@ -123,15 +123,6 @@ export class SortService {
       this.onLocalSortChanged(grid, dataView, sortColumns);
       this.emitSortChanged('local');
     });
-
-    if (dataView && dataView.onRowCountChanged) {
-      this._eventHandler.subscribe(dataView.onRowCountChanged, (e: Event, args: any) => {
-        // load any presets if there are any
-        if (args.current > 0) {
-          this.loadLocalPresets(grid, dataView);
-        }
-      });
-    }
   }
 
   /**
@@ -160,7 +151,6 @@ export class SortService {
 
     // set current sorter to empty & emit a sort changed event
     this._currentLocalSorters = [];
-    const sender = (this._gridOptions && this._gridOptions.backendServiceApi) ? 'remote' : 'local';
 
     // emit an event when filters are all cleared
     this.ea.publish('sortService:sortCleared', this._currentLocalSorters);


### PR DESCRIPTION
- fixes Presets unintended behavior after Clearing Sorting, then Clearing Filters. 
- also refactored dispatch of Custom Event to be 1 liner for cleaner code

@jmzagorski 
Thanks a lot in finding this one, I was pulling my hair.
The DataView subscribe was way overkill to do the presets, just calling the `loadLocalPresets` after the DataView finished updating is more than enough. That is much cleaner and it works all the time (one time that is... lol)

![2018-06-05_16-25-48](https://user-images.githubusercontent.com/643976/41000884-6b17ec24-68dd-11e8-87ef-39ca308d8da3.gif)