### PR TITLE
fix(example): prerequisite prop should only use integer values, closes #95

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/selectEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/selectEditor.ts
@@ -202,19 +202,19 @@ export class SelectEditor implements Editor {
 
   loadValue(item: any): void {
     if (this.isMultipleSelect) {
-      // convert to string because that is how the DOM will return these values
-      this.defaultValue = item[this.columnDef.field].map((i: any) => i.toString());
-      this.$editorElm.find('option').each((i: number, $e: any) => {
-        if (this.defaultValue.indexOf($e.value) !== -1) {
-          $e.selected = true;
-        } else {
-          $e.selected = false;
-        }
-      });
+      this.loadMultipleValues(item);
     } else {
       this.loadSingleValue(item);
     }
     this.refresh();
+  }
+
+  loadMultipleValues(items: any[]) {
+    // convert to string because that is how the DOM will return these values
+    this.defaultValue = items[this.columnDef.field].map((i: any) => i.toString());
+    this.$editorElm.find('option').each((i: number, $e: any) => {
+      $e.selected = (this.defaultValue.indexOf($e.value) !== -1);
+    });
   }
 
   loadSingleValue(item: any) {
@@ -222,11 +222,7 @@ export class SelectEditor implements Editor {
     // make sure the prop exists first
     this.defaultValue = item[this.columnDef.field] && item[this.columnDef.field].toString();
     this.$editorElm.find('option').each((i: number, $e: any) => {
-      if (this.defaultValue === $e.value) {
-        $e.selected = true;
-      } else {
-        $e.selected = false;
-      }
+      $e.selected = (this.defaultValue === $e.value);
     });
   }
 

--- a/aurelia-slickgrid/src/examples/slickgrid/example3.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example3.ts
@@ -33,6 +33,16 @@ const myCustomTitleValidator: EditorValidator = (value) => {
   }
 };
 
+// create a custom Formatter to show the Task + value
+const taskFormatter = (row, cell, value, columnDef, dataContext) => {
+  if (value && Array.isArray(value)) {
+    const taskValues = value.map((val) => `Task ${val}`);
+    const values = taskValues.join(', ');
+    return `<span title="${values}">${values}</span>`;
+  }
+  return '';
+};
+
 @autoinject()
 export class Example3 {
   title = 'Example 3: Editors / Delete';
@@ -238,6 +248,7 @@ export class Example3 {
       name: 'Prerequisites',
       field: 'prerequisites',
       filterable: true,
+      formatter: taskFormatter,
       minWidth: 100,
       sortable: true,
       type: FieldType.string,
@@ -271,8 +282,7 @@ export class Example3 {
           labelPrefix: 'prefix',
         },
         collectionOptions: {
-          separatorBetweenTextLabels: '',
-          includePrefixSuffixToSelectedValues: true
+          separatorBetweenTextLabels: ' '
         },
         model: Editors.multipleSelect,
       },
@@ -385,7 +395,7 @@ export class Example3 {
         start: new Date(randomYear, randomMonth, randomDay),
         finish: new Date(randomYear, (randomMonth + 1), randomDay),
         effortDriven: (i % 5 === 0),
-        prerequisites: (i % 2 === 0) && i !== 0 && i < 12 ? [`Task ${i}`, `Task ${i - 1}`] : []
+        prerequisites: (i % 2 === 0) && i !== 0 && i < 12 ? [i, i - 1] : []
       });
     }
     return tempDataset;

--- a/doc/github-demo/src/examples/slickgrid/example3.ts
+++ b/doc/github-demo/src/examples/slickgrid/example3.ts
@@ -3,16 +3,16 @@ import { HttpClient as FetchClient } from 'aurelia-fetch-client';
 import { HttpClient } from 'aurelia-http-client';
 import { I18N } from 'aurelia-i18n';
 import {
-  AureliaGridInstance,
-  Column,
-  EditorValidator,
-  Editors,
-  FieldType,
-  Filters,
-  Formatters,
-  GridOption,
-  OnEventArgs,
-  OperatorType
+    AureliaGridInstance,
+    Column,
+    EditorValidator,
+    Editors,
+    FieldType,
+    Filters,
+    Formatters,
+    GridOption,
+    OnEventArgs,
+    OperatorType
 } from 'aurelia-slickgrid';
 import { CustomInputEditor } from './custom-inputEditor';
 
@@ -24,19 +24,29 @@ const URL_SAMPLE_COLLECTION_DATA = 'assets/data/collection_100_numbers.json';
 
 // you can create custom validator to pass to an inline editor
 const myCustomTitleValidator: EditorValidator = (value) => {
-  if (value == null || value === undefined || !value.length) {
-    return { valid: false, msg: 'This is a required field' };
-  } else if (!/^Task\s\d+$/.test(value)) {
-    return { valid: false, msg: 'Your title is invalid, it must start with "Task" followed by a number' };
-  } else {
-    return { valid: true, msg: '' };
-  }
+    if (value == null || value === undefined || !value.length) {
+        return { valid: false, msg: 'This is a required field' };
+    } else if (!/^Task\s\d+$/.test(value)) {
+        return { valid: false, msg: 'Your title is invalid, it must start with "Task" followed by a number' };
+    } else {
+        return { valid: true, msg: '' };
+    }
+};
+
+// create a custom Formatter to show the Task + value
+const taskFormatter = (row, cell, value, columnDef, dataContext) => {
+    if (value && Array.isArray(value)) {
+        const taskValues = value.map((val) => `Task ${val}`);
+        const values = taskValues.join(', ');
+        return `<span title="${values}">${values}</span>`;
+    }
+    return '';
 };
 
 @autoinject()
 export class Example3 {
-  title = 'Example 3: Editors / Delete';
-  subTitle = `
+    title = 'Example 3: Editors / Delete';
+    subTitle = `
   Grid with Inline Editors and onCellClick actions (<a href="https://github.com/ghiscoding/aurelia-slickgrid/wiki/Editors" target="_blank">Wiki docs</a>).
   <ul>
     <li>When using "enableCellNavigation: true", clicking on a cell will automatically make it active &amp; selected.</li>
@@ -49,395 +59,395 @@ export class Example3 {
     <li>Support of "collectionAsync" is possible, click on "Clear Filters/Sorting" then add/delete item(s) and look at "Prerequisites" Select Filter</li>
   </ul>
   `;
-  private _commandQueue = [];
-  aureliaGrid: AureliaGridInstance;
-  gridObj: any;
-  gridOptions: GridOption;
-  columnDefinitions: Column[];
-  dataset: any[];
-  updatedObject: any;
-  isAutoEdit: boolean = true;
-  alertWarning: any;
-  selectedLanguage: string;
+    private _commandQueue = [];
+    aureliaGrid: AureliaGridInstance;
+    gridObj: any;
+    gridOptions: GridOption;
+    columnDefinitions: Column[];
+    dataset: any[];
+    updatedObject: any;
+    isAutoEdit: boolean = true;
+    alertWarning: any;
+    selectedLanguage: string;
 
-  constructor(private http: HttpClient, private httpFetch: FetchClient, private i18n: I18N) {
-    // define the grid options & columns and then create the grid itself
-    this.defineGrid();
-    this.selectedLanguage = this.i18n.getLocale();
-  }
+    constructor(private http: HttpClient, private httpFetch: FetchClient, private i18n: I18N) {
+        // define the grid options & columns and then create the grid itself
+        this.defineGrid();
+        this.selectedLanguage = this.i18n.getLocale();
+    }
 
-  attached() {
-    // populate the dataset once the grid is ready
-    this.dataset = this.mockData(NB_ITEMS);
-  }
+    attached() {
+        // populate the dataset once the grid is ready
+        this.dataset = this.mockData(NB_ITEMS);
+    }
 
-  aureliaGridReady(aureliaGrid: AureliaGridInstance) {
-    this.aureliaGrid = aureliaGrid;
-    this.gridObj = aureliaGrid && aureliaGrid.slickGrid;
-  }
+    aureliaGridReady(aureliaGrid: AureliaGridInstance) {
+        this.aureliaGrid = aureliaGrid;
+        this.gridObj = aureliaGrid && aureliaGrid.slickGrid;
+    }
 
-  /* Define grid Options and Columns */
-  defineGrid() {
-    this.columnDefinitions = [{
-      id: 'edit',
-      field: 'id',
-      excludeFromHeaderMenu: true,
-      formatter: Formatters.editIcon,
-      minWidth: 30,
-      maxWidth: 30,
-      // use onCellClick OR grid.onClick.subscribe which you can see down below
-      onCellClick: (e: Event, args: OnEventArgs) => {
-        console.log(args);
-        this.alertWarning = `Editing: ${args.dataContext.title}`;
-        this.aureliaGrid.gridService.highlightRow(args.row, 1500);
-        this.aureliaGrid.gridService.setSelectedRow(args.row);
-      }
-    }, {
-      id: 'delete',
-      field: 'id',
-      excludeFromHeaderMenu: true,
-      formatter: Formatters.deleteIcon,
-      minWidth: 30,
-      maxWidth: 30,
-      // use onCellClick OR grid.onClick.subscribe which you can see down below
-      /*
-      onCellClick: (e: Event, args: OnEventArgs) => {
-        console.log(args);
-        this.alertWarning = `Deleting: ${args.dataContext.title}`;
-      }
-      */
-    }, {
-      id: 'title',
-      name: 'Title',
-      field: 'title',
-      filterable: true,
-      sortable: true,
-      type: FieldType.string,
-      editor: {
-        model: Editors.longText,
-        validator: myCustomTitleValidator, // use a custom validator
-      },
-      minWidth: 100,
-      onCellChange: (e: Event, args: OnEventArgs) => {
-        console.log(args);
-        this.alertWarning = `Updated Title: ${args.dataContext.title}`;
-      }
-    }, {
-      id: 'title2',
-      name: 'Title, Custom Editor',
-      field: 'title',
-      filterable: true,
-      sortable: true,
-      type: FieldType.string,
-      editor: {
-        model: CustomInputEditor,
-        validator: myCustomTitleValidator, // use a custom validator
-      },
-      minWidth: 70
-    }, {
-      id: 'duration',
-      name: 'Duration (days)',
-      field: 'duration',
-      filterable: true,
-      sortable: true,
-      type: FieldType.number,
-      filter: { model: Filters.slider, params: { hideSliderNumber: false } },
-      editor: {
-        model: Editors.slider,
-        minValue: 0,
-        maxValue: 100,
-        // params: { hideSliderNumber: true },
-      },
-      /*
-      editor: {
-        // default is 0 decimals, if no decimals is passed it will accept 0 or more decimals
-        // however if you pass the "decimalPlaces", it will validate with that maximum
-        model: Editors.float,
-        minValue: 0,
-        maxValue: 365,
-        // the default validation error message is in English but you can override it by using "errorMessage"
-        // errorMessage: this.i18n.tr('INVALID_FLOAT', { maxDecimal: 2 }),
-        params: { decimalPlaces: 2 },
-      },
-      */
-      minWidth: 100
-    }, {
-      id: 'complete',
-      name: '% Complete',
-      field: 'percentComplete',
-      filterable: true,
-      formatter: Formatters.multiple,
-      type: FieldType.number,
-      editor: {
-        // We can also add HTML text to be rendered (any bad script will be sanitized) but we have to opt-in, else it will be sanitized
-        enableRenderHtml: true,
-        collection: Array.from(Array(101).keys()).map(k => ({ value: k, label: k, symbol: '<i class="fa fa-percent" style="color:cadetblue"></i>' })),
-        customStructure: {
-          value: 'value',
-          label: 'label',
-          labelSuffix: 'symbol'
-        },
-        collectionSortBy: {
-          property: 'label',
-          sortDesc: true
-        },
-        collectionFilterBy: {
-          property: 'value',
-          value: 0,
-          operator: OperatorType.notEqual
-        },
-        model: Editors.singleSelect,
-      },
-      minWidth: 100,
-      params: {
-        formatters: [Formatters.collectionEditor, Formatters.percentCompleteBar],
-      }
-    }, {
-      id: 'start',
-      name: 'Start',
-      field: 'start',
-      filterable: true,
-      filter: { model: Filters.compoundDate },
-      formatter: Formatters.dateIso,
-      sortable: true,
-      minWidth: 100,
-      type: FieldType.date,
-      editor: {
-        model: Editors.date
-      },
-    }, {
-      id: 'finish',
-      name: 'Finish',
-      field: 'finish',
-      filterable: true,
-      filter: { model: Filters.compoundDate },
-      formatter: Formatters.dateIso,
-      sortable: true,
-      minWidth: 100,
-      type: FieldType.date,
-      editor: {
-        model: Editors.date
-      },
-    }, {
-      id: 'effort-driven',
-      name: 'Effort Driven',
-      field: 'effortDriven',
-      filterable: true,
-      type: FieldType.boolean,
-      filter: {
-        model: Filters.singleSelect,
-        collection: [{ value: '', label: '' }, { value: true, label: 'True' }, { value: false, label: 'False' }]
-      },
-      formatter: Formatters.checkmark,
-      editor: {
-        model: Editors.checkbox,
-      },
-      minWidth: 70
-    }, {
-      id: 'prerequisites',
-      name: 'Prerequisites',
-      field: 'prerequisites',
-      filterable: true,
-      minWidth: 100,
-      sortable: true,
-      type: FieldType.string,
-      editor: {
-        // We can load the "collection" asynchronously (on first load only, after that we will simply use "collection")
-        // 3 ways are supported (aurelia-http-client, aurelia-fetch-client OR even Promise)
+    /* Define grid Options and Columns */
+    defineGrid() {
+        this.columnDefinitions = [{
+            id: 'edit',
+            field: 'id',
+            excludeFromHeaderMenu: true,
+            formatter: Formatters.editIcon,
+            minWidth: 30,
+            maxWidth: 30,
+            // use onCellClick OR grid.onClick.subscribe which you can see down below
+            onCellClick: (e: Event, args: OnEventArgs) => {
+                console.log(args);
+                this.alertWarning = `Editing: ${args.dataContext.title}`;
+                this.aureliaGrid.gridService.highlightRow(args.row, 1500);
+                this.aureliaGrid.gridService.setSelectedRow(args.row);
+            }
+        }, {
+            id: 'delete',
+            field: 'id',
+            excludeFromHeaderMenu: true,
+            formatter: Formatters.deleteIcon,
+            minWidth: 30,
+            maxWidth: 30,
+            // use onCellClick OR grid.onClick.subscribe which you can see down below
+            /*
+            onCellClick: (e: Event, args: OnEventArgs) => {
+              console.log(args);
+              this.alertWarning = `Deleting: ${args.dataContext.title}`;
+            }
+            */
+        }, {
+            id: 'title',
+            name: 'Title',
+            field: 'title',
+            filterable: true,
+            sortable: true,
+            type: FieldType.string,
+            editor: {
+                model: Editors.longText,
+                validator: myCustomTitleValidator, // use a custom validator
+            },
+            minWidth: 100,
+            onCellChange: (e: Event, args: OnEventArgs) => {
+                console.log(args);
+                this.alertWarning = `Updated Title: ${args.dataContext.title}`;
+            }
+        }, {
+            id: 'title2',
+            name: 'Title, Custom Editor',
+            field: 'title',
+            filterable: true,
+            sortable: true,
+            type: FieldType.string,
+            editor: {
+                model: CustomInputEditor,
+                validator: myCustomTitleValidator, // use a custom validator
+            },
+            minWidth: 70
+        }, {
+            id: 'duration',
+            name: 'Duration (days)',
+            field: 'duration',
+            filterable: true,
+            sortable: true,
+            type: FieldType.number,
+            filter: { model: Filters.slider, params: { hideSliderNumber: false } },
+            editor: {
+                model: Editors.slider,
+                minValue: 0,
+                maxValue: 100,
+                // params: { hideSliderNumber: true },
+            },
+            /*
+            editor: {
+              // default is 0 decimals, if no decimals is passed it will accept 0 or more decimals
+              // however if you pass the "decimalPlaces", it will validate with that maximum
+              model: Editors.float,
+              minValue: 0,
+              maxValue: 365,
+              // the default validation error message is in English but you can override it by using "errorMessage"
+              // errorMessage: this.i18n.tr('INVALID_FLOAT', { maxDecimal: 2 }),
+              params: { decimalPlaces: 2 },
+            },
+            */
+            minWidth: 100
+        }, {
+            id: 'complete',
+            name: '% Complete',
+            field: 'percentComplete',
+            filterable: true,
+            formatter: Formatters.multiple,
+            type: FieldType.number,
+            editor: {
+                // We can also add HTML text to be rendered (any bad script will be sanitized) but we have to opt-in, else it will be sanitized
+                enableRenderHtml: true,
+                collection: Array.from(Array(101).keys()).map(k => ({ value: k, label: k, symbol: '<i class="fa fa-percent" style="color:cadetblue"></i>' })),
+                customStructure: {
+                    value: 'value',
+                    label: 'label',
+                    labelSuffix: 'symbol'
+                },
+                collectionSortBy: {
+                    property: 'label',
+                    sortDesc: true
+                },
+                collectionFilterBy: {
+                    property: 'value',
+                    value: 0,
+                    operator: OperatorType.notEqual
+                },
+                model: Editors.singleSelect,
+            },
+            minWidth: 100,
+            params: {
+                formatters: [Formatters.collectionEditor, Formatters.percentCompleteBar],
+            }
+        }, {
+            id: 'start',
+            name: 'Start',
+            field: 'start',
+            filterable: true,
+            filter: { model: Filters.compoundDate },
+            formatter: Formatters.dateIso,
+            sortable: true,
+            minWidth: 100,
+            type: FieldType.date,
+            editor: {
+                model: Editors.date
+            },
+        }, {
+            id: 'finish',
+            name: 'Finish',
+            field: 'finish',
+            filterable: true,
+            filter: { model: Filters.compoundDate },
+            formatter: Formatters.dateIso,
+            sortable: true,
+            minWidth: 100,
+            type: FieldType.date,
+            editor: {
+                model: Editors.date
+            },
+        }, {
+            id: 'effort-driven',
+            name: 'Effort Driven',
+            field: 'effortDriven',
+            filterable: true,
+            type: FieldType.boolean,
+            filter: {
+                model: Filters.singleSelect,
+                collection: [{ value: '', label: '' }, { value: true, label: 'True' }, { value: false, label: 'False' }]
+            },
+            formatter: Formatters.checkmark,
+            editor: {
+                model: Editors.checkbox,
+            },
+            minWidth: 70
+        }, {
+            id: 'prerequisites',
+            name: 'Prerequisites',
+            field: 'prerequisites',
+            filterable: true,
+            formatter: taskFormatter,
+            minWidth: 100,
+            sortable: true,
+            type: FieldType.string,
+            editor: {
+                // We can load the "collection" asynchronously (on first load only, after that we will simply use "collection")
+                // 3 ways are supported (aurelia-http-client, aurelia-fetch-client OR even Promise)
 
-        // 1- USE HttpClient from "aurelia-http-client" to load collection asynchronously
-        // collectionAsync: this.http.createRequest(URL_SAMPLE_COLLECTION_DATA).asGet().send(),
+                // 1- USE HttpClient from "aurelia-http-client" to load collection asynchronously
+                // collectionAsync: this.http.createRequest(URL_SAMPLE_COLLECTION_DATA).asGet().send(),
 
-        // OR 2- use "aurelia-fetch-client", they are both supported
-        collectionAsync: this.httpFetch.fetch(URL_SAMPLE_COLLECTION_DATA),
+                // OR 2- use "aurelia-fetch-client", they are both supported
+                collectionAsync: this.httpFetch.fetch(URL_SAMPLE_COLLECTION_DATA),
 
-        // OR 3- use a Promise
-        // collectionAsync: new Promise<any>((resolve) => {
-        //   setTimeout(() => {
-        //     resolve(Array.from(Array(NB_ITEMS).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })));
-        //   }, 500);
-        // }),
+                // OR 3- use a Promise
+                // collectionAsync: new Promise<any>((resolve) => {
+                //   setTimeout(() => {
+                //     resolve(Array.from(Array(NB_ITEMS).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })));
+                //   }, 500);
+                // }),
 
-        // OR a regular "collection" load
-        // collection: Array.from(Array(NB_ITEMS).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })),
-        collectionSortBy: {
-          property: 'value',
-          sortDesc: true,
-          fieldType: FieldType.number
-        },
-        customStructure: {
-          label: 'label',
-          value: 'value',
-          labelPrefix: 'prefix',
-        },
-        collectionOptions: {
-          separatorBetweenTextLabels: '',
-          includePrefixSuffixToSelectedValues: true
-        },
-        model: Editors.multipleSelect,
-      },
-      filter: {
-        collectionAsync: this.httpFetch.fetch(URL_SAMPLE_COLLECTION_DATA),
-        // OR a regular collection load
-        // collection: Array.from(Array(NB_ITEMS).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })),
-        collectionSortBy: {
-          property: 'value',
-          sortDesc: true,
-          fieldType: FieldType.number
-        },
-        customStructure: {
-          label: 'label',
-          value: 'value',
-          labelPrefix: 'prefix',
-        },
-        collectionOptions: {
-          separatorBetweenTextLabels: ''
-        },
-        model: Filters.multipleSelect,
-        operator: OperatorType.inContains,
-      }
-    }];
+                // OR a regular "collection" load
+                // collection: Array.from(Array(NB_ITEMS).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })),
+                collectionSortBy: {
+                    property: 'value',
+                    sortDesc: true,
+                    fieldType: FieldType.number
+                },
+                customStructure: {
+                    label: 'label',
+                    value: 'value',
+                    labelPrefix: 'prefix',
+                },
+                collectionOptions: {
+                    separatorBetweenTextLabels: ' '
+                },
+                model: Editors.multipleSelect,
+            },
+            filter: {
+                collectionAsync: this.httpFetch.fetch(URL_SAMPLE_COLLECTION_DATA),
+                // OR a regular collection load
+                // collection: Array.from(Array(NB_ITEMS).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })),
+                collectionSortBy: {
+                    property: 'value',
+                    sortDesc: true,
+                    fieldType: FieldType.number
+                },
+                customStructure: {
+                    label: 'label',
+                    value: 'value',
+                    labelPrefix: 'prefix',
+                },
+                collectionOptions: {
+                    separatorBetweenTextLabels: ''
+                },
+                model: Filters.multipleSelect,
+                operator: OperatorType.inContains,
+            }
+        }];
 
-    this.gridOptions = {
-      autoEdit: this.isAutoEdit,
-      autoResize: {
-        containerId: 'demo-container',
-        sidePadding: 15
-      },
-      editable: true,
-      enableCellNavigation: true,
-      enableExcelCopyBuffer: true,
-      enableFiltering: true,
-      editCommandHandler: (item, column, editCommand) => {
-        this._commandQueue.push(editCommand);
-        editCommand.execute();
-      },
-      i18n: this.i18n,
-    };
-  }
+        this.gridOptions = {
+            autoEdit: this.isAutoEdit,
+            autoResize: {
+                containerId: 'demo-container',
+                sidePadding: 15
+            },
+            editable: true,
+            enableCellNavigation: true,
+            enableExcelCopyBuffer: true,
+            enableFiltering: true,
+            editCommandHandler: (item, column, editCommand) => {
+                this._commandQueue.push(editCommand);
+                editCommand.execute();
+            },
+            i18n: this.i18n,
+        };
+    }
 
-  /** Add a new row to the grid and refresh the Filter collection */
-  addItem() {
-    const lastRowIndex = this.dataset.length;
-    const newRows = this.mockData(1, lastRowIndex);
+    /** Add a new row to the grid and refresh the Filter collection */
+    addItem() {
+        const lastRowIndex = this.dataset.length;
+        const newRows = this.mockData(1, lastRowIndex);
 
-    // wrap into a timer to simulate a backend async call
-    setTimeout(() => {
-      // at any time, we can poke the "collection" property and modify it
-      const requisiteColumnDef = this.columnDefinitions.find((column: Column) => column.id === 'prerequisites');
-      if (requisiteColumnDef) {
-        const collectionEditor = requisiteColumnDef.editor.collection;
-        const collectionFilter = requisiteColumnDef.filter.collection;
+        // wrap into a timer to simulate a backend async call
+        setTimeout(() => {
+            // at any time, we can poke the "collection" property and modify it
+            const requisiteColumnDef = this.columnDefinitions.find((column: Column) => column.id === 'prerequisites');
+            if (requisiteColumnDef) {
+                const collectionEditor = requisiteColumnDef.editor.collection;
+                const collectionFilter = requisiteColumnDef.filter.collection;
 
-        if (Array.isArray(collectionEditor) && Array.isArray(collectionFilter)) {
-          // add the new row to the grid
-          this.aureliaGrid.gridService.addItemToDatagrid(newRows[0]);
+                if (Array.isArray(collectionEditor) && Array.isArray(collectionFilter)) {
+                    // add the new row to the grid
+                    this.aureliaGrid.gridService.addItemToDatagrid(newRows[0]);
 
-          // then refresh the Editor/Filter "collection", we have 2 ways of doing it
+                    // then refresh the Editor/Filter "collection", we have 2 ways of doing it
 
-          // 1- push to the "collection"
-          collectionEditor.push({ value: lastRowIndex, label: lastRowIndex, prefix: 'Task', suffix: 'days' });
-          collectionFilter.push({ value: lastRowIndex, label: lastRowIndex, prefix: 'Task', suffix: 'days' });
+                    // 1- push to the "collection"
+                    collectionEditor.push({ value: lastRowIndex, label: lastRowIndex, prefix: 'Task', suffix: 'days' });
+                    collectionFilter.push({ value: lastRowIndex, label: lastRowIndex, prefix: 'Task', suffix: 'days' });
 
-          // OR 2- replace the entire "collection" is also supported
-          // requisiteColumnDef.filter.collection = [...collection, ...[{ value: lastRowIndex, label: lastRowIndex }]];
-          // requisiteColumnDef.editor.collection = [...collection, ...[{ value: lastRowIndex, label: lastRowIndex }]];
+                    // OR 2- replace the entire "collection" is also supported
+                    // requisiteColumnDef.filter.collection = [...collection, ...[{ value: lastRowIndex, label: lastRowIndex }]];
+                    // requisiteColumnDef.editor.collection = [...collection, ...[{ value: lastRowIndex, label: lastRowIndex }]];
+                }
+            }
+        }, 250);
+    }
+
+    /** Delete last inserted row */
+    deleteItem() {
+        const requisiteColumnDef = this.columnDefinitions.find((column: Column) => column.id === 'prerequisites');
+        if (requisiteColumnDef) {
+            const collectionEditor = requisiteColumnDef.editor.collection;
+            const collectionFilter = requisiteColumnDef.filter.collection;
+
+            if (Array.isArray(collectionEditor) && Array.isArray(collectionFilter)) {
+                // sort collection in descending order and take out last option from the collection
+                const selectCollectionObj = this.sortCollectionDescending(collectionEditor).pop();
+                this.sortCollectionDescending(collectionFilter).pop();
+                this.aureliaGrid.gridService.deleteDataGridItemById(selectCollectionObj.value);
+            }
         }
-      }
-    }, 250);
-  }
-
-  /** Delete last inserted row */
-  deleteItem() {
-    const requisiteColumnDef = this.columnDefinitions.find((column: Column) => column.id === 'prerequisites');
-    if (requisiteColumnDef) {
-      const collectionEditor = requisiteColumnDef.editor.collection;
-      const collectionFilter = requisiteColumnDef.filter.collection;
-
-      if (Array.isArray(collectionEditor) && Array.isArray(collectionFilter)) {
-        // sort collection in descending order and take out last option from the collection
-        const selectCollectionObj = this.sortCollectionDescending(collectionEditor).pop();
-        this.sortCollectionDescending(collectionFilter).pop();
-        this.aureliaGrid.gridService.deleteDataGridItemById(selectCollectionObj.value);
-      }
     }
-  }
 
-  sortCollectionDescending(collection) {
-    return collection.sort((item1, item2) => item1.value - item2.value);
-  }
-
-  mockData(itemCount, startingIndex = 0) {
-    // mock a dataset
-    const tempDataset = [];
-    for (let i = startingIndex; i < (startingIndex + itemCount); i++) {
-      const randomYear = 2000 + Math.floor(Math.random() * 10);
-      const randomMonth = Math.floor(Math.random() * 11);
-      const randomDay = Math.floor((Math.random() * 29));
-      const randomPercent = Math.round(Math.random() * 100);
-
-      tempDataset.push({
-        id: i,
-        title: 'Task ' + i,
-        duration: Math.round(Math.random() * 100) + '',
-        percentComplete: randomPercent,
-        percentCompleteNumber: randomPercent,
-        start: new Date(randomYear, randomMonth, randomDay),
-        finish: new Date(randomYear, (randomMonth + 1), randomDay),
-        effortDriven: (i % 5 === 0),
-        prerequisites: (i % 2 === 0) && i !== 0 && i < 12 ? [`Task ${i}`, `Task ${i - 1}`] : []
-      });
+    sortCollectionDescending(collection) {
+        return collection.sort((item1, item2) => item1.value - item2.value);
     }
-    return tempDataset;
-  }
 
-  onCellChanged(e, args) {
-    console.log('onCellChange', args);
-    this.updatedObject = { ...args.item };
-  }
+    mockData(itemCount, startingIndex = 0) {
+        // mock a dataset
+        const tempDataset = [];
+        for (let i = startingIndex; i < (startingIndex + itemCount); i++) {
+            const randomYear = 2000 + Math.floor(Math.random() * 10);
+            const randomMonth = Math.floor(Math.random() * 11);
+            const randomDay = Math.floor((Math.random() * 29));
+            const randomPercent = Math.round(Math.random() * 100);
 
-  onCellClicked(e, args) {
-    const metadata = this.aureliaGrid.gridService.getColumnFromEventArguments(args);
-    console.log(metadata);
-
-    if (metadata.columnDef.id === 'edit') {
-      this.alertWarning = `open a modal window to edit: ${metadata.dataContext.title}`;
-
-      // highlight the row, to customize the color, you can change the SASS variable $row-highlight-background-color
-      this.aureliaGrid.gridService.highlightRow(args.row, 1500);
-
-      // you could also select the row, when using "enableCellNavigation: true", it automatically selects the row
-      // this.aureliaGrid.gridService.setSelectedRow(args.row);
-    } else if (metadata.columnDef.id === 'delete') {
-      if (confirm('Are you sure?')) {
-        this.aureliaGrid.gridService.deleteDataGridItemById(metadata.dataContext.id);
-        this.alertWarning = `Deleted: ${metadata.dataContext.title}`;
-      }
+            tempDataset.push({
+                id: i,
+                title: 'Task ' + i,
+                duration: Math.round(Math.random() * 100) + '',
+                percentComplete: randomPercent,
+                percentCompleteNumber: randomPercent,
+                start: new Date(randomYear, randomMonth, randomDay),
+                finish: new Date(randomYear, (randomMonth + 1), randomDay),
+                effortDriven: (i % 5 === 0),
+                prerequisites: (i % 2 === 0) && i !== 0 && i < 12 ? [i, i - 1] : []
+            });
+        }
+        return tempDataset;
     }
-  }
 
-  onCellValidation(e, args) {
-    alert(args.validationResults.msg);
-  }
-
-  setAutoEdit(isAutoEdit) {
-    this.isAutoEdit = isAutoEdit;
-    this.gridObj.setOptions({
-      autoEdit: isAutoEdit
-    });
-    return true;
-  }
-
-  switchLanguage() {
-    this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
-    this.i18n.setLocale(this.selectedLanguage);
-  }
-
-  undo() {
-    const command = this._commandQueue.pop();
-    if (command && Slick.GlobalEditorLock.cancelCurrentEdit()) {
-      command.undo();
-      this.gridObj.gotoCell(command.row, command.cell, false);
+    onCellChanged(e, args) {
+        console.log('onCellChange', args);
+        this.updatedObject = { ...args.item };
     }
-  }
+
+    onCellClicked(e, args) {
+        const metadata = this.aureliaGrid.gridService.getColumnFromEventArguments(args);
+        console.log(metadata);
+
+        if (metadata.columnDef.id === 'edit') {
+            this.alertWarning = `open a modal window to edit: ${metadata.dataContext.title}`;
+
+            // highlight the row, to customize the color, you can change the SASS variable $row-highlight-background-color
+            this.aureliaGrid.gridService.highlightRow(args.row, 1500);
+
+            // you could also select the row, when using "enableCellNavigation: true", it automatically selects the row
+            // this.aureliaGrid.gridService.setSelectedRow(args.row);
+        } else if (metadata.columnDef.id === 'delete') {
+            if (confirm('Are you sure?')) {
+                this.aureliaGrid.gridService.deleteDataGridItemById(metadata.dataContext.id);
+                this.alertWarning = `Deleted: ${metadata.dataContext.title}`;
+            }
+        }
+    }
+
+    onCellValidation(e, args) {
+        alert(args.validationResults.msg);
+    }
+
+    setAutoEdit(isAutoEdit) {
+        this.isAutoEdit = isAutoEdit;
+        this.gridObj.setOptions({
+            autoEdit: isAutoEdit
+        });
+        return true;
+    }
+
+    switchLanguage() {
+        this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
+        this.i18n.setLocale(this.selectedLanguage);
+    }
+
+    undo() {
+        const command = this._commandQueue.pop();
+        if (command && Slick.GlobalEditorLock.cancelCurrentEdit()) {
+            command.undo();
+            this.gridObj.gotoCell(command.row, command.cell, false);
+        }
+    }
 }

--- a/doc/github-demo/src/examples/slickgrid/example3.ts
+++ b/doc/github-demo/src/examples/slickgrid/example3.ts
@@ -3,16 +3,16 @@ import { HttpClient as FetchClient } from 'aurelia-fetch-client';
 import { HttpClient } from 'aurelia-http-client';
 import { I18N } from 'aurelia-i18n';
 import {
-    AureliaGridInstance,
-    Column,
-    EditorValidator,
-    Editors,
-    FieldType,
-    Filters,
-    Formatters,
-    GridOption,
-    OnEventArgs,
-    OperatorType
+  AureliaGridInstance,
+  Column,
+  EditorValidator,
+  Editors,
+  FieldType,
+  Filters,
+  Formatters,
+  GridOption,
+  OnEventArgs,
+  OperatorType
 } from 'aurelia-slickgrid';
 import { CustomInputEditor } from './custom-inputEditor';
 
@@ -24,29 +24,29 @@ const URL_SAMPLE_COLLECTION_DATA = 'assets/data/collection_100_numbers.json';
 
 // you can create custom validator to pass to an inline editor
 const myCustomTitleValidator: EditorValidator = (value) => {
-    if (value == null || value === undefined || !value.length) {
-        return { valid: false, msg: 'This is a required field' };
-    } else if (!/^Task\s\d+$/.test(value)) {
-        return { valid: false, msg: 'Your title is invalid, it must start with "Task" followed by a number' };
-    } else {
-        return { valid: true, msg: '' };
-    }
+  if (value == null || value === undefined || !value.length) {
+    return { valid: false, msg: 'This is a required field' };
+  } else if (!/^Task\s\d+$/.test(value)) {
+    return { valid: false, msg: 'Your title is invalid, it must start with "Task" followed by a number' };
+  } else {
+    return { valid: true, msg: '' };
+  }
 };
 
 // create a custom Formatter to show the Task + value
 const taskFormatter = (row, cell, value, columnDef, dataContext) => {
-    if (value && Array.isArray(value)) {
-        const taskValues = value.map((val) => `Task ${val}`);
-        const values = taskValues.join(', ');
-        return `<span title="${values}">${values}</span>`;
-    }
-    return '';
+  if (value && Array.isArray(value)) {
+    const taskValues = value.map((val) => `Task ${val}`);
+    const values = taskValues.join(', ');
+    return `<span title="${values}">${values}</span>`;
+  }
+  return '';
 };
 
 @autoinject()
 export class Example3 {
-    title = 'Example 3: Editors / Delete';
-    subTitle = `
+  title = 'Example 3: Editors / Delete';
+  subTitle = `
   Grid with Inline Editors and onCellClick actions (<a href="https://github.com/ghiscoding/aurelia-slickgrid/wiki/Editors" target="_blank">Wiki docs</a>).
   <ul>
     <li>When using "enableCellNavigation: true", clicking on a cell will automatically make it active &amp; selected.</li>
@@ -59,395 +59,395 @@ export class Example3 {
     <li>Support of "collectionAsync" is possible, click on "Clear Filters/Sorting" then add/delete item(s) and look at "Prerequisites" Select Filter</li>
   </ul>
   `;
-    private _commandQueue = [];
-    aureliaGrid: AureliaGridInstance;
-    gridObj: any;
-    gridOptions: GridOption;
-    columnDefinitions: Column[];
-    dataset: any[];
-    updatedObject: any;
-    isAutoEdit: boolean = true;
-    alertWarning: any;
-    selectedLanguage: string;
+  private _commandQueue = [];
+  aureliaGrid: AureliaGridInstance;
+  gridObj: any;
+  gridOptions: GridOption;
+  columnDefinitions: Column[];
+  dataset: any[];
+  updatedObject: any;
+  isAutoEdit: boolean = true;
+  alertWarning: any;
+  selectedLanguage: string;
 
-    constructor(private http: HttpClient, private httpFetch: FetchClient, private i18n: I18N) {
-        // define the grid options & columns and then create the grid itself
-        this.defineGrid();
-        this.selectedLanguage = this.i18n.getLocale();
-    }
+  constructor(private http: HttpClient, private httpFetch: FetchClient, private i18n: I18N) {
+    // define the grid options & columns and then create the grid itself
+    this.defineGrid();
+    this.selectedLanguage = this.i18n.getLocale();
+  }
 
-    attached() {
-        // populate the dataset once the grid is ready
-        this.dataset = this.mockData(NB_ITEMS);
-    }
+  attached() {
+    // populate the dataset once the grid is ready
+    this.dataset = this.mockData(NB_ITEMS);
+  }
 
-    aureliaGridReady(aureliaGrid: AureliaGridInstance) {
-        this.aureliaGrid = aureliaGrid;
-        this.gridObj = aureliaGrid && aureliaGrid.slickGrid;
-    }
+  aureliaGridReady(aureliaGrid: AureliaGridInstance) {
+    this.aureliaGrid = aureliaGrid;
+    this.gridObj = aureliaGrid && aureliaGrid.slickGrid;
+  }
 
-    /* Define grid Options and Columns */
-    defineGrid() {
-        this.columnDefinitions = [{
-            id: 'edit',
-            field: 'id',
-            excludeFromHeaderMenu: true,
-            formatter: Formatters.editIcon,
-            minWidth: 30,
-            maxWidth: 30,
-            // use onCellClick OR grid.onClick.subscribe which you can see down below
-            onCellClick: (e: Event, args: OnEventArgs) => {
-                console.log(args);
-                this.alertWarning = `Editing: ${args.dataContext.title}`;
-                this.aureliaGrid.gridService.highlightRow(args.row, 1500);
-                this.aureliaGrid.gridService.setSelectedRow(args.row);
-            }
-        }, {
-            id: 'delete',
-            field: 'id',
-            excludeFromHeaderMenu: true,
-            formatter: Formatters.deleteIcon,
-            minWidth: 30,
-            maxWidth: 30,
-            // use onCellClick OR grid.onClick.subscribe which you can see down below
-            /*
-            onCellClick: (e: Event, args: OnEventArgs) => {
-              console.log(args);
-              this.alertWarning = `Deleting: ${args.dataContext.title}`;
-            }
-            */
-        }, {
-            id: 'title',
-            name: 'Title',
-            field: 'title',
-            filterable: true,
-            sortable: true,
-            type: FieldType.string,
-            editor: {
-                model: Editors.longText,
-                validator: myCustomTitleValidator, // use a custom validator
-            },
-            minWidth: 100,
-            onCellChange: (e: Event, args: OnEventArgs) => {
-                console.log(args);
-                this.alertWarning = `Updated Title: ${args.dataContext.title}`;
-            }
-        }, {
-            id: 'title2',
-            name: 'Title, Custom Editor',
-            field: 'title',
-            filterable: true,
-            sortable: true,
-            type: FieldType.string,
-            editor: {
-                model: CustomInputEditor,
-                validator: myCustomTitleValidator, // use a custom validator
-            },
-            minWidth: 70
-        }, {
-            id: 'duration',
-            name: 'Duration (days)',
-            field: 'duration',
-            filterable: true,
-            sortable: true,
-            type: FieldType.number,
-            filter: { model: Filters.slider, params: { hideSliderNumber: false } },
-            editor: {
-                model: Editors.slider,
-                minValue: 0,
-                maxValue: 100,
-                // params: { hideSliderNumber: true },
-            },
-            /*
-            editor: {
-              // default is 0 decimals, if no decimals is passed it will accept 0 or more decimals
-              // however if you pass the "decimalPlaces", it will validate with that maximum
-              model: Editors.float,
-              minValue: 0,
-              maxValue: 365,
-              // the default validation error message is in English but you can override it by using "errorMessage"
-              // errorMessage: this.i18n.tr('INVALID_FLOAT', { maxDecimal: 2 }),
-              params: { decimalPlaces: 2 },
-            },
-            */
-            minWidth: 100
-        }, {
-            id: 'complete',
-            name: '% Complete',
-            field: 'percentComplete',
-            filterable: true,
-            formatter: Formatters.multiple,
-            type: FieldType.number,
-            editor: {
-                // We can also add HTML text to be rendered (any bad script will be sanitized) but we have to opt-in, else it will be sanitized
-                enableRenderHtml: true,
-                collection: Array.from(Array(101).keys()).map(k => ({ value: k, label: k, symbol: '<i class="fa fa-percent" style="color:cadetblue"></i>' })),
-                customStructure: {
-                    value: 'value',
-                    label: 'label',
-                    labelSuffix: 'symbol'
-                },
-                collectionSortBy: {
-                    property: 'label',
-                    sortDesc: true
-                },
-                collectionFilterBy: {
-                    property: 'value',
-                    value: 0,
-                    operator: OperatorType.notEqual
-                },
-                model: Editors.singleSelect,
-            },
-            minWidth: 100,
-            params: {
-                formatters: [Formatters.collectionEditor, Formatters.percentCompleteBar],
-            }
-        }, {
-            id: 'start',
-            name: 'Start',
-            field: 'start',
-            filterable: true,
-            filter: { model: Filters.compoundDate },
-            formatter: Formatters.dateIso,
-            sortable: true,
-            minWidth: 100,
-            type: FieldType.date,
-            editor: {
-                model: Editors.date
-            },
-        }, {
-            id: 'finish',
-            name: 'Finish',
-            field: 'finish',
-            filterable: true,
-            filter: { model: Filters.compoundDate },
-            formatter: Formatters.dateIso,
-            sortable: true,
-            minWidth: 100,
-            type: FieldType.date,
-            editor: {
-                model: Editors.date
-            },
-        }, {
-            id: 'effort-driven',
-            name: 'Effort Driven',
-            field: 'effortDriven',
-            filterable: true,
-            type: FieldType.boolean,
-            filter: {
-                model: Filters.singleSelect,
-                collection: [{ value: '', label: '' }, { value: true, label: 'True' }, { value: false, label: 'False' }]
-            },
-            formatter: Formatters.checkmark,
-            editor: {
-                model: Editors.checkbox,
-            },
-            minWidth: 70
-        }, {
-            id: 'prerequisites',
-            name: 'Prerequisites',
-            field: 'prerequisites',
-            filterable: true,
-            formatter: taskFormatter,
-            minWidth: 100,
-            sortable: true,
-            type: FieldType.string,
-            editor: {
-                // We can load the "collection" asynchronously (on first load only, after that we will simply use "collection")
-                // 3 ways are supported (aurelia-http-client, aurelia-fetch-client OR even Promise)
+  /* Define grid Options and Columns */
+  defineGrid() {
+    this.columnDefinitions = [{
+      id: 'edit',
+      field: 'id',
+      excludeFromHeaderMenu: true,
+      formatter: Formatters.editIcon,
+      minWidth: 30,
+      maxWidth: 30,
+      // use onCellClick OR grid.onClick.subscribe which you can see down below
+      onCellClick: (e: Event, args: OnEventArgs) => {
+        console.log(args);
+        this.alertWarning = `Editing: ${args.dataContext.title}`;
+        this.aureliaGrid.gridService.highlightRow(args.row, 1500);
+        this.aureliaGrid.gridService.setSelectedRow(args.row);
+      }
+    }, {
+      id: 'delete',
+      field: 'id',
+      excludeFromHeaderMenu: true,
+      formatter: Formatters.deleteIcon,
+      minWidth: 30,
+      maxWidth: 30,
+      // use onCellClick OR grid.onClick.subscribe which you can see down below
+      /*
+      onCellClick: (e: Event, args: OnEventArgs) => {
+        console.log(args);
+        this.alertWarning = `Deleting: ${args.dataContext.title}`;
+      }
+      */
+    }, {
+      id: 'title',
+      name: 'Title',
+      field: 'title',
+      filterable: true,
+      sortable: true,
+      type: FieldType.string,
+      editor: {
+        model: Editors.longText,
+        validator: myCustomTitleValidator, // use a custom validator
+      },
+      minWidth: 100,
+      onCellChange: (e: Event, args: OnEventArgs) => {
+        console.log(args);
+        this.alertWarning = `Updated Title: ${args.dataContext.title}`;
+      }
+    }, {
+      id: 'title2',
+      name: 'Title, Custom Editor',
+      field: 'title',
+      filterable: true,
+      sortable: true,
+      type: FieldType.string,
+      editor: {
+        model: CustomInputEditor,
+        validator: myCustomTitleValidator, // use a custom validator
+      },
+      minWidth: 70
+    }, {
+      id: 'duration',
+      name: 'Duration (days)',
+      field: 'duration',
+      filterable: true,
+      sortable: true,
+      type: FieldType.number,
+      filter: { model: Filters.slider, params: { hideSliderNumber: false } },
+      editor: {
+        model: Editors.slider,
+        minValue: 0,
+        maxValue: 100,
+        // params: { hideSliderNumber: true },
+      },
+      /*
+      editor: {
+        // default is 0 decimals, if no decimals is passed it will accept 0 or more decimals
+        // however if you pass the "decimalPlaces", it will validate with that maximum
+        model: Editors.float,
+        minValue: 0,
+        maxValue: 365,
+        // the default validation error message is in English but you can override it by using "errorMessage"
+        // errorMessage: this.i18n.tr('INVALID_FLOAT', { maxDecimal: 2 }),
+        params: { decimalPlaces: 2 },
+      },
+      */
+      minWidth: 100
+    }, {
+      id: 'complete',
+      name: '% Complete',
+      field: 'percentComplete',
+      filterable: true,
+      formatter: Formatters.multiple,
+      type: FieldType.number,
+      editor: {
+        // We can also add HTML text to be rendered (any bad script will be sanitized) but we have to opt-in, else it will be sanitized
+        enableRenderHtml: true,
+        collection: Array.from(Array(101).keys()).map(k => ({ value: k, label: k, symbol: '<i class="fa fa-percent" style="color:cadetblue"></i>' })),
+        customStructure: {
+          value: 'value',
+          label: 'label',
+          labelSuffix: 'symbol'
+        },
+        collectionSortBy: {
+          property: 'label',
+          sortDesc: true
+        },
+        collectionFilterBy: {
+          property: 'value',
+          value: 0,
+          operator: OperatorType.notEqual
+        },
+        model: Editors.singleSelect,
+      },
+      minWidth: 100,
+      params: {
+        formatters: [Formatters.collectionEditor, Formatters.percentCompleteBar],
+      }
+    }, {
+      id: 'start',
+      name: 'Start',
+      field: 'start',
+      filterable: true,
+      filter: { model: Filters.compoundDate },
+      formatter: Formatters.dateIso,
+      sortable: true,
+      minWidth: 100,
+      type: FieldType.date,
+      editor: {
+        model: Editors.date
+      },
+    }, {
+      id: 'finish',
+      name: 'Finish',
+      field: 'finish',
+      filterable: true,
+      filter: { model: Filters.compoundDate },
+      formatter: Formatters.dateIso,
+      sortable: true,
+      minWidth: 100,
+      type: FieldType.date,
+      editor: {
+        model: Editors.date
+      },
+    }, {
+      id: 'effort-driven',
+      name: 'Effort Driven',
+      field: 'effortDriven',
+      filterable: true,
+      type: FieldType.boolean,
+      filter: {
+        model: Filters.singleSelect,
+        collection: [{ value: '', label: '' }, { value: true, label: 'True' }, { value: false, label: 'False' }]
+      },
+      formatter: Formatters.checkmark,
+      editor: {
+        model: Editors.checkbox,
+      },
+      minWidth: 70
+    }, {
+      id: 'prerequisites',
+      name: 'Prerequisites',
+      field: 'prerequisites',
+      filterable: true,
+      formatter: taskFormatter,
+      minWidth: 100,
+      sortable: true,
+      type: FieldType.string,
+      editor: {
+        // We can load the "collection" asynchronously (on first load only, after that we will simply use "collection")
+        // 3 ways are supported (aurelia-http-client, aurelia-fetch-client OR even Promise)
 
-                // 1- USE HttpClient from "aurelia-http-client" to load collection asynchronously
-                // collectionAsync: this.http.createRequest(URL_SAMPLE_COLLECTION_DATA).asGet().send(),
+        // 1- USE HttpClient from "aurelia-http-client" to load collection asynchronously
+        // collectionAsync: this.http.createRequest(URL_SAMPLE_COLLECTION_DATA).asGet().send(),
 
-                // OR 2- use "aurelia-fetch-client", they are both supported
-                collectionAsync: this.httpFetch.fetch(URL_SAMPLE_COLLECTION_DATA),
+        // OR 2- use "aurelia-fetch-client", they are both supported
+        collectionAsync: this.httpFetch.fetch(URL_SAMPLE_COLLECTION_DATA),
 
-                // OR 3- use a Promise
-                // collectionAsync: new Promise<any>((resolve) => {
-                //   setTimeout(() => {
-                //     resolve(Array.from(Array(NB_ITEMS).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })));
-                //   }, 500);
-                // }),
+        // OR 3- use a Promise
+        // collectionAsync: new Promise<any>((resolve) => {
+        //   setTimeout(() => {
+        //     resolve(Array.from(Array(NB_ITEMS).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })));
+        //   }, 500);
+        // }),
 
-                // OR a regular "collection" load
-                // collection: Array.from(Array(NB_ITEMS).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })),
-                collectionSortBy: {
-                    property: 'value',
-                    sortDesc: true,
-                    fieldType: FieldType.number
-                },
-                customStructure: {
-                    label: 'label',
-                    value: 'value',
-                    labelPrefix: 'prefix',
-                },
-                collectionOptions: {
-                    separatorBetweenTextLabels: ' '
-                },
-                model: Editors.multipleSelect,
-            },
-            filter: {
-                collectionAsync: this.httpFetch.fetch(URL_SAMPLE_COLLECTION_DATA),
-                // OR a regular collection load
-                // collection: Array.from(Array(NB_ITEMS).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })),
-                collectionSortBy: {
-                    property: 'value',
-                    sortDesc: true,
-                    fieldType: FieldType.number
-                },
-                customStructure: {
-                    label: 'label',
-                    value: 'value',
-                    labelPrefix: 'prefix',
-                },
-                collectionOptions: {
-                    separatorBetweenTextLabels: ''
-                },
-                model: Filters.multipleSelect,
-                operator: OperatorType.inContains,
-            }
-        }];
+        // OR a regular "collection" load
+        // collection: Array.from(Array(NB_ITEMS).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })),
+        collectionSortBy: {
+          property: 'value',
+          sortDesc: true,
+          fieldType: FieldType.number
+        },
+        customStructure: {
+          label: 'label',
+          value: 'value',
+          labelPrefix: 'prefix',
+        },
+        collectionOptions: {
+          separatorBetweenTextLabels: ' '
+        },
+        model: Editors.multipleSelect,
+      },
+      filter: {
+        collectionAsync: this.httpFetch.fetch(URL_SAMPLE_COLLECTION_DATA),
+        // OR a regular collection load
+        // collection: Array.from(Array(NB_ITEMS).keys()).map(k => ({ value: k, label: k, prefix: 'Task', suffix: 'days' })),
+        collectionSortBy: {
+          property: 'value',
+          sortDesc: true,
+          fieldType: FieldType.number
+        },
+        customStructure: {
+          label: 'label',
+          value: 'value',
+          labelPrefix: 'prefix',
+        },
+        collectionOptions: {
+          separatorBetweenTextLabels: ''
+        },
+        model: Filters.multipleSelect,
+        operator: OperatorType.inContains,
+      }
+    }];
 
-        this.gridOptions = {
-            autoEdit: this.isAutoEdit,
-            autoResize: {
-                containerId: 'demo-container',
-                sidePadding: 15
-            },
-            editable: true,
-            enableCellNavigation: true,
-            enableExcelCopyBuffer: true,
-            enableFiltering: true,
-            editCommandHandler: (item, column, editCommand) => {
-                this._commandQueue.push(editCommand);
-                editCommand.execute();
-            },
-            i18n: this.i18n,
-        };
-    }
+    this.gridOptions = {
+      autoEdit: this.isAutoEdit,
+      autoResize: {
+        containerId: 'demo-container',
+        sidePadding: 15
+      },
+      editable: true,
+      enableCellNavigation: true,
+      enableExcelCopyBuffer: true,
+      enableFiltering: true,
+      editCommandHandler: (item, column, editCommand) => {
+        this._commandQueue.push(editCommand);
+        editCommand.execute();
+      },
+      i18n: this.i18n,
+    };
+  }
 
-    /** Add a new row to the grid and refresh the Filter collection */
-    addItem() {
-        const lastRowIndex = this.dataset.length;
-        const newRows = this.mockData(1, lastRowIndex);
+  /** Add a new row to the grid and refresh the Filter collection */
+  addItem() {
+    const lastRowIndex = this.dataset.length;
+    const newRows = this.mockData(1, lastRowIndex);
 
-        // wrap into a timer to simulate a backend async call
-        setTimeout(() => {
-            // at any time, we can poke the "collection" property and modify it
-            const requisiteColumnDef = this.columnDefinitions.find((column: Column) => column.id === 'prerequisites');
-            if (requisiteColumnDef) {
-                const collectionEditor = requisiteColumnDef.editor.collection;
-                const collectionFilter = requisiteColumnDef.filter.collection;
+    // wrap into a timer to simulate a backend async call
+    setTimeout(() => {
+      // at any time, we can poke the "collection" property and modify it
+      const requisiteColumnDef = this.columnDefinitions.find((column: Column) => column.id === 'prerequisites');
+      if (requisiteColumnDef) {
+        const collectionEditor = requisiteColumnDef.editor.collection;
+        const collectionFilter = requisiteColumnDef.filter.collection;
 
-                if (Array.isArray(collectionEditor) && Array.isArray(collectionFilter)) {
-                    // add the new row to the grid
-                    this.aureliaGrid.gridService.addItemToDatagrid(newRows[0]);
+        if (Array.isArray(collectionEditor) && Array.isArray(collectionFilter)) {
+          // add the new row to the grid
+          this.aureliaGrid.gridService.addItemToDatagrid(newRows[0]);
 
-                    // then refresh the Editor/Filter "collection", we have 2 ways of doing it
+          // then refresh the Editor/Filter "collection", we have 2 ways of doing it
 
-                    // 1- push to the "collection"
-                    collectionEditor.push({ value: lastRowIndex, label: lastRowIndex, prefix: 'Task', suffix: 'days' });
-                    collectionFilter.push({ value: lastRowIndex, label: lastRowIndex, prefix: 'Task', suffix: 'days' });
+          // 1- push to the "collection"
+          collectionEditor.push({ value: lastRowIndex, label: lastRowIndex, prefix: 'Task', suffix: 'days' });
+          collectionFilter.push({ value: lastRowIndex, label: lastRowIndex, prefix: 'Task', suffix: 'days' });
 
-                    // OR 2- replace the entire "collection" is also supported
-                    // requisiteColumnDef.filter.collection = [...collection, ...[{ value: lastRowIndex, label: lastRowIndex }]];
-                    // requisiteColumnDef.editor.collection = [...collection, ...[{ value: lastRowIndex, label: lastRowIndex }]];
-                }
-            }
-        }, 250);
-    }
-
-    /** Delete last inserted row */
-    deleteItem() {
-        const requisiteColumnDef = this.columnDefinitions.find((column: Column) => column.id === 'prerequisites');
-        if (requisiteColumnDef) {
-            const collectionEditor = requisiteColumnDef.editor.collection;
-            const collectionFilter = requisiteColumnDef.filter.collection;
-
-            if (Array.isArray(collectionEditor) && Array.isArray(collectionFilter)) {
-                // sort collection in descending order and take out last option from the collection
-                const selectCollectionObj = this.sortCollectionDescending(collectionEditor).pop();
-                this.sortCollectionDescending(collectionFilter).pop();
-                this.aureliaGrid.gridService.deleteDataGridItemById(selectCollectionObj.value);
-            }
+          // OR 2- replace the entire "collection" is also supported
+          // requisiteColumnDef.filter.collection = [...collection, ...[{ value: lastRowIndex, label: lastRowIndex }]];
+          // requisiteColumnDef.editor.collection = [...collection, ...[{ value: lastRowIndex, label: lastRowIndex }]];
         }
+      }
+    }, 250);
+  }
+
+  /** Delete last inserted row */
+  deleteItem() {
+    const requisiteColumnDef = this.columnDefinitions.find((column: Column) => column.id === 'prerequisites');
+    if (requisiteColumnDef) {
+      const collectionEditor = requisiteColumnDef.editor.collection;
+      const collectionFilter = requisiteColumnDef.filter.collection;
+
+      if (Array.isArray(collectionEditor) && Array.isArray(collectionFilter)) {
+        // sort collection in descending order and take out last option from the collection
+        const selectCollectionObj = this.sortCollectionDescending(collectionEditor).pop();
+        this.sortCollectionDescending(collectionFilter).pop();
+        this.aureliaGrid.gridService.deleteDataGridItemById(selectCollectionObj.value);
+      }
     }
+  }
 
-    sortCollectionDescending(collection) {
-        return collection.sort((item1, item2) => item1.value - item2.value);
+  sortCollectionDescending(collection) {
+    return collection.sort((item1, item2) => item1.value - item2.value);
+  }
+
+  mockData(itemCount, startingIndex = 0) {
+    // mock a dataset
+    const tempDataset = [];
+    for (let i = startingIndex; i < (startingIndex + itemCount); i++) {
+      const randomYear = 2000 + Math.floor(Math.random() * 10);
+      const randomMonth = Math.floor(Math.random() * 11);
+      const randomDay = Math.floor((Math.random() * 29));
+      const randomPercent = Math.round(Math.random() * 100);
+
+      tempDataset.push({
+        id: i,
+        title: 'Task ' + i,
+        duration: Math.round(Math.random() * 100) + '',
+        percentComplete: randomPercent,
+        percentCompleteNumber: randomPercent,
+        start: new Date(randomYear, randomMonth, randomDay),
+        finish: new Date(randomYear, (randomMonth + 1), randomDay),
+        effortDriven: (i % 5 === 0),
+        prerequisites: (i % 2 === 0) && i !== 0 && i < 12 ? [i, i - 1] : []
+      });
     }
+    return tempDataset;
+  }
 
-    mockData(itemCount, startingIndex = 0) {
-        // mock a dataset
-        const tempDataset = [];
-        for (let i = startingIndex; i < (startingIndex + itemCount); i++) {
-            const randomYear = 2000 + Math.floor(Math.random() * 10);
-            const randomMonth = Math.floor(Math.random() * 11);
-            const randomDay = Math.floor((Math.random() * 29));
-            const randomPercent = Math.round(Math.random() * 100);
+  onCellChanged(e, args) {
+    console.log('onCellChange', args);
+    this.updatedObject = { ...args.item };
+  }
 
-            tempDataset.push({
-                id: i,
-                title: 'Task ' + i,
-                duration: Math.round(Math.random() * 100) + '',
-                percentComplete: randomPercent,
-                percentCompleteNumber: randomPercent,
-                start: new Date(randomYear, randomMonth, randomDay),
-                finish: new Date(randomYear, (randomMonth + 1), randomDay),
-                effortDriven: (i % 5 === 0),
-                prerequisites: (i % 2 === 0) && i !== 0 && i < 12 ? [i, i - 1] : []
-            });
-        }
-        return tempDataset;
+  onCellClicked(e, args) {
+    const metadata = this.aureliaGrid.gridService.getColumnFromEventArguments(args);
+    console.log(metadata);
+
+    if (metadata.columnDef.id === 'edit') {
+      this.alertWarning = `open a modal window to edit: ${metadata.dataContext.title}`;
+
+      // highlight the row, to customize the color, you can change the SASS variable $row-highlight-background-color
+      this.aureliaGrid.gridService.highlightRow(args.row, 1500);
+
+      // you could also select the row, when using "enableCellNavigation: true", it automatically selects the row
+      // this.aureliaGrid.gridService.setSelectedRow(args.row);
+    } else if (metadata.columnDef.id === 'delete') {
+      if (confirm('Are you sure?')) {
+        this.aureliaGrid.gridService.deleteDataGridItemById(metadata.dataContext.id);
+        this.alertWarning = `Deleted: ${metadata.dataContext.title}`;
+      }
     }
+  }
 
-    onCellChanged(e, args) {
-        console.log('onCellChange', args);
-        this.updatedObject = { ...args.item };
+  onCellValidation(e, args) {
+    alert(args.validationResults.msg);
+  }
+
+  setAutoEdit(isAutoEdit) {
+    this.isAutoEdit = isAutoEdit;
+    this.gridObj.setOptions({
+      autoEdit: isAutoEdit
+    });
+    return true;
+  }
+
+  switchLanguage() {
+    this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
+    this.i18n.setLocale(this.selectedLanguage);
+  }
+
+  undo() {
+    const command = this._commandQueue.pop();
+    if (command && Slick.GlobalEditorLock.cancelCurrentEdit()) {
+      command.undo();
+      this.gridObj.gotoCell(command.row, command.cell, false);
     }
-
-    onCellClicked(e, args) {
-        const metadata = this.aureliaGrid.gridService.getColumnFromEventArguments(args);
-        console.log(metadata);
-
-        if (metadata.columnDef.id === 'edit') {
-            this.alertWarning = `open a modal window to edit: ${metadata.dataContext.title}`;
-
-            // highlight the row, to customize the color, you can change the SASS variable $row-highlight-background-color
-            this.aureliaGrid.gridService.highlightRow(args.row, 1500);
-
-            // you could also select the row, when using "enableCellNavigation: true", it automatically selects the row
-            // this.aureliaGrid.gridService.setSelectedRow(args.row);
-        } else if (metadata.columnDef.id === 'delete') {
-            if (confirm('Are you sure?')) {
-                this.aureliaGrid.gridService.deleteDataGridItemById(metadata.dataContext.id);
-                this.alertWarning = `Deleted: ${metadata.dataContext.title}`;
-            }
-        }
-    }
-
-    onCellValidation(e, args) {
-        alert(args.validationResults.msg);
-    }
-
-    setAutoEdit(isAutoEdit) {
-        this.isAutoEdit = isAutoEdit;
-        this.gridObj.setOptions({
-            autoEdit: isAutoEdit
-        });
-        return true;
-    }
-
-    switchLanguage() {
-        this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
-        this.i18n.setLocale(this.selectedLanguage);
-    }
-
-    undo() {
-        const command = this._commandQueue.pop();
-        if (command && Slick.GlobalEditorLock.cancelCurrentEdit()) {
-            command.undo();
-            this.gridObj.gotoCell(command.row, command.cell, false);
-        }
-    }
+  }
 }


### PR DESCRIPTION
- the prerequisites property should only be filled with integer values and to get the missing "Task" text, inside the Editor we use a `customStructure` with Prefix, but we also need to use a Formatter to display it in the grid
- also the `selectEditor.ts` did not change, however some code cleaning was done in it

@jmzagorski 
So the issue #95 was all in the demo itself, nothing to do with the SelectEditor (I did some code cleanup but the functionality is exactly the same). So the reason was explained a bit inside the commit (on the top), but basically since I wanted to demo the use of `customStructure` inside an Editor with Prefix, I should make sure to use the prerequisites as an array of integers (without the word "Task"). But then, I'm missing the word text since they are only integers, I simply had to add a custom Formatter and we're done. You can also see after editing that the prerequisites is just an array of integers which is what we should expect. 

~Note, I did this code change late at night. It looks all good after this but that would be great if you could test everything out with your other PR.~ 
Did all the necessary tests today and implemented it in the Angular-Slickgrid repo, also updated it's [demo](https://ghiscoding.github.io/Angular-Slickgrid/#/editor), so you can visually see and test it there if you wish. 

See below for a quick test
![2018-09-18_00-34-03](https://user-images.githubusercontent.com/643976/45664698-36839f80-badb-11e8-8636-cf192d92f7b1.gif)
