### PR TITLE
feat(sort): add posibility to sort complex objects

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/services/sort.service.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/services/sort.service.ts
@@ -8,11 +8,10 @@ import {
   SlickEvent,
   SortDirection,
   CurrentSorter,
-  CellArgs,
   SortDirectionNumber,
   SortDirectionString
 } from './../models/index';
-import { Sorters } from './../sorters/index';
+import { getDescendantProperty } from './utilities';
 import { sortByFieldType } from '../sorters/sorterUtilities';
 
 // using external non-typed js libraries
@@ -240,8 +239,15 @@ export class SortService {
           const sortDirection = columnSortObj.sortAsc ? SortDirectionNumber.asc : SortDirectionNumber.desc;
           const sortField = columnSortObj.sortCol.queryField || columnSortObj.sortCol.queryFieldFilter || columnSortObj.sortCol.field;
           const fieldType = columnSortObj.sortCol.type || FieldType.string;
-          const value1 = dataRow1[sortField];
-          const value2 = dataRow2[sortField];
+          let value1 = dataRow1[sortField];
+          let value2 = dataRow2[sortField];
+
+          // when item is a complex object (dot "." notation), we need to filter the value contained in the object tree
+          if (sortField && sortField.indexOf('.') >= 0) {
+            value1 = getDescendantProperty(dataRow1, sortField);
+            value2 = getDescendantProperty(dataRow2, sortField);
+          }
+
           const sortResult = sortByFieldType(value1, value2, fieldType, sortDirection);
           if (sortResult !== SortDirectionNumber.neutral) {
             return sortResult;


### PR DESCRIPTION
This PR is a continuation of PR #100 and is to Sort Complex Objects

For example, let say that we have this dataset
```typescript
const dataset = [
 { item: 'HP Desktop', buyer: { id: 1234, address: { street: '123 belleville', zip: 123456 }},
 { item: 'Lenovo Mouse', buyer: { id: 456, address: { street: '456 hollywood blvd', zip: 789123 }}
];
```

We can now filter the zip code from the buyer's address using this filter:
```typescript
this.columnDefinitions = [
  {
    // the zip is a property of a complex object which is under the "buyer" property
    // it will use the "field" property to explode (from "." notation) and find the child value
    id: 'zip', name: 'ZIP', field: 'buyer.address.zip', sortable: true
   // id: 'street',  ...
];
```