### PR TITLE
feat(filter): add new slider filter (input range)

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/compoundSliderFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/compoundSliderFilter.ts
@@ -1,0 +1,237 @@
+import { inject } from 'aurelia-framework';
+import { I18N } from 'aurelia-i18n';
+import {
+  Column,
+  ColumnFilter,
+  Filter,
+  FilterArguments,
+  FilterCallback,
+  GridOption,
+  OperatorString,
+  OperatorType,
+  SearchTerm
+} from './../models/index';
+import * as $ from 'jquery';
+
+const DEFAULT_MIN_VALUE = 0;
+const DEFAULT_MAX_VALUE = 100;
+const DEFAULT_STEP = 1;
+
+@inject(I18N)
+export class CompoundSliderFilter implements Filter {
+  private _operator: OperatorType | OperatorString;
+  private $containerInputGroupElm: any;
+  private $filterElm: any;
+  private $filterInputElm: any;
+  private $selectOperatorElm: any;
+  grid: any;
+  searchTerms: SearchTerm[];
+  columnDef: Column;
+  callback: FilterCallback;
+
+  constructor(private i18n: I18N) { }
+
+  /** Getter for the Grid Options pulled through the Grid Object */
+  private get gridOptions(): GridOption {
+    return (this.grid && this.grid.getOptions) ? this.grid.getOptions() : {};
+  }
+
+  /** Getter for the Filter Generic Params */
+  private get filterParams(): any {
+    return this.columnDef && this.columnDef.filter && this.columnDef.filter.params || {};
+  }
+
+  /** Getter for the `filter` properties */
+  private get filterProperties(): ColumnFilter {
+    return this.columnDef && this.columnDef.filter || {};
+  }
+
+  set operator(op: OperatorType | OperatorString) {
+    this._operator = op;
+  }
+
+  get operator(): OperatorType | OperatorString {
+    return this._operator || OperatorType.empty;
+  }
+
+  /**
+   * Initialize the Filter
+   */
+  init(args: FilterArguments) {
+    if (args) {
+      this.grid = args.grid;
+      this.callback = args.callback;
+      this.columnDef = args.columnDef;
+      this.operator = args.operator || '';
+      this.searchTerms = args.searchTerms || [];
+
+      // filter input can only have 1 search term, so we will use the 1st array index if it exist
+      const searchTerm = (Array.isArray(this.searchTerms) && this.searchTerms[0]) || '';
+
+      // step 1, create the DOM Element of the filter which contain the compound Operator+Input
+      // and initialize it if searchTerm is filled
+      this.$filterElm = this.createDomElement(searchTerm);
+
+      // step 3, subscribe to the keyup event and run the callback when that happens
+      // also add/remove "filled" class for styling purposes
+      this.$filterInputElm.change((e: any) => {
+        this.onTriggerEvent(e);
+      });
+      this.$selectOperatorElm.change((e: any) => {
+        this.onTriggerEvent(e);
+      });
+    }
+  }
+
+  /**
+   * Clear the filter value
+   */
+  clear() {
+    if (this.$filterElm && this.$selectOperatorElm) {
+      const clearedValue = this.filterParams.hasOwnProperty('sliderStartValue') ? this.filterParams.sliderStartValue : DEFAULT_MIN_VALUE;
+      this.$selectOperatorElm.val(0);
+      this.$filterInputElm.val(clearedValue);
+      if (!this.filterParams.hideSliderNumber) {
+        this.$containerInputGroupElm.children('span.input-group-addon').last().html(clearedValue);
+      }
+      this.onTriggerEvent(undefined, true);
+    }
+  }
+
+  /**
+   * destroy the filter
+   */
+  destroy() {
+    if (this.$filterElm) {
+      this.$filterElm.off('change').remove();
+    }
+  }
+
+  /**
+   * Set value(s) on the DOM element
+   */
+  setValues(values: SearchTerm[]) {
+    if (values && Array.isArray(values)) {
+      this.$filterInputElm.val(values[0]);
+      this.$containerInputGroupElm.children('span.input-group-addon').last().html(values[0]);
+    }
+  }
+
+  //
+  // private functions
+  // ------------------
+
+  /** Build HTML Template for the input range (slider) */
+  private buildTemplateHtmlString() {
+    const minValue = this.filterProperties.hasOwnProperty('minValue') ? this.filterProperties.minValue : DEFAULT_MIN_VALUE;
+    const maxValue = this.filterProperties.hasOwnProperty('maxValue') ? this.filterProperties.maxValue : DEFAULT_MAX_VALUE;
+    const defaultValue = this.filterParams.hasOwnProperty('sliderStartValue') ? this.filterParams.sliderStartValue : minValue;
+    const step = this.filterProperties.hasOwnProperty('valueStep') ? this.filterProperties.valueStep : DEFAULT_STEP;
+
+    return `<input type="range" id="rangeInput_${this.columnDef.field}"
+              name="rangeInput_${this.columnDef.field}"
+              defaultValue="${defaultValue}" min="${minValue}" max="${maxValue}" step="${step}"
+              class="form-control search-filter range compound-slider"
+              onmousemove="$('#rangeOuput_${this.columnDef.field}').html(rangeInput_${this.columnDef.field}.value)" />`;
+  }
+
+  /** Build HTML Template for the text (number) that is shown appended to the slider */
+  private buildTemplateSliderTextHtmlString() {
+    const minValue = this.filterProperties.hasOwnProperty('minValue') ? this.filterProperties.minValue : DEFAULT_MIN_VALUE;
+    const defaultValue = this.filterParams.hasOwnProperty('sliderStartValue') ? this.filterParams.sliderStartValue : minValue;
+
+    return `<span class="input-group-addon slider-value" id="rangeOuput_${this.columnDef.field}">${defaultValue}</span>`;
+  }
+
+  /** Build HTML Template select dropdown (operator) */
+  private buildSelectOperatorHtmlString() {
+    const optionValues = this.getOptionValues();
+    let optionValueString = '';
+    optionValues.forEach((option) => {
+      optionValueString += `<option value="${option.operator}" title="${option.description}">${option.operator}</option>`;
+    });
+
+    return `<select class="form-control">${optionValueString}</select>`;
+  }
+
+  /** Get the available operator option values */
+  private getOptionValues(): { operator: OperatorString, description: string }[] {
+    return [
+      { operator: '' as OperatorString, description: '' },
+      { operator: '=' as OperatorString, description: '' },
+      { operator: '<' as OperatorString, description: '' },
+      { operator: '<=' as OperatorString, description: '' },
+      { operator: '>' as OperatorString, description: '' },
+      { operator: '>=' as OperatorString, description: '' },
+      { operator: '<>' as OperatorString, description: '' }
+    ];
+  }
+
+  /**
+   * Create the DOM element
+   */
+  private createDomElement(searchTerm?: SearchTerm) {
+    const searchTermInput = (searchTerm || '0') as string;
+    const $headerElm = this.grid.getHeaderRowColumn(this.columnDef.id);
+    $($headerElm).empty();
+
+    // create the DOM Select dropdown for the Operator
+    this.$selectOperatorElm = $(this.buildSelectOperatorHtmlString());
+    this.$filterInputElm = $(this.buildTemplateHtmlString());
+    const $filterContainerElm = $(`<div class="form-group search-filter"></div>`);
+    this.$containerInputGroupElm = $(`<div class="input-group"></div>`);
+    const $operatorInputGroupAddon = $(`<span class="input-group-addon operator"></span>`);
+
+    /* the DOM element final structure will be
+      <div class="input-group">
+        <div class="input-group-addon operator">
+          <select class="form-control"></select>
+        </div>
+        <input class="form-control" type="text" />
+        <span class="input-group-addon" id="rangeOuput_percentComplete">0</span>
+      </div>
+    */
+    $operatorInputGroupAddon.append(this.$selectOperatorElm);
+    this.$containerInputGroupElm.append($operatorInputGroupAddon);
+    this.$containerInputGroupElm.append(this.$filterInputElm);
+    if (!this.filterParams.hideSliderNumber) {
+      const $sliderTextInputAppendAddon = $(this.buildTemplateSliderTextHtmlString());
+      $sliderTextInputAppendAddon.html(searchTermInput);
+      this.$containerInputGroupElm.append($sliderTextInputAppendAddon);
+    }
+
+    // create the DOM element & add an ID and filter class
+    $filterContainerElm.append(this.$containerInputGroupElm);
+    $filterContainerElm.attr('id', `filter-${this.columnDef.field}`);
+
+    this.$filterInputElm.val(searchTermInput);
+    this.$filterInputElm.data('columnId', this.columnDef.field);
+
+    if (this.operator) {
+      this.$selectOperatorElm.val(this.operator);
+    }
+
+    // if there's a search term, we will add the "filled" class for styling purposes
+    if (searchTerm) {
+      $filterContainerElm.addClass('filled');
+    }
+
+    // append the new DOM element to the header row
+    if ($filterContainerElm && typeof $filterContainerElm.appendTo === 'function') {
+      $filterContainerElm.appendTo($headerElm);
+    }
+
+    return $filterContainerElm;
+  }
+
+  private onTriggerEvent(e: Event | undefined, clearFilterTriggered?: boolean) {
+    if (clearFilterTriggered) {
+      this.callback(e, { columnDef: this.columnDef, clearFilterTriggered: true });
+    } else {
+      const selectedOperator = this.$selectOperatorElm.find('option:selected').text();
+      const value = this.$filterInputElm.val();
+      (value) ? this.$filterElm.addClass('filled') : this.$filterElm.removeClass('filled');
+      this.callback(e, { columnDef: this.columnDef, searchTerms: (value ? [value] : null), operator: selectedOperator || '' });
+    }
+  }
+}

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/index.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/index.ts
@@ -1,6 +1,7 @@
 import { CompoundDateFilter } from './compoundDateFilter';
 import { CompoundInputFilter } from './compoundInputFilter';
 import { InputFilter } from './inputFilter';
+import { InputRangeFilter } from './inputRangeFilter';
 import { MultipleSelectFilter } from './multipleSelectFilter';
 import { SelectFilter } from './selectFilter';
 import { SingleSelectFilter } from './singleSelectFilter';
@@ -14,6 +15,9 @@ export const Filters = {
 
   /** Default Filter, input type text filter with a magnifying glass placeholder */
   input: InputFilter,
+
+  /** Default Filter, input type text filter with a magnifying glass placeholder */
+  slider: InputRangeFilter,
 
   /** Multiple Select filter, which uses 3rd party lib "multiple-select.js" */
   multipleSelect: MultipleSelectFilter,

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/index.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/index.ts
@@ -1,7 +1,7 @@
 import { CompoundDateFilter } from './compoundDateFilter';
 import { CompoundInputFilter } from './compoundInputFilter';
 import { InputFilter } from './inputFilter';
-import { InputRangeFilter } from './inputRangeFilter';
+import { SliderFilter } from './sliderFilter';
 import { MultipleSelectFilter } from './multipleSelectFilter';
 import { SelectFilter } from './selectFilter';
 import { SingleSelectFilter } from './singleSelectFilter';
@@ -17,7 +17,7 @@ export const Filters = {
   input: InputFilter,
 
   /** Default Filter, input type text filter with a magnifying glass placeholder */
-  slider: InputRangeFilter,
+  slider: SliderFilter,
 
   /** Multiple Select filter, which uses 3rd party lib "multiple-select.js" */
   multipleSelect: MultipleSelectFilter,

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/index.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/index.ts
@@ -1,5 +1,6 @@
 import { CompoundDateFilter } from './compoundDateFilter';
 import { CompoundInputFilter } from './compoundInputFilter';
+import { CompoundSliderFilter } from './compoundSliderFilter';
 import { InputFilter } from './inputFilter';
 import { SliderFilter } from './sliderFilter';
 import { MultipleSelectFilter } from './multipleSelectFilter';
@@ -13,10 +14,13 @@ export const Filters = {
   /** Compound Input Filter (compound of Operator + Input) */
   compoundInput: CompoundInputFilter,
 
-  /** Default Filter, input type text filter with a magnifying glass placeholder */
+  /** Compound Slider Filter (compound of Operator + Slider) */
+  compoundSlider: CompoundSliderFilter,
+
+  /** Default Filter, input type text filter */
   input: InputFilter,
 
-  /** Default Filter, input type text filter with a magnifying glass placeholder */
+  /** Default Filter, input type text filter */
   slider: SliderFilter,
 
   /** Multiple Select filter, which uses 3rd party lib "multiple-select.js" */

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/inputRangeFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/inputRangeFilter.ts
@@ -1,0 +1,132 @@
+import {
+  Column,
+  Filter,
+  FilterArguments,
+  FilterCallback,
+  GridOption,
+  OperatorType,
+  OperatorString,
+  SearchTerm
+} from './../models/index';
+import * as $ from 'jquery';
+
+export class InputRangeFilter implements Filter {
+  private $filterElm: any;
+  grid: any;
+  searchTerms: SearchTerm[];
+  columnDef: Column;
+  callback: FilterCallback;
+
+  /** Getter for the Grid Options pulled through the Grid Object */
+  private get gridOptions(): GridOption {
+    return (this.grid && this.grid.getOptions) ? this.grid.getOptions() : {};
+  }
+
+  get operator(): OperatorType | OperatorString {
+    return OperatorType.equal;
+  }
+
+  /**
+   * Initialize the Filter
+   */
+  init(args: FilterArguments) {
+    if (!args) {
+      throw new Error('[Aurelia-SlickGrid] A filter must always have an "init()" with valid arguments.');
+    }
+    this.grid = args.grid;
+    this.callback = args.callback;
+    this.columnDef = args.columnDef;
+    this.searchTerms = args.searchTerms || [];
+
+    // filter input can only have 1 search term, so we will use the 1st array index if it exist
+    const searchTerm = (Array.isArray(this.searchTerms) && this.searchTerms[0]) || '';
+
+    // step 1, create HTML string template
+    const filterTemplate = this.buildTemplateHtmlString();
+
+    // step 2, create the DOM Element of the filter & initialize it if searchTerm is filled
+    this.$filterElm = this.createDomElement(filterTemplate, searchTerm);
+
+    // step 3, subscribe to the change event and run the callback when that happens
+    // also add/remove "filled" class for styling purposes
+    this.$filterElm.change((e: any) => {
+      const value = e && e.target && e.target.value || '';
+      if (!value || value === '') {
+        this.callback(e, { columnDef: this.columnDef, clearFilterTriggered: true });
+        this.$filterElm.removeClass('filled');
+      } else {
+        this.$filterElm.addClass('filled');
+        this.callback(e, { columnDef: this.columnDef, searchTerms: [value] });
+      }
+    });
+  }
+
+  /**
+   * Clear the filter value
+   */
+  clear() {
+    if (this.$filterElm) {
+      this.$filterElm.val('');
+      this.$filterElm.trigger('change');
+    }
+  }
+
+  /**
+   * destroy the filter
+   */
+  destroy() {
+    if (this.$filterElm) {
+      this.$filterElm.off('change').remove();
+    }
+  }
+
+  /**
+   * Set value(s) on the DOM element
+   */
+  setValues(values: SearchTerm) {
+    if (values) {
+      this.$filterElm.val(values);
+    }
+  }
+
+  //
+  // private functions
+  // ------------------
+
+  /**
+   * Create the HTML template as a string
+   */
+  private buildTemplateHtmlString() {
+    const placeholder = (this.gridOptions) ? (this.gridOptions.defaultFilterPlaceholder || '') : '';
+    return `<input type="range" defaultValue="0" value="0" class="form-control search-filter range">`;
+  }
+
+  /**
+   * From the html template string, create a DOM element
+   * @param filterTemplate
+   */
+  private createDomElement(filterTemplate: string, searchTerm?: SearchTerm) {
+    const $headerElm = this.grid.getHeaderRowColumn(this.columnDef.id);
+    $($headerElm).empty();
+
+    // create the DOM element & add an ID and filter class
+    const $filterElm = $(filterTemplate);
+    const searchTermInput = (searchTerm || '0') as string;
+
+    $filterElm.val(searchTermInput);
+    $filterElm.attr('id', `filter-${this.columnDef.id}`);
+    $filterElm.data('columnId', this.columnDef.id);
+
+    // if there's a search term, we will add the "filled" class for styling purposes
+    if (searchTerm) {
+      $filterElm.addClass('filled');
+    }
+
+    // append the new DOM element to the header row
+    if ($filterElm && typeof $filterElm.appendTo === 'function') {
+      $filterElm.appendTo($headerElm);
+    }
+
+    return $filterElm;
+  }
+}

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/inputRangeFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/inputRangeFilter.ts
@@ -10,6 +10,8 @@ import {
 } from './../models/index';
 import * as $ from 'jquery';
 
+const DEFAULT_VALUE = '0';
+
 export class InputRangeFilter implements Filter {
   private $filterElm: any;
   grid: any;
@@ -66,7 +68,9 @@ export class InputRangeFilter implements Filter {
    */
   clear() {
     if (this.$filterElm) {
-      this.$filterElm.val('');
+      const clearedValue = this.columnDef && this.columnDef.params && this.columnDef.params.sliderDefaultValue || DEFAULT_VALUE;
+      this.$filterElm.children('input').val(clearedValue);
+      this.$filterElm.children('span.input-group-addon').html(clearedValue);
       this.$filterElm.trigger('change');
     }
   }
@@ -102,7 +106,7 @@ export class InputRangeFilter implements Filter {
     <div class="input-group">
       <input type="range" id="rangeInput_${this.columnDef.field}"
         name="rangeInput_${this.columnDef.field}"
-        defaultValue="0" value="0" max="${maxValue}"
+        defaultValue="0" max="${maxValue}"
         class="form-control search-filter range"
         oninput="$('#rangeOuput_${this.columnDef.field}').html(rangeInput_${this.columnDef.field}.value)"
       >
@@ -123,7 +127,8 @@ export class InputRangeFilter implements Filter {
     const $filterElm = $(filterTemplate);
     const searchTermInput = (searchTerm || '0') as string;
 
-    $filterElm.val(searchTermInput);
+    $filterElm.children('input').val(searchTermInput);
+    $filterElm.children('span.input-group-addon').html(searchTermInput);
     $filterElm.attr('id', `filter-${this.columnDef.id}`);
     $filterElm.data('columnId', this.columnDef.id);
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/inputRangeFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/inputRangeFilter.ts
@@ -97,8 +97,18 @@ export class InputRangeFilter implements Filter {
    * Create the HTML template as a string
    */
   private buildTemplateHtmlString() {
-    const placeholder = (this.gridOptions) ? (this.gridOptions.defaultFilterPlaceholder || '') : '';
-    return `<input type="range" defaultValue="0" value="0" class="form-control search-filter range">`;
+    const maxValue = this.columnDef && this.columnDef.params && this.columnDef.params.sliderMaxValue || 100;
+    return `
+    <div class="input-group">
+      <input type="range" id="rangeInput_${this.columnDef.field}"
+        name="rangeInput_${this.columnDef.field}"
+        defaultValue="0" value="0" max="${maxValue}"
+        class="form-control search-filter range"
+        oninput="$('#rangeOuput_${this.columnDef.field}').html(rangeInput_${this.columnDef.field}.value)"
+      >
+      <span class="input-group-addon" id="rangeOuput_${this.columnDef.field}">0</span>
+    </div>
+    `;
   }
 
   /**

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/sliderFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/sliderFilter.ts
@@ -109,16 +109,24 @@ export class SliderFilter implements Filter {
     const maxValue = this.filterParams.sliderMaxValue || DEFAULT_MAX_VALUE;
     const step = this.filterParams.sliderStep || DEFAULT_STEP;
 
+    if (this.filterParams.hideSliderValue) {
+      return `
+        <input type="range" id="rangeInput_${this.columnDef.field}"
+          name="rangeInput_${this.columnDef.field}"
+          defaultValue="${defaultValue}" min="${minValue}" max="${maxValue}" step="${step}"
+          class="form-control search-filter range"
+          onmousemove="$('#rangeOuput_${this.columnDef.field}').html(rangeInput_${this.columnDef.field}.value)" />`;
+    }
+
     return `
-    <div class="input-group">
-      <input type="range" id="rangeInput_${this.columnDef.field}"
-        name="rangeInput_${this.columnDef.field}"
-        defaultValue="${defaultValue}" min="${minValue}" max="${maxValue}" step="${step}"
-        class="form-control search-filter range"
-        oninput="$('#rangeOuput_${this.columnDef.field}').html(rangeInput_${this.columnDef.field}.value)" />
-      <span class="input-group-addon" id="rangeOuput_${this.columnDef.field}">${defaultValue}</span>
-    </div>
-    `;
+      <div class="input-group">
+        <input type="range" id="rangeInput_${this.columnDef.field}"
+          name="rangeInput_${this.columnDef.field}"
+          defaultValue="${defaultValue}" min="${minValue}" max="${maxValue}" step="${step}"
+          class="form-control search-filter range"
+          onmousemove="$('#rangeOuput_${this.columnDef.field}').html(rangeInput_${this.columnDef.field}.value)" />
+        <span class="input-group-addon" id="rangeOuput_${this.columnDef.field}">${defaultValue}</span>
+      </div>`;
   }
 
   /**

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/sliderFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/sliderFilter.ts
@@ -12,16 +12,16 @@ import * as $ from 'jquery';
 
 const DEFAULT_VALUE = '0';
 
-export class InputRangeFilter implements Filter {
+export class SliderFilter implements Filter {
   private $filterElm: any;
   grid: any;
   searchTerms: SearchTerm[];
   columnDef: Column;
   callback: FilterCallback;
 
-  /** Getter for the Grid Options pulled through the Grid Object */
-  private get gridOptions(): GridOption {
-    return (this.grid && this.grid.getOptions) ? this.grid.getOptions() : {};
+  /** Getter for the Filter Generic Params */
+  private get filterParams(): any {
+    return this.columnDef && this.columnDef.filter && this.columnDef.filter.params || {};
   }
 
   get operator(): OperatorType | OperatorString {
@@ -68,7 +68,7 @@ export class InputRangeFilter implements Filter {
    */
   clear() {
     if (this.$filterElm) {
-      const clearedValue = this.columnDef && this.columnDef.params && this.columnDef.params.sliderDefaultValue || DEFAULT_VALUE;
+      const clearedValue = this.filterParams.sliderDefaultValue || DEFAULT_VALUE;
       this.$filterElm.children('input').val(clearedValue);
       this.$filterElm.children('span.input-group-addon').html(clearedValue);
       this.$filterElm.trigger('change');
@@ -101,7 +101,7 @@ export class InputRangeFilter implements Filter {
    * Create the HTML template as a string
    */
   private buildTemplateHtmlString() {
-    const maxValue = this.columnDef && this.columnDef.params && this.columnDef.params.sliderMaxValue || 100;
+    const maxValue = this.filterParams.sliderMaxValue || 100;
     return `
     <div class="input-group">
       <input type="range" id="rangeInput_${this.columnDef.field}"

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/sliderFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/sliderFilter.ts
@@ -10,7 +10,6 @@ import {
 } from './../models/index';
 import * as $ from 'jquery';
 
-const DEFAULT_VALUE = 0;
 const DEFAULT_MIN_VALUE = 0;
 const DEFAULT_MAX_VALUE = 100;
 const DEFAULT_STEP = 1;
@@ -71,7 +70,7 @@ export class SliderFilter implements Filter {
    */
   clear() {
     if (this.$filterElm) {
-      const clearedValue = this.filterParams.sliderDefaultValue || DEFAULT_VALUE;
+      const clearedValue = this.filterParams.hasOwnProperty('sliderDefaultValue') ? this.filterParams.sliderDefaultValue : DEFAULT_MIN_VALUE;
       this.$filterElm.children('input').val(clearedValue);
       this.$filterElm.children('span.input-group-addon').html(clearedValue);
       this.$filterElm.trigger('change');
@@ -104,10 +103,10 @@ export class SliderFilter implements Filter {
    * Create the HTML template as a string
    */
   private buildTemplateHtmlString() {
-    const defaultValue = this.filterParams.sliderDefaultValue || DEFAULT_VALUE;
-    const minValue = this.filterParams.sliderMinValue || DEFAULT_MIN_VALUE;
-    const maxValue = this.filterParams.sliderMaxValue || DEFAULT_MAX_VALUE;
-    const step = this.filterParams.sliderStep || DEFAULT_STEP;
+    const minValue = this.filterParams.hasOwnProperty('sliderMinValue') ? this.filterParams.sliderMinValue : DEFAULT_MIN_VALUE;
+    const maxValue = this.filterParams.hasOwnProperty('sliderMaxValue') ? this.filterParams.sliderMaxValue : DEFAULT_MAX_VALUE;
+    const defaultValue = this.filterParams.hasOwnProperty('sliderDefaultValue') ? this.filterParams.sliderDefaultValue : minValue;
+    const step = this.filterParams.hasOwnProperty('sliderStep') ? this.filterParams.sliderStep : DEFAULT_STEP;
 
     if (this.filterParams.hideSliderValue) {
       return `

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/sliderFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/sliderFilter.ts
@@ -1,12 +1,12 @@
 import {
   Column,
+  ColumnFilter,
   Filter,
   FilterArguments,
   FilterCallback,
-  GridOption,
   OperatorType,
   OperatorString,
-  SearchTerm
+  SearchTerm,
 } from './../models/index';
 import * as $ from 'jquery';
 
@@ -26,8 +26,13 @@ export class SliderFilter implements Filter {
     return this.columnDef && this.columnDef.filter && this.columnDef.filter.params || {};
   }
 
+  /** Getter for the `filter` properties */
+  private get filterProperties(): ColumnFilter {
+    return this.columnDef && this.columnDef.filter || {};
+  }
+
   get operator(): OperatorType | OperatorString {
-    return OperatorType.equal;
+    return this.columnDef.filter.operator || OperatorType.equal;
   }
 
   /**
@@ -60,7 +65,7 @@ export class SliderFilter implements Filter {
         this.$filterElm.removeClass('filled');
       } else {
         this.$filterElm.addClass('filled');
-        this.callback(e, { columnDef: this.columnDef, searchTerms: [value] });
+        this.callback(e, { columnDef: this.columnDef, operator: this.operator, searchTerms: [value] });
       }
     });
   }
@@ -70,7 +75,7 @@ export class SliderFilter implements Filter {
    */
   clear() {
     if (this.$filterElm) {
-      const clearedValue = this.filterParams.hasOwnProperty('sliderDefaultValue') ? this.filterParams.sliderDefaultValue : DEFAULT_MIN_VALUE;
+      const clearedValue = this.filterParams.hasOwnProperty('sliderStartValue') ? this.filterParams.sliderStartValue : DEFAULT_MIN_VALUE;
       this.$filterElm.children('input').val(clearedValue);
       this.$filterElm.children('span.input-group-addon').html(clearedValue);
       this.$filterElm.trigger('change');
@@ -103,18 +108,17 @@ export class SliderFilter implements Filter {
    * Create the HTML template as a string
    */
   private buildTemplateHtmlString() {
-    const minValue = this.filterParams.hasOwnProperty('sliderMinValue') ? this.filterParams.sliderMinValue : DEFAULT_MIN_VALUE;
-    const maxValue = this.filterParams.hasOwnProperty('sliderMaxValue') ? this.filterParams.sliderMaxValue : DEFAULT_MAX_VALUE;
-    const defaultValue = this.filterParams.hasOwnProperty('sliderDefaultValue') ? this.filterParams.sliderDefaultValue : minValue;
-    const step = this.filterParams.hasOwnProperty('sliderStep') ? this.filterParams.sliderStep : DEFAULT_STEP;
+    const minValue = this.filterProperties.hasOwnProperty('minValue') ? this.filterProperties.minValue : DEFAULT_MIN_VALUE;
+    const maxValue = this.filterProperties.hasOwnProperty('maxValue') ? this.filterProperties.maxValue : DEFAULT_MAX_VALUE;
+    const defaultValue = this.filterParams.hasOwnProperty('sliderStartValue') ? this.filterParams.sliderStartValue : minValue;
+    const step = this.filterProperties.hasOwnProperty('valueStep') ? this.filterProperties.valueStep : DEFAULT_STEP;
 
-    if (this.filterParams.hideSliderValue) {
+    if (this.filterParams.hideSliderNumber) {
       return `
         <input type="range" id="rangeInput_${this.columnDef.field}"
           name="rangeInput_${this.columnDef.field}"
           defaultValue="${defaultValue}" min="${minValue}" max="${maxValue}" step="${step}"
-          class="form-control search-filter range"
-          onmousemove="$('#rangeOuput_${this.columnDef.field}').html(rangeInput_${this.columnDef.field}.value)" />`;
+          class="form-control search-filter range" />`;
     }
 
     return `
@@ -124,7 +128,7 @@ export class SliderFilter implements Filter {
           defaultValue="${defaultValue}" min="${minValue}" max="${maxValue}" step="${step}"
           class="form-control search-filter range"
           onmousemove="$('#rangeOuput_${this.columnDef.field}').html(rangeInput_${this.columnDef.field}.value)" />
-        <span class="input-group-addon" id="rangeOuput_${this.columnDef.field}">${defaultValue}</span>
+        <span class="input-group-addon slider-value" id="rangeOuput_${this.columnDef.field}">${defaultValue}</span>
       </div>`;
   }
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/sliderFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/sliderFilter.ts
@@ -10,7 +10,10 @@ import {
 } from './../models/index';
 import * as $ from 'jquery';
 
-const DEFAULT_VALUE = '0';
+const DEFAULT_VALUE = 0;
+const DEFAULT_MIN_VALUE = 0;
+const DEFAULT_MAX_VALUE = 100;
+const DEFAULT_STEP = 1;
 
 export class SliderFilter implements Filter {
   private $filterElm: any;
@@ -101,16 +104,19 @@ export class SliderFilter implements Filter {
    * Create the HTML template as a string
    */
   private buildTemplateHtmlString() {
-    const maxValue = this.filterParams.sliderMaxValue || 100;
+    const defaultValue = this.filterParams.sliderDefaultValue || DEFAULT_VALUE;
+    const minValue = this.filterParams.sliderMinValue || DEFAULT_MIN_VALUE;
+    const maxValue = this.filterParams.sliderMaxValue || DEFAULT_MAX_VALUE;
+    const step = this.filterParams.sliderStep || DEFAULT_STEP;
+
     return `
     <div class="input-group">
       <input type="range" id="rangeInput_${this.columnDef.field}"
         name="rangeInput_${this.columnDef.field}"
-        defaultValue="0" max="${maxValue}"
+        defaultValue="${defaultValue}" min="${minValue}" max="${maxValue}" step="${step}"
         class="form-control search-filter range"
-        oninput="$('#rangeOuput_${this.columnDef.field}').html(rangeInput_${this.columnDef.field}.value)"
-      >
-      <span class="input-group-addon" id="rangeOuput_${this.columnDef.field}">0</span>
+        oninput="$('#rangeOuput_${this.columnDef.field}').html(rangeInput_${this.columnDef.field}.value)" />
+      <span class="input-group-addon" id="rangeOuput_${this.columnDef.field}">${defaultValue}</span>
     </div>
     `;
   }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/index.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/index.ts
@@ -43,11 +43,12 @@ export function configure(aurelia: any, callback: any) {
   // must register a transient so the container will get a new instance everytime
   aurelia.container.registerTransient(Filters.compoundDate);
   aurelia.container.registerTransient(Filters.compoundInput);
+  aurelia.container.registerTransient(Filters.compoundSlider);
   aurelia.container.registerTransient(Filters.input);
-  aurelia.container.registerTransient(Filters.slider);
   aurelia.container.registerTransient(Filters.multipleSelect);
   aurelia.container.registerTransient(Filters.singleSelect);
   aurelia.container.registerTransient(Filters.select);
+  aurelia.container.registerTransient(Filters.slider);
 
   const config = new SlickgridConfig();
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/index.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/index.ts
@@ -44,6 +44,7 @@ export function configure(aurelia: any, callback: any) {
   aurelia.container.registerTransient(Filters.compoundDate);
   aurelia.container.registerTransient(Filters.compoundInput);
   aurelia.container.registerTransient(Filters.input);
+  aurelia.container.registerTransient(Filters.slider);
   aurelia.container.registerTransient(Filters.multipleSelect);
   aurelia.container.registerTransient(Filters.singleSelect);
   aurelia.container.registerTransient(Filters.select);

--- a/aurelia-slickgrid/src/aurelia-slickgrid/models/columnFilter.interface.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/models/columnFilter.interface.ts
@@ -24,6 +24,12 @@ export interface ColumnFilter {
   /** Operator to use when filtering (>, >=, EQ, IN, ...) */
   operator?: OperatorType | OperatorString;
 
+  /** Maximum value of the filter, works only with Filters supporting it (text, number, float, slider) */
+  maxValue?: number | string;
+
+  /** Minimum value of the filter, works only with Filters supporting it (text, number, float, slider) */
+  minValue?: number | string;
+
   /** Filter to use (input, multipleSelect, singleSelect, select, custom) */
   model?: any;
 
@@ -54,4 +60,7 @@ export interface ColumnFilter {
    * params: { options: [{ value: true, label: 'True' }, { value: true, label: 'True'} ]}
    */
   params?: any;
+
+  /** Step value of the filter, works only with Filters supporting it (input text, number, float, range, slider) */
+  valueStep?: number | string;
 }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/models/filterCallback.interface.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/models/filterCallback.interface.ts
@@ -1,9 +1,9 @@
-import { Column, OperatorString, SearchTerm } from './../models/index';
+import { Column, OperatorString, OperatorType, SearchTerm } from './../models/index';
 
 export interface FilterCallbackArg {
   clearFilterTriggered?: boolean;
   columnDef: Column;
-  operator?: OperatorString;
+  operator?: OperatorType | OperatorString;
   searchTerms?: SearchTerm[];
 }
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/styles/_variables.scss
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/styles/_variables.scss
@@ -172,13 +172,13 @@ $compound-filter-text-color:            $primary-color !default;
 $compound-filter-text-font-size:        13px !default;
 $compound-filter-text-padding:          0 0 0 2px !default;
 
-/* Input Range Filter */@at-root
-$slide-filter-handle-color:             rgb(157, 199, 214) !default;
+/* Input Range Filter */
+$slide-filter-handle-color:             rgb(159, 190, 162) !default;
 $slide-filter-border:                   1px solid #ccc !default;
 $slide-filter-bgcolor:                  #eee !default;
-$slide-filter-runnable-track-bgcolor:   #aaa !default;
-$slide-filter-fill-lower-color:         #777 !default; /* ms only */
-$slide-filter-fill-focus-lower-color:   #888 !default; /* ms only */
+$slide-filter-runnable-track-bgcolor:   #ddd !default;
+$slide-filter-fill-lower-color:         #ddd !default; /* ms only */
+$slide-filter-fill-focus-lower-color:   #aaa !default; /* ms only */
 
 /* Multiple-Select Filter */
 $multiselect-input-filter-border:       1px solid #ccc !default;

--- a/aurelia-slickgrid/src/aurelia-slickgrid/styles/_variables.scss
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/styles/_variables.scss
@@ -173,12 +173,15 @@ $compound-filter-text-font-size:        13px !default;
 $compound-filter-text-padding:          0 0 0 2px !default;
 
 /* Input Range Filter */
-$slider-filter-handle-color:             rgb(159, 190, 162) !default;
 $slider-filter-border:                   1px solid #ccc !default;
 $slider-filter-bgcolor:                  #eee !default;
 $slider-filter-runnable-track-bgcolor:   #ddd !default;
+$slider-filter-runnable-track-height:    4px !default;
 $slider-filter-fill-lower-color:         #ddd !default; /* ms only */
 $slider-filter-fill-focus-lower-color:   #aaa !default; /* ms only */
+$slider-filter-thumb-color:              rgb(201, 219, 203) !default;
+$slider-filter-thumb-size:               14px !default;
+$slider-filter-thumb-border:             1px solid darken($slider-filter-thumb-color, 15%) !default;
 $slider-filter-number-padding:           4px 8px !default;
 $slider-filter-number-font-size:         ($font-size-base-value - 1px) !default;
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/styles/_variables.scss
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/styles/_variables.scss
@@ -173,12 +173,14 @@ $compound-filter-text-font-size:        13px !default;
 $compound-filter-text-padding:          0 0 0 2px !default;
 
 /* Input Range Filter */
-$slide-filter-handle-color:             rgb(159, 190, 162) !default;
-$slide-filter-border:                   1px solid #ccc !default;
-$slide-filter-bgcolor:                  #eee !default;
-$slide-filter-runnable-track-bgcolor:   #ddd !default;
-$slide-filter-fill-lower-color:         #ddd !default; /* ms only */
-$slide-filter-fill-focus-lower-color:   #aaa !default; /* ms only */
+$slider-filter-handle-color:             rgb(159, 190, 162) !default;
+$slider-filter-border:                   1px solid #ccc !default;
+$slider-filter-bgcolor:                  #eee !default;
+$slider-filter-runnable-track-bgcolor:   #ddd !default;
+$slider-filter-fill-lower-color:         #ddd !default; /* ms only */
+$slider-filter-fill-focus-lower-color:   #aaa !default; /* ms only */
+$slider-filter-number-padding:           4px 8px !default;
+$slider-filter-number-font-size:         ($font-size-base-value - 1px) !default;
 
 /* Multiple-Select Filter */
 $multiselect-input-filter-border:       1px solid #ccc !default;

--- a/aurelia-slickgrid/src/aurelia-slickgrid/styles/_variables.scss
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/styles/_variables.scss
@@ -172,6 +172,14 @@ $compound-filter-text-color:            $primary-color !default;
 $compound-filter-text-font-size:        13px !default;
 $compound-filter-text-padding:          0 0 0 2px !default;
 
+/* Input Range Filter */@at-root
+$slide-filter-handle-color:             rgb(157, 199, 214) !default;
+$slide-filter-border:                   1px solid #ccc !default;
+$slide-filter-bgcolor:                  #eee !default;
+$slide-filter-runnable-track-bgcolor:   #aaa !default;
+$slide-filter-fill-lower-color:         #777 !default; /* ms only */
+$slide-filter-fill-focus-lower-color:   #888 !default; /* ms only */
+
 /* Multiple-Select Filter */
 $multiselect-input-filter-border:       1px solid #ccc !default;
 $multiselect-input-filter-font-family:  "Helvetica Neue", Helvetica, Arial !default;

--- a/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
@@ -343,82 +343,93 @@ input.search-filter[type=range] {
   /*removes default webkit styles*/
   -webkit-appearance: none;
 
+  /* change runnable track color while in focus on all browsers */
+  &:focus {
+    outline: none;
+
+    &::-webkit-slider-runnable-track {
+      background: $slide-filter-runnable-track-bgcolor;
+    }
+    &::-moz-range-track {
+      background: $slide-filter-runnable-track-bgcolor;
+    }
+    &::-ms-fill-lower {
+      background: $slide-filter-fill-focus-lower-color;
+    }
+    &::-ms-fill-upper {
+      background: $slide-filter-runnable-track-bgcolor;
+    }
+  }
+
+  /* WebKit specific (Opera/Chrome/Safari) */
+  &::-webkit-slider-runnable-track {
+    height: 5px;
+    background: $slide-filter-bgcolor;
+    border: none;
+    border-radius: 3px;
+  }
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    border: none;
+    height: 16px;
+    width: 16px;
+    border-radius: 50%;
+    background: $slide-filter-handle-color;
+    margin-top: -4px;
+  }
+
+  /* Mozilla Firefox specific */
+
   /*fix for FF unable to apply focus style bug */
   border: $slide-filter-border;
-}
-input.search-filter[type=range]::-webkit-slider-runnable-track {
-  height: 5px;
-  background: $slide-filter-bgcolor;
-  border: none;
-  border-radius: 3px;
-}
-input.search-filter[type=range]::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  border: none;
-  height: 16px;
-  width: 16px;
-  border-radius: 50%;
-  background: $slide-filter-handle-color;
-  margin-top: -4px;
-}
-input.search-filter[type=range]:focus {
-  outline: none;
-}
-input.search-filter[type=range]:focus::-webkit-slider-runnable-track {
-  background: $slide-filter-runnable-track-bgcolor;
-}
 
-input.search-filter[type=range]::-moz-range-track {
-  height: 5px;
-  background: $slide-filter-bgcolor;
-  border: none;
-  border-radius: 3px;
-}
-input.search-filter[type=range]::-moz-range-thumb {
-  border: none;
-  height: 16px;
-  width: 16px;
-  border-radius: 50%;
-  background: $slide-filter-handle-color;
-}
+  &::-moz-range-track {
+    height: 5px;
+    background: $slide-filter-bgcolor;
+    border: none;
+    border-radius: 3px;
+  }
+  &::-moz-range-thumb {
+    border: none;
+    height: 16px;
+    width: 16px;
+    border-radius: 50%;
+    background: $slide-filter-handle-color;
+  }
 
-/*hide the outline behind the border*/
-input.search-filter[type=range]:-moz-focusring{
-  outline: 1px solid white;
-  outline-offset: -1px;
-}
+  /*hide the outline behind the border*/
+  &:-moz-focusring{
+    outline: 1px solid white;
+    outline-offset: -1px;
+  }
 
-input.search-filter[type=range]::-ms-track {
-  height: 5px;
+  /* Microsoft IE specific */
+  &::-ms-track {
+    height: 5px;
 
-  /*remove bg colour from the track, we'll use ms-fill-lower and ms-fill-upper instead */
-  background: transparent;
+    /*remove bg colour from the track, we'll use ms-fill-lower and ms-fill-upper instead */
+    background: transparent;
 
-  /*leave room for the larger thumb to overflow with a transparent border */
-  border-color: transparent;
-  border-width: 6px 0;
+    /*leave room for the larger thumb to overflow with a transparent border */
+    border-color: transparent;
+    border-width: 6px 0;
 
-  /*remove default tick marks*/
-  color: transparent;
-}
-input.search-filter[type=range]::-ms-fill-lower {
-  background: $slide-filter-fill-lower-color;
-  border-radius: 10px;
-}
-input.search-filter[type=range]::-ms-fill-upper {
-  background: $slide-filter-bgcolor;
-  border-radius: 10px;
-}
-input.search-filter[type=range]::-ms-thumb {
-  border: none;
-  height: 16px;
-  width: 16px;
-  border-radius: 50%;
-  background: $slide-filter-handle-color;
-}
-input.search-filter[type=range]:focus::-ms-fill-lower {
-  background: $slide-filter-fill-focus-lower-color;
-}
-input.search-filter[type=range]:focus::-ms-fill-upper {
-  background: $slide-filter-runnable-track-bgcolor;
+    /*remove default tick marks*/
+    color: transparent;
+  }
+  &::-ms-fill-lower {
+    background: $slide-filter-fill-lower-color;
+    border-radius: 10px;
+  }
+  &::-ms-fill-upper {
+    background: $slide-filter-bgcolor;
+    border-radius: 10px;
+  }
+  &::-ms-thumb {
+    border: none;
+    height: 16px;
+    width: 16px;
+    border-radius: 50%;
+    background: $slide-filter-handle-color;
+  }
 }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
@@ -433,3 +433,8 @@ input.search-filter[type=range] {
     background: $slide-filter-handle-color;
   }
 }
+
+.slider-value {
+  font-size: ($font-size-base-value - 1px) !important;
+  height: $header-input-height;
+}

--- a/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
@@ -363,7 +363,7 @@ input.search-filter[type=range] {
 
   /* WebKit specific (Opera/Chrome/Safari) */
   &::-webkit-slider-runnable-track {
-    height: 5px;
+    height: $slider-filter-runnable-track-height;
     background: $slider-filter-bgcolor;
     border: none;
     border-radius: 3px;
@@ -371,10 +371,11 @@ input.search-filter[type=range] {
   &::-webkit-slider-thumb {
     -webkit-appearance: none;
     border: none;
-    height: 16px;
-    width: 16px;
+    height: $slider-filter-thumb-size;
+    width: $slider-filter-thumb-size;
     border-radius: 50%;
-    background: $slider-filter-handle-color;
+    border: $slider-filter-thumb-border;
+    background: $slider-filter-thumb-color;
     margin-top: -4px;
   }
 
@@ -384,17 +385,18 @@ input.search-filter[type=range] {
   border: $slider-filter-border;
 
   &::-moz-range-track {
-    height: 5px;
+    height: $slider-filter-runnable-track-height;
     background: $slider-filter-bgcolor;
     border: none;
     border-radius: 3px;
   }
   &::-moz-range-thumb {
     border: none;
-    height: 16px;
-    width: 16px;
+    height: $slider-filter-thumb-size;
+    width: $slider-filter-thumb-size;
     border-radius: 50%;
-    background: $slider-filter-handle-color;
+    border: $slider-filter-thumb-border;
+    background: $slider-filter-thumb-color;
   }
 
   /*hide the outline behind the border*/
@@ -405,7 +407,7 @@ input.search-filter[type=range] {
 
   /* Microsoft IE specific */
   &::-ms-track {
-    height: 5px;
+    height: $slider-filter-runnable-track-height;
 
     /*remove bg colour from the track, we'll use ms-fill-lower and ms-fill-upper instead */
     background: transparent;
@@ -427,10 +429,12 @@ input.search-filter[type=range] {
   }
   &::-ms-thumb {
     border: none;
-    height: 16px;
-    width: 16px;
+    height: $slider-filter-thumb-size;
+    width: $slider-filter-thumb-size;
     border-radius: 50%;
-    background: $slider-filter-handle-color;
+    border: $slider-filter-thumb-border;
+    background: $slider-filter-thumb-color;
+    margin-top: 2px;
   }
 }
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
@@ -348,23 +348,23 @@ input.search-filter[type=range] {
     outline: none;
 
     &::-webkit-slider-runnable-track {
-      background: $slide-filter-runnable-track-bgcolor;
+      background: $slider-filter-runnable-track-bgcolor;
     }
     &::-moz-range-track {
-      background: $slide-filter-runnable-track-bgcolor;
+      background: $slider-filter-runnable-track-bgcolor;
     }
     &::-ms-fill-lower {
-      background: $slide-filter-fill-focus-lower-color;
+      background: $slider-filter-fill-focus-lower-color;
     }
     &::-ms-fill-upper {
-      background: $slide-filter-runnable-track-bgcolor;
+      background: $slider-filter-runnable-track-bgcolor;
     }
   }
 
   /* WebKit specific (Opera/Chrome/Safari) */
   &::-webkit-slider-runnable-track {
     height: 5px;
-    background: $slide-filter-bgcolor;
+    background: $slider-filter-bgcolor;
     border: none;
     border-radius: 3px;
   }
@@ -374,18 +374,18 @@ input.search-filter[type=range] {
     height: 16px;
     width: 16px;
     border-radius: 50%;
-    background: $slide-filter-handle-color;
+    background: $slider-filter-handle-color;
     margin-top: -4px;
   }
 
   /* Mozilla Firefox specific */
 
   /*fix for FF unable to apply focus style bug */
-  border: $slide-filter-border;
+  border: $slider-filter-border;
 
   &::-moz-range-track {
     height: 5px;
-    background: $slide-filter-bgcolor;
+    background: $slider-filter-bgcolor;
     border: none;
     border-radius: 3px;
   }
@@ -394,7 +394,7 @@ input.search-filter[type=range] {
     height: 16px;
     width: 16px;
     border-radius: 50%;
-    background: $slide-filter-handle-color;
+    background: $slider-filter-handle-color;
   }
 
   /*hide the outline behind the border*/
@@ -418,11 +418,11 @@ input.search-filter[type=range] {
     color: transparent;
   }
   &::-ms-fill-lower {
-    background: $slide-filter-fill-lower-color;
+    background: $slider-filter-fill-lower-color;
     border-radius: 10px;
   }
   &::-ms-fill-upper {
-    background: $slide-filter-bgcolor;
+    background: $slider-filter-bgcolor;
     border-radius: 10px;
   }
   &::-ms-thumb {
@@ -430,11 +430,14 @@ input.search-filter[type=range] {
     height: 16px;
     width: 16px;
     border-radius: 50%;
-    background: $slide-filter-handle-color;
+    background: $slider-filter-handle-color;
   }
 }
 
-.slider-value {
-  font-size: ($font-size-base-value - 1px) !important;
-  height: $header-input-height;
+.search-filter {
+  .slider-value {
+    padding: $slider-filter-number-padding !important;
+    font-size: $slider-filter-number-font-size !important;
+    height: $header-input-height;
+  }
 }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
@@ -345,12 +345,8 @@ input.search-filter[type=range] {
 
   /*fix for FF unable to apply focus style bug */
   border: $slide-filter-border;
-
-  /*required for proper track sizing in FF*/
-  width: 300px;
 }
 input.search-filter[type=range]::-webkit-slider-runnable-track {
-  width: 300px;
   height: 5px;
   background: $slide-filter-bgcolor;
   border: none;
@@ -393,7 +389,6 @@ input.search-filter[type=range]:-moz-focusring{
 }
 
 input.search-filter[type=range]::-ms-track {
-  width: 300px;
   height: 5px;
 
   /*remove bg colour from the track, we'll use ms-fill-lower and ms-fill-upper instead */

--- a/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
@@ -327,7 +327,103 @@ input.search-filter {
         font-family: $filter-placeholder-font-family;
     }
 }
+
+// ----------------------------------------------
+// Date Picker Filter
+// ----------------------------------------------
 .flatpickr-input {
     background-color: $flatpickr-bgcolor !important;
     font-family: $filter-placeholder-font-family;
+}
+
+// ----------------------------------------------
+// Input Range Filter
+// ----------------------------------------------
+input.search-filter[type=range] {
+  /*removes default webkit styles*/
+  -webkit-appearance: none;
+
+  /*fix for FF unable to apply focus style bug */
+  border: $slide-filter-border;
+
+  /*required for proper track sizing in FF*/
+  width: 300px;
+}
+input.search-filter[type=range]::-webkit-slider-runnable-track {
+  width: 300px;
+  height: 5px;
+  background: $slide-filter-bgcolor;
+  border: none;
+  border-radius: 3px;
+}
+input.search-filter[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  border: none;
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  background: $slide-filter-handle-color;
+  margin-top: -4px;
+}
+input.search-filter[type=range]:focus {
+  outline: none;
+}
+input.search-filter[type=range]:focus::-webkit-slider-runnable-track {
+  background: $slide-filter-runnable-track-bgcolor;
+}
+
+input.search-filter[type=range]::-moz-range-track {
+  height: 5px;
+  background: $slide-filter-bgcolor;
+  border: none;
+  border-radius: 3px;
+}
+input.search-filter[type=range]::-moz-range-thumb {
+  border: none;
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  background: $slide-filter-handle-color;
+}
+
+/*hide the outline behind the border*/
+input.search-filter[type=range]:-moz-focusring{
+  outline: 1px solid white;
+  outline-offset: -1px;
+}
+
+input.search-filter[type=range]::-ms-track {
+  width: 300px;
+  height: 5px;
+
+  /*remove bg colour from the track, we'll use ms-fill-lower and ms-fill-upper instead */
+  background: transparent;
+
+  /*leave room for the larger thumb to overflow with a transparent border */
+  border-color: transparent;
+  border-width: 6px 0;
+
+  /*remove default tick marks*/
+  color: transparent;
+}
+input.search-filter[type=range]::-ms-fill-lower {
+  background: $slide-filter-fill-lower-color;
+  border-radius: 10px;
+}
+input.search-filter[type=range]::-ms-fill-upper {
+  background: $slide-filter-bgcolor;
+  border-radius: 10px;
+}
+input.search-filter[type=range]::-ms-thumb {
+  border: none;
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  background: $slide-filter-handle-color;
+}
+input.search-filter[type=range]:focus::-ms-fill-lower {
+  background: $slide-filter-fill-focus-lower-color;
+}
+input.search-filter[type=range]:focus::-ms-fill-upper {
+  background: $slide-filter-runnable-track-bgcolor;
 }

--- a/aurelia-slickgrid/src/examples/slickgrid/example12.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example12.ts
@@ -69,7 +69,7 @@ export class Example12 {
     this.columnDefinitions = [
       { id: 'title', name: 'Title', field: 'id', headerKey: 'TITLE', formatter: this.taskTranslateFormatter, sortable: true, minWidth: 100, filterable: true, params: { useFormatterOuputToFilter: true } },
       { id: 'description', name: 'Description', field: 'description', filterable: true, sortable: true, minWidth: 80 },
-      { id: 'duration', name: 'Duration (days)', field: 'duration', headerKey: 'DURATION', sortable: true, minWidth: 100, filterable: true },
+      { id: 'duration', name: 'Duration (days)', field: 'duration', headerKey: 'DURATION', sortable: true, formatter: Formatters.percentCompleteBar, minWidth: 100, filterable: true, filter: { model: Filters.slider } },
       { id: 'start', name: 'Start', field: 'start', headerKey: 'START', formatter: Formatters.dateIso, outputType: FieldType.dateIso, type: FieldType.date, minWidth: 100, filterable: true, filter: { model: Filters.compoundDate } },
       { id: 'finish', name: 'Finish', field: 'finish', headerKey: 'FINISH', formatter: Formatters.dateIso, outputType: FieldType.dateIso, type: FieldType.date, minWidth: 100, filterable: true, filter: { model: Filters.compoundDate } },
       {

--- a/aurelia-slickgrid/src/examples/slickgrid/example12.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example12.ts
@@ -69,7 +69,12 @@ export class Example12 {
     this.columnDefinitions = [
       { id: 'title', name: 'Title', field: 'id', headerKey: 'TITLE', formatter: this.taskTranslateFormatter, sortable: true, minWidth: 100, filterable: true, params: { useFormatterOuputToFilter: true } },
       { id: 'description', name: 'Description', field: 'description', filterable: true, sortable: true, minWidth: 80 },
-      { id: 'duration', name: 'Duration (days)', field: 'duration', headerKey: 'DURATION', sortable: true, formatter: Formatters.percentCompleteBar, minWidth: 100, filterable: true, filter: { model: Filters.slider } },
+      {
+        id: 'duration', name: 'Duration (days)', field: 'duration', headerKey: 'DURATION', sortable: true,
+        formatter: Formatters.percentCompleteBar, minWidth: 100,
+        filterable: true,
+        filter: { model: Filters.slider, /* operator: '>=',*/ params: { hideSliderNumber: true } }
+      },
       { id: 'start', name: 'Start', field: 'start', headerKey: 'START', formatter: Formatters.dateIso, outputType: FieldType.dateIso, type: FieldType.date, minWidth: 100, filterable: true, filter: { model: Filters.compoundDate } },
       { id: 'finish', name: 'Finish', field: 'finish', headerKey: 'FINISH', formatter: Formatters.dateIso, outputType: FieldType.dateIso, type: FieldType.date, minWidth: 100, filterable: true, filter: { model: Filters.compoundDate } },
       {

--- a/aurelia-slickgrid/src/examples/slickgrid/example15.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example15.ts
@@ -105,7 +105,7 @@ export class Example15 {
       },
       {
         id: 'complete', name: '% Complete', field: 'percentComplete', minWidth: 70, type: FieldType.number, sortable: true, width: 100,
-        formatter: Formatters.percentCompleteBar, filterable: true, filter: { model: Filters.slider }
+        formatter: Formatters.percentCompleteBar, filterable: true, filter: { model: Filters.slider, operator: '>' }
       },
       {
         id: 'start', name: 'Start', field: 'start', headerKey: 'START', formatter: Formatters.dateIso, sortable: true, minWidth: 75, exportWithFormatter: true, width: 100,

--- a/aurelia-slickgrid/src/examples/slickgrid/example15.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example15.ts
@@ -95,7 +95,7 @@ export class Example15 {
         filter: {
           collection: multiSelectFilterArray,
           model: Filters.multipleSelect,
-          searchTerms: [1, 33, 50], // default selection
+          searchTerms: [1, 33, 44, 50, 66], // default selection
           // we could add certain option(s) to the "multiple-select" plugin
           filterOptions: {
             maxHeight: 250,
@@ -104,8 +104,8 @@ export class Example15 {
         }
       },
       {
-        id: 'complete', name: '% Complete', field: 'percentComplete', formatter: Formatters.percentCompleteBar, minWidth: 70, type: FieldType.number, sortable: true, width: 100,
-        filterable: true, filter: { model: Filters.compoundInput }
+        id: 'complete', name: '% Complete', field: 'percentComplete', minWidth: 70, type: FieldType.number, sortable: true, width: 100,
+        formatter: Formatters.percentCompleteBar, filterable: true, filter: { model: Filters.slider }
       },
       {
         id: 'start', name: 'Start', field: 'start', headerKey: 'START', formatter: Formatters.dateIso, sortable: true, minWidth: 75, exportWithFormatter: true, width: 100,

--- a/aurelia-slickgrid/src/examples/slickgrid/example9.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example9.ts
@@ -47,7 +47,12 @@ export class Example9 {
     this.columnDefinitions = [
       { id: 'title', name: 'Title', field: 'title', filterable: true, type: FieldType.string },
       { id: 'duration', name: 'Duration', field: 'duration', sortable: true, filterable: true, type: FieldType.string },
-      { id: '%', name: '% Complete', field: 'percentComplete', sortable: true, filterable: true, type: FieldType.number, formatter: Formatters.percentCompleteBar },
+      {
+        id: '%', name: '% Complete', field: 'percentComplete', sortable: true, filterable: true,
+        type: FieldType.number,
+        formatter: Formatters.percentCompleteBar,
+        filter: { model: Filters.slider }
+      },
       { id: 'start', name: 'Start', field: 'start', filterable: true, type: FieldType.dateUs, filter: { model: Filters.compoundDate } },
       { id: 'finish', name: 'Finish', field: 'finish', filterable: true, type: FieldType.dateUs, filter: { model: Filters.compoundDate } },
       {

--- a/aurelia-slickgrid/src/examples/slickgrid/example9.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example9.ts
@@ -51,7 +51,7 @@ export class Example9 {
         id: '%', name: '% Complete', field: 'percentComplete', sortable: true, filterable: true,
         type: FieldType.number,
         formatter: Formatters.percentCompleteBar,
-        filter: { model: Filters.slider }
+        filter: { model: Filters.compoundSlider, params: { hideSliderNumber: false } }
       },
       { id: 'start', name: 'Start', field: 'start', filterable: true, type: FieldType.dateUs, filter: { model: Filters.compoundDate } },
       { id: 'finish', name: 'Finish', field: 'finish', filterable: true, type: FieldType.dateUs, filter: { model: Filters.compoundDate } },


### PR DESCRIPTION
Use an input range to add what looks like a slider filter. 
- when the slider is set to 0 (default value), it returns all values
- when going over over, it will return only the rows with selected value
- styled to be cross-browser compatible
- tooltip only shown in IE, I wish we could add them for all browser though

@jmzagorski 
It's not yet finished but it's functional, so don't approve yet. I just need to clear up the styling and see if we can add tooltip for all browser. Not as useful without tooltip of the value

![chrome_2018-06-09_18-35-56](https://user-images.githubusercontent.com/643976/41196662-06d4886e-6c14-11e8-9366-cf24afc4603f.png)
