### PR TITLE
feat(editor): Add auto commit edit flag to grid options

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.html
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.html
@@ -1,6 +1,7 @@
 <template>
   <div id="slickGridContainer-${gridId}" class="gridPane" css="width: ${gridWidth}px">
-    <div id.bind="gridId" class="slickgrid-container" style="width: 100%" css="height: ${gridHeight}px">
+    <div id.bind="gridId" class="slickgrid-container" style="width: 100%" css="height: ${gridHeight}px"
+      focusout.delegate="commitEdit($event.target)">
     </div>
 
     <slick-pagination id="slickPagingContainer-${gridId}" if.bind="showPagination" asg-on-pagination-changed.delegate="paginationChanged($event.detail)"

--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -300,8 +300,6 @@ export class AureliaSlickgridCustomElement {
       // tries to commit the edit when going from one editor to another on the grid
       // through the click event. If the timeout was not here it would
       // try to commit/destroy the twice, which would throw a jquery
-      //
-      //
       // error about the element not being in the DOM
       setTimeout(() => {
         // make sure the target is the active editor so we do not

--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -289,6 +289,30 @@ export class AureliaSlickgridCustomElement {
     }
   }
 
+  /**
+   * Commits the current edit to the grid
+   */
+  commitEdit(target: Element) {
+    if (this.grid.getOptions().autoCommitEdit) {
+      const activeNode = this.grid.getActiveCellNode();
+
+      // a timeout must be set or this could come into conflict when slickgrid
+      // tries to commit the edit when going from one editor to another on the grid
+      // through the click event. If the timeout was not here it would
+      // try to commit/destroy the twice, which would throw a jquery
+      //
+      //
+      // error about the element not being in the DOM
+      setTimeout(() => {
+        // make sure the target is the active editor so we do not
+        // commit prematurely
+        if (activeNode && activeNode.contains(target) && this.grid.getEditorLock().isActive()) {
+          this.grid.getEditorLock().commitCurrentEdit();
+        }
+      });
+    }
+  }
+
   datasetChanged(newValue: any[], oldValue: any[]) {
     this._dataset = newValue;
     this.refreshGridData(newValue);

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/checkboxEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/checkboxEditor.ts
@@ -32,6 +32,11 @@ export class CheckboxEditor implements Editor {
     this.$input = $(`<input type="checkbox" value="true" class="editor-checkbox" />`);
     this.$input.appendTo(this.args.container);
     this.$input.focus();
+
+    // make the checkbox editor act like a regular checkbox that commit the value on click
+    if (this.args.grid.getOptions().autoCommitEdit) {
+      this.$input.click(() => this.args.grid.getEditorLock().commitCurrentEdit());
+    }
   }
 
   destroy(): void {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/dateEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/dateEditor.ts
@@ -100,7 +100,12 @@ export class DateEditor implements Editor {
   }
 
   save() {
-    this.args.commitChanges();
+    // autocommit will not focus the next editor
+    if (this.args.grid.getOptions().autoCommitEdit) {
+      this.args.grid.getEditorLock().commitCurrentEdit();
+    } else {
+      this.args.commitChanges();
+    }
   }
 
   loadValue(item: any) {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/longTextEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/longTextEditor.ts
@@ -41,6 +41,10 @@ export class LongTextEditor implements Editor {
     return this.columnEditor.validator || this.columnDef.validator;
   }
 
+  get hasAutoCommitEdit() {
+    return this.args.grid.getOptions().autoCommitEdit;
+  }
+
   init(): void {
     const cancelText = this.i18n.tr('CANCEL') || Constants.TEXT_CANCEL;
     const saveText = this.i18n.tr('SAVE') || Constants.TEXT_SAVE;
@@ -48,6 +52,12 @@ export class LongTextEditor implements Editor {
 
     this.$wrapper = $(`<div class="slick-large-editor-text" />`).appendTo($container);
     this.$input = $(`<textarea hidefocus rows="5">`).appendTo(this.$wrapper);
+
+    // aurelia-slickgrid does not get the focus out event for some reason
+    // so register it here
+    if (this.hasAutoCommitEdit) {
+      this.$input.on('focusout', () => this.save());
+    }
 
     $(`<div class="editor-footer">
         <button class="btn btn-primary btn-xs">${saveText}</button>
@@ -82,7 +92,9 @@ export class LongTextEditor implements Editor {
   }
 
   save() {
-    if (this.args && this.args.commitChanges) {
+    if (this.hasAutoCommitEdit) {
+      this.args.grid.getEditorLock().commitCurrentEdit();
+    } else {
       this.args.commitChanges();
     }
   }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/selectEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/selectEditor.ts
@@ -86,8 +86,7 @@ export class SelectEditor implements Editor {
       onClose: () => {
         if (!this._destroying && args.grid.getOptions().autoCommitEdit) {
           // do not use args.commitChanges() as this sets the focus to the next
-          // row and does not have a nice user experience. Also the select list will
-          // stay shown when clicking off the grid
+          // row. Also the select list will stay shown when clicking off the grid
           args.grid.getEditorLock().commitCurrentEdit();
         }
       }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/selectEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/selectEditor.ts
@@ -57,6 +57,10 @@ export class SelectEditor implements Editor {
   /** Event Subscriptions */
   subscriptions: Subscription[] = [];
 
+  // flag to signal that the editor is destroying itself, helps prevent
+  // commit changes from being called twice and erroring
+  _destroying = false;
+
   constructor(protected bindingEngine: BindingEngine, protected collectionService: CollectionService, protected i18n: I18N, protected args: any, protected isMultipleSelect = true) {
     this.gridOptions = this.args.grid.getOptions() as GridOption;
 
@@ -78,7 +82,15 @@ export class SelectEditor implements Editor {
         const isRenderHtmlEnabled = this.columnDef && this.columnDef.internalColumnEditor && this.columnDef.internalColumnEditor.enableRenderHtml || false;
         return isRenderHtmlEnabled ? $elm.text() : $elm.html();
       },
-      onBlur: () => this.destroy()
+      onBlur: () => this.destroy(),
+      onClose: () => {
+        if (!this._destroying && args.grid.getOptions().autoCommitEdit) {
+          // do not use args.commitChanges() as this sets the focus to the next
+          // row and does not have a nice user experience. Also the select list will
+          // stay shown when clicking off the grid
+          args.grid.getEditorLock().commitCurrentEdit();
+        }
+      }
     };
     if (isMultipleSelect) {
       libOptions.single = false;
@@ -193,6 +205,7 @@ export class SelectEditor implements Editor {
   }
 
   destroy() {
+    this._destroying = true;
     if (this.$editorElm && this.$editorElm.multipleSelect) {
       this.$editorElm.multipleSelect('close');
       this.$editorElm.remove();

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/sliderEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/sliderEditor.ts
@@ -85,7 +85,11 @@ export class SliderEditor implements Editor {
   }
 
   save() {
-    this.args.commitChanges();
+    if (this.args.grid.getOptions().autoCommitEdit) {
+      this.args.grid.getEditorLock().commitCurrentEdit();
+    } else {
+      this.args.commitChanges();
+    }
   }
 
   cancel() {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/models/gridOption.interface.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/models/gridOption.interface.ts
@@ -36,6 +36,9 @@ export interface GridOption {
   /** Defaults to false, when enabled will automatically open the inlined editor as soon as there is a focus on the cell (can be combined with "enableCellNavigation: true"). */
   autoEdit?: boolean;
 
+  /** Defaults to false, when enabled will try to commit the current edit without focusing on the next row. If a custom editor is implemented and the grid cannot auto commit, you must use this option to implement it yourself */
+  autoCommitEdit?: boolean;
+
   /** Defaults to true, which leads to automatically adjust the size of each column with the available space. Similar to "Force Fit Column" but only happens on first page/component load. */
   autoFitColumnsOnFirstLoad?: boolean;
 

--- a/aurelia-slickgrid/src/examples/slickgrid/example3.html
+++ b/aurelia-slickgrid/src/examples/slickgrid/example3.html
@@ -22,6 +22,10 @@
           <i class="fa fa-undo"></i>
           Undo last edit(s)
         </button>
+        <label class="checkbox-inline control-label" for="autoCommitEdit">
+          <input type="checkbox" id="autoCommitEdit" value.bind="gridOptions.autoCommitEdit" click.delegate="changeAutoCommit()">
+          Auto Commit Edit
+        </label>
       </div>
     </span>
     <div class="row" style="margin-top: 5px">

--- a/aurelia-slickgrid/src/examples/slickgrid/example3.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example3.ts
@@ -322,6 +322,7 @@ export class Example3 {
 
     this.gridOptions = {
       autoEdit: this.isAutoEdit,
+      autoCommitEdit: false,
       autoResize: {
         containerId: 'demo-container',
         sidePadding: 15
@@ -440,6 +441,14 @@ export class Example3 {
 
   onCellValidation(e, args) {
     alert(args.validationResults.msg);
+  }
+
+  changeAutoCommit() {
+    this.gridOptions.autoCommitEdit = !this.gridOptions.autoCommitEdit;
+    this.gridObj.setOptions({
+      autoCommitEdit: this.gridOptions.autoCommitEdit
+    });
+    return true;
   }
 
   setAutoEdit(isAutoEdit) {


### PR DESCRIPTION
The auto commit flag will attempt to commit the current editor when the
editor is focused out. However, not all editors behave the same so extra
logic had to be included in some editors. This means that the grid may not
be able to auto commit custom editors and it will be the
responsibility of the user building the editor.

**checkboxEditor**: Can be handled by the focusout event, but a click event
was added in the editor to make it behave more like a checkbox
**dateEditor**, **sliderEditor**: Prevent focus to the next editor
**longTextEditor**: Add focusout event to textarea, grid does not capture event
**selectEditor**: No focusout event so commit on close
**others**: handled by aurelia-slickgrid subscription to focusout

Also, i tried to build the code and it is broken right now from what looks like other changes.

closes #82