### PR TITLE
fix(export): Export should work with datasetIdPropertyName defined

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/export.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/export.service.ts
@@ -32,6 +32,10 @@ export class ExportService {
 
   constructor(private i18n: I18N, private ea: EventAggregator) { }
 
+  private get datasetIdName(): string {
+    return this._gridOptions && this._gridOptions.datasetIdPropertyName || 'id';
+  }
+
   /** Getter for the Grid Options pulled through the Grid Object */
   private get _gridOptions(): GridOption {
     return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
@@ -131,7 +135,7 @@ export class ExportService {
 
       if (itemObj != null) {
         // Normal row (not grouped by anything) would have an ID which was predefined in the Grid Columns definition
-        if (itemObj.id != null) {
+        if (itemObj[this.datasetIdName] != null) {
           // get regular row item data
           outputDataStrings.push(this.readRegularRowData(columns, rowNumber, itemObj));
         } else if (this._hasGroupedItems && itemObj.__groupTotals === undefined) {


### PR DESCRIPTION
This was reported in the `Angular-Slickgrid` repo under this [issue](https://github.com/ghiscoding/Angular-Slickgrid/issues/67)