### PR TITLE
fix(editor): Select Editor should close when tabbing away, fixes #92

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/longTextEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/longTextEditor.ts
@@ -54,11 +54,11 @@ export class LongTextEditor implements Editor {
         <button class="btn btn-default btn-xs">${cancelText}</button>
       </div>`).appendTo(this.$wrapper);
 
-    this.$wrapper.find('button:first').on('click', (event: Event) => this.save());
-    this.$wrapper.find('button:last').on('click', (event: Event) => this.cancel());
-    this.$input.on('keydown', this.handleKeyDown);
+    this.$wrapper.find('button:first').on('click', () => this.save());
+    this.$wrapper.find('button:last').on('click', () => this.cancel());
+    this.$input.on('keydown', this.handleKeyDown.bind(this));
 
-    this.position(this.args.position);
+    this.position(this.args && this.args.position);
     this.$input.focus().select();
   }
 
@@ -70,20 +70,28 @@ export class LongTextEditor implements Editor {
       this.cancel();
     } else if (e.which === KeyCode.TAB && e.shiftKey) {
       e.preventDefault();
-      this.args.grid.navigatePrev();
+      if (this.args && this.args.grid) {
+        this.args.grid.navigatePrev();
+      }
     } else if (e.which === KeyCode.TAB) {
       e.preventDefault();
-      this.args.grid.navigateNext();
+      if (this.args && this.args.grid) {
+        this.args.grid.navigateNext();
+      }
     }
   }
 
   save() {
-    this.args.commitChanges();
+    if (this.args && this.args.commitChanges) {
+      this.args.commitChanges();
+    }
   }
 
   cancel() {
     this.$input.val(this.defaultValue);
-    this.args.cancelChanges();
+    if (this.args && this.args.cancelChanges) {
+      this.args.cancelChanges();
+    }
   }
 
   hide() {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/selectEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/selectEditor.ts
@@ -17,9 +17,6 @@ import { arraysEqual, getDescendantProperty, htmlEncode } from '../services/util
 import * as DOMPurify from 'dompurify';
 import * as $ from 'jquery';
 
-// height in pixel of the multiple-select DOM element
-const SELECT_ELEMENT_HEIGHT = 26;
-
 /**
  * Slickgrid editor class for multiple select lists
  */
@@ -81,6 +78,7 @@ export class SelectEditor implements Editor {
         const isRenderHtmlEnabled = this.columnDef && this.columnDef.internalColumnEditor && this.columnDef.internalColumnEditor.enableRenderHtml || false;
         return isRenderHtmlEnabled ? $elm.text() : $elm.html();
       },
+      onBlur: () => this.destroy()
     };
     if (isMultipleSelect) {
       libOptions.single = false;
@@ -195,7 +193,8 @@ export class SelectEditor implements Editor {
   }
 
   destroy() {
-    if (this.$editorElm) {
+    if (this.$editorElm && this.$editorElm.multipleSelect) {
+      this.$editorElm.multipleSelect('close');
       this.$editorElm.remove();
     }
     this.subscriptions = disposeAllSubscriptions(this.subscriptions);
@@ -236,7 +235,9 @@ export class SelectEditor implements Editor {
   }
 
   focus() {
-    this.$editorElm.focus();
+    if (this.$editorElm && this.$editorElm.multipleSelect) {
+      this.$editorElm.multipleSelect('focus');
+    }
   }
 
   isValueChanged(): boolean {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/selectFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/selectFilter.ts
@@ -63,6 +63,7 @@ export class SelectFilter implements Filter {
         const isRenderHtmlEnabled = this.columnDef && this.columnDef.filter && this.columnDef.filter.enableRenderHtml || false;
         return isRenderHtmlEnabled ? $elm.text() : $elm.html();
       },
+      onBlur: () => this.destroy(),
       onClose: () => {
         // we will subscribe to the onClose event for triggering our callback
         // also add/remove "filled" class for styling purposes
@@ -171,6 +172,12 @@ export class SelectFilter implements Filter {
    */
   destroy() {
     if (this.$filterElm) {
+      // close the drop
+      if (this.$filterElm.multipleSelect) {
+        this.$filterElm.multipleSelect('close');
+      }
+
+      // remove event watcher
       this.$filterElm.off().remove();
 
       // also dispose of all Subscriptions


### PR DESCRIPTION
- Single/Multiple Editors now closes the drop when tabbing away (blur)
- also fixed the `focus()` function inside the Editor
- demo shown below, I used tab key and arrows to test it out

- Since this seems to work quite good, I should probably do the same on the Select Filter as well. I'll add another commit within same PR

![2018-09-08_00-10-46](https://user-images.githubusercontent.com/643976/45250177-d41ce900-b2fb-11e8-94ab-b7aa71037d8f.gif)
