### PR TITLE
fix(http): remove aurelia-http-client dependency, closes #101

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -21,7 +21,6 @@ import 'slickgrid/plugins/slick.rowmovemanager';
 import 'slickgrid/plugins/slick.rowselectionmodel';
 
 import { bindable, BindingEngine, bindingMode, Container, Factory, inject } from 'aurelia-framework';
-import { HttpResponseMessage } from 'aurelia-http-client';
 import { EventAggregator, Subscription } from 'aurelia-event-aggregator';
 import { GlobalGridOptions } from './global-grid-options';
 import {
@@ -659,19 +658,19 @@ export class AureliaSlickgridCustomElement {
       // wait for the "collectionAsync", once resolved we will save it into the "collection"
       // the collectionAsync can be of 3 types HttpClient, HttpFetch or a Promise
       //
-      collectionAsync.then((response: HttpResponseMessage | Response | any[]) => {
-        if (response instanceof Response && typeof response.json === 'function') {
+      collectionAsync.then((response: any | any[]) => {
+        if (Array.isArray(response)) {
+          this.updateEditorCollection(column, response); // from Promise
+        } else if (response instanceof Response && typeof response.json === 'function') {
           if (response.bodyUsed) {
             throw new Error('[Aurelia-SlickGrid] The response body passed to collectionAsync was ' +
               'already read. Either pass the dataset from the Response ' +
               'or clone the response first using response.clone()');
           }
-
+          // from aurelia-fetch-client
           (response as Response).json().then(data => this.updateEditorCollection(column, data));
-        } else if (response instanceof HttpResponseMessage) {
-          this.updateEditorCollection(column, response['content']);
-        } else if (Array.isArray(response)) {
-          this.updateEditorCollection(column, response);
+        } else if (response && response['content']) {
+          this.updateEditorCollection(column, response['content']); // from aurelia-http-client
         }
       });
     }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -667,7 +667,7 @@ export class AureliaSlickgridCustomElement {
               'already read. Either pass the dataset from the Response ' +
               'or clone the response first using response.clone()');
           }
-          // from aurelia-fetch-client
+          // from Fetch
           (response as Response).json().then(data => this.updateEditorCollection(column, data));
         } else if (response && response['content']) {
           this.updateEditorCollection(column, response['content']); // from aurelia-http-client

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/selectFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/selectFilter.ts
@@ -236,7 +236,7 @@ export class SelectFilter implements Filter {
       if (Array.isArray(response)) {
         awaitedCollection = response; // from Promise
       } else if (response instanceof Response && typeof response['json'] === 'function') {
-        awaitedCollection = await response['json'](); // from aurelia-fetch-client
+        awaitedCollection = await response['json'](); // from Fetch
       } else if (response && response['content']) {
         awaitedCollection = response['content']; // from aurelia-http-client
       }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/selectFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/selectFilter.ts
@@ -1,21 +1,20 @@
 import { I18N } from 'aurelia-i18n';
 import { Subscription } from 'aurelia-event-aggregator';
 import { BindingEngine } from 'aurelia-framework';
-import { HttpResponseMessage } from 'aurelia-http-client';
 import {
-    CollectionCustomStructure,
-    CollectionOption,
-    Column,
-    ColumnFilter,
-    Filter,
-    FilterArguments,
-    FilterCallback,
-    GridOption,
-    MultipleSelectOption,
-    OperatorType,
-    OperatorString,
-    SearchTerm,
-    SelectOption
+  CollectionCustomStructure,
+  CollectionOption,
+  Column,
+  ColumnFilter,
+  Filter,
+  FilterArguments,
+  FilterCallback,
+  GridOption,
+  MultipleSelectOption,
+  OperatorType,
+  OperatorString,
+  SearchTerm,
+  SelectOption
 } from './../models/index';
 import { CollectionService } from '../services/collection.service';
 import { disposeAllSubscriptions, getDescendantProperty, htmlEncode } from '../services/utilities';
@@ -23,392 +22,392 @@ import * as DOMPurify from 'dompurify';
 import * as $ from 'jquery';
 
 export class SelectFilter implements Filter {
-    /** DOM Element Name, useful for auto-detecting positioning (dropup / dropdown) */
-    elementName: string;
+  /** DOM Element Name, useful for auto-detecting positioning (dropup / dropdown) */
+  elementName: string;
 
-    /** Filter Multiple-Select options */
-    filterElmOptions: MultipleSelectOption;
+  /** Filter Multiple-Select options */
+  filterElmOptions: MultipleSelectOption;
 
-    /** The JQuery DOM element */
-    $filterElm: any;
+  /** The JQuery DOM element */
+  $filterElm: any;
 
-    grid: any;
-    searchTerms: SearchTerm[];
-    columnDef: Column;
-    callback: FilterCallback;
-    defaultOptions: MultipleSelectOption;
-    isFilled = false;
-    labelName: string;
-    labelPrefixName: string;
-    labelSuffixName: string;
-    valueName: string;
-    enableTranslateLabel = false;
-    subscriptions: Subscription[] = [];
+  grid: any;
+  searchTerms: SearchTerm[];
+  columnDef: Column;
+  callback: FilterCallback;
+  defaultOptions: MultipleSelectOption;
+  isFilled = false;
+  labelName: string;
+  labelPrefixName: string;
+  labelSuffixName: string;
+  valueName: string;
+  enableTranslateLabel = false;
+  subscriptions: Subscription[] = [];
 
-    /**
-     * Initialize the Filter
-     */
-    constructor(protected bindingEngine: BindingEngine, protected collectionService: CollectionService, protected i18n: I18N, protected isMultipleSelect = true) {
-        // default options used by this Filter, user can overwrite any of these by passing "otions"
-        const options: MultipleSelectOption = {
-            autoAdjustDropHeight: true,
-            autoAdjustDropPosition: true,
-            autoAdjustDropWidthByTextSize: true,
-            container: 'body',
-            filter: false,  // input search term on top of the select option list
-            maxHeight: 275,
-            single: true,
-            textTemplate: ($elm) => {
-                // render HTML code or not, by default it is sanitized and won't be rendered
-                const isRenderHtmlEnabled = this.columnDef && this.columnDef.filter && this.columnDef.filter.enableRenderHtml || false;
-                return isRenderHtmlEnabled ? $elm.text() : $elm.html();
-            },
-            onClose: () => {
-                // we will subscribe to the onClose event for triggering our callback
-                // also add/remove "filled" class for styling purposes
-                const selectedItems = this.$filterElm.multipleSelect('getSelects');
-                if (Array.isArray(selectedItems) && selectedItems.length > 0) {
-                    this.isFilled = true;
-                    this.$filterElm.addClass('filled').siblings('div .search-filter').addClass('filled');
-                } else {
-                    this.isFilled = false;
-                    this.$filterElm.removeClass('filled').siblings('div .search-filter').removeClass('filled');
-                }
-                this.callback(undefined, { columnDef: this.columnDef, operator: this.operator, searchTerms: selectedItems });
+  /**
+   * Initialize the Filter
+   */
+  constructor(protected bindingEngine: BindingEngine, protected collectionService: CollectionService, protected i18n: I18N, protected isMultipleSelect = true) {
+    // default options used by this Filter, user can overwrite any of these by passing "otions"
+    const options: MultipleSelectOption = {
+      autoAdjustDropHeight: true,
+      autoAdjustDropPosition: true,
+      autoAdjustDropWidthByTextSize: true,
+      container: 'body',
+      filter: false,  // input search term on top of the select option list
+      maxHeight: 275,
+      single: true,
+      textTemplate: ($elm) => {
+        // render HTML code or not, by default it is sanitized and won't be rendered
+        const isRenderHtmlEnabled = this.columnDef && this.columnDef.filter && this.columnDef.filter.enableRenderHtml || false;
+        return isRenderHtmlEnabled ? $elm.text() : $elm.html();
+      },
+      onClose: () => {
+        // we will subscribe to the onClose event for triggering our callback
+        // also add/remove "filled" class for styling purposes
+        const selectedItems = this.$filterElm.multipleSelect('getSelects');
+        if (Array.isArray(selectedItems) && selectedItems.length > 0) {
+          this.isFilled = true;
+          this.$filterElm.addClass('filled').siblings('div .search-filter').addClass('filled');
+        } else {
+          this.isFilled = false;
+          this.$filterElm.removeClass('filled').siblings('div .search-filter').removeClass('filled');
+        }
+        this.callback(undefined, { columnDef: this.columnDef, operator: this.operator, searchTerms: selectedItems });
+      }
+    };
+    if (this.isMultipleSelect) {
+      options.single = false;
+      options.okButton = true;
+      options.addTitle = true; // show tooltip of all selected items while hovering the filter
+      options.countSelected = this.i18n.tr('X_OF_Y_SELECTED');
+      options.allSelected = this.i18n.tr('ALL_SELECTED');
+      options.selectAllText = this.i18n.tr('SELECT_ALL');
+      options.selectAllDelimiter = ['', '']; // remove default square brackets of default text "[Select All]" => "Select All"
+    }
+    this.defaultOptions = options;
+  }
+
+  /** Getter for the Collection Options */
+  protected get collectionOptions(): CollectionOption {
+    return this.columnDef && this.columnDef.filter && this.columnDef.filter.collectionOptions || {};
+  }
+
+  /** Getter for the Filter Operator */
+  get columnFilter(): ColumnFilter {
+    return this.columnDef && this.columnDef.filter || {};
+  }
+
+  /** Getter for the Custom Structure if exist */
+  get customStructure(): CollectionCustomStructure | undefined {
+    return this.columnDef && this.columnDef.filter && this.columnDef.filter.customStructure;
+  }
+
+  /** Getter for the Grid Options pulled through the Grid Object */
+  get gridOptions(): GridOption {
+    return (this.grid && this.grid.getOptions) ? this.grid.getOptions() : {};
+  }
+
+  /** Getter for the Filter Operator */
+  get operator(): OperatorType | OperatorString {
+    return (this.columnDef && this.columnDef.filter && this.columnDef.filter.operator) || OperatorType.in;
+  }
+
+  /**
+   * Initialize the filter template
+   */
+  async init(args: FilterArguments) {
+    if (!args) {
+      throw new Error('[Aurelia-SlickGrid] A filter must always have an "init()" with valid arguments.');
+    }
+    this.grid = args.grid;
+    this.callback = args.callback;
+    this.columnDef = args.columnDef;
+    this.searchTerms = args.searchTerms || [];
+
+    if (!this.grid || !this.columnDef || !this.columnFilter || (!this.columnFilter.collection && !this.columnFilter.collectionAsync)) {
+      throw new Error(`[Aurelia-SlickGrid] You need to pass a "collection" (or "collectionAsync") for the MultipleSelect Filter to work correctly. Also each option should include a value/label pair (or value/labelKey when using Locale). For example:: { filter: model: Filters.multipleSelect, collection: [{ value: true, label: 'True' }, { value: false, label: 'False'}] }`);
+    }
+
+    this.enableTranslateLabel = this.columnFilter && this.columnFilter.enableTranslateLabel || false;
+    this.labelName = this.customStructure && this.customStructure.label || 'label';
+    this.labelPrefixName = this.customStructure && this.customStructure.labelPrefix || 'labelPrefix';
+    this.labelSuffixName = this.customStructure && this.customStructure.labelSuffix || 'labelSuffix';
+    this.valueName = this.customStructure && this.customStructure.value || 'value';
+
+    // always render the Select (dropdown) DOM element, even if user passed a "collectionAsync",
+    // if that is the case, the Select will simply be without any options but we still have to render it (else SlickGrid would throw an error)
+    let newCollection = this.columnFilter.collection || [];
+    this.renderDomElement(newCollection);
+
+    const collectionAsync = this.columnFilter.collectionAsync;
+    if (collectionAsync) {
+      newCollection = await this.renderOptionsAsync(collectionAsync);
+    }
+
+    // subscribe to both CollectionObserver and PropertyObserver
+    // any collection changes will trigger a re-render of the DOM element filter
+    if (collectionAsync || (this.columnFilter.enableCollectionWatch)) {
+      this.watchCollectionChanges();
+    }
+  }
+
+  /**
+   * Clear the filter values
+   */
+  clear() {
+    if (this.$filterElm && this.$filterElm.multipleSelect) {
+      // reload the filter element by it's id, to make sure it's still a valid element (because of some issue in the GraphQL example)
+      this.$filterElm.multipleSelect('setSelects', []);
+      this.$filterElm.removeClass('filled');
+      this.searchTerms = [];
+      this.callback(undefined, { columnDef: this.columnDef, clearFilterTriggered: true });
+    }
+  }
+
+  /**
+   * destroy the filter
+   */
+  destroy() {
+    if (this.$filterElm) {
+      // remove event watcher
+      this.$filterElm.off().remove();
+
+      // also dispose of all Subscriptions
+      this.subscriptions = disposeAllSubscriptions(this.subscriptions);
+    }
+  }
+
+  /**
+   * Set value(s) on the DOM element
+   */
+  setValues(values: SearchTerm | SearchTerm[]) {
+    if (values) {
+      values = Array.isArray(values) ? values : [values];
+      this.$filterElm.multipleSelect('setSelects', values);
+    }
+  }
+
+  //
+  // protected functions
+  // ------------------
+
+  /**
+   * user might want to filter certain items of the collection
+   * @param inputCollection
+   * @return outputCollection filtered and/or sorted collection
+   */
+  protected filterCollection(inputCollection: any[]): any[] {
+    let outputCollection = inputCollection;
+
+    // user might want to filter certain items of the collection
+    if (this.columnFilter && this.columnFilter.collectionFilterBy) {
+      const filterBy = this.columnFilter.collectionFilterBy;
+      outputCollection = this.collectionService.filterCollection(outputCollection, filterBy);
+    }
+
+    return outputCollection;
+  }
+
+  /**
+   * user might want to sort the collection in a certain way
+   * @param inputCollection
+   * @return outputCollection filtered and/or sorted collection
+   */
+  protected sortCollection(inputCollection: any[]): any[] {
+    let outputCollection = inputCollection;
+
+    // user might want to sort the collection
+    if (this.columnFilter && this.columnFilter.collectionSortBy) {
+      const sortBy = this.columnFilter.collectionSortBy;
+      outputCollection = this.collectionService.sortCollection(outputCollection, sortBy, this.enableTranslateLabel);
+    }
+
+    return outputCollection;
+  }
+
+  protected async renderOptionsAsync(collectionAsync: Promise<any | any[]>): Promise<any[]> {
+    let awaitedCollection: any = [];
+
+    if (collectionAsync) {
+      // wait for the "collectionAsync", once resolved we will save it into the "collection"
+      const response: any | any[] = await collectionAsync;
+
+      if (Array.isArray(response)) {
+        awaitedCollection = response; // from Promise
+      } else if (response instanceof Response && typeof response['json'] === 'function') {
+        awaitedCollection = await response['json'](); // from aurelia-fetch-client
+      } else if (response && response['content']) {
+        awaitedCollection = response['content']; // from aurelia-http-client
+      }
+
+      if (!Array.isArray(awaitedCollection)) {
+        throw new Error('Something went wrong while trying to pull the collection from the "collectionAsync" call');
+      }
+
+      // copy over the array received from the async call to the "collection" as the new collection to use
+      // this has to be BEFORE the `collectionObserver().subscribe` to avoid going into an infinite loop
+      this.columnFilter.collection = awaitedCollection;
+
+      // recreate Multiple Select after getting async collection
+      this.renderDomElement(awaitedCollection);
+    }
+
+    return awaitedCollection;
+  }
+
+  /**
+   * Subscribe to both CollectionObserver & PropertyObserver with BindingEngine.
+   * They each have their own purpose, the "propertyObserver" will trigger once the collection is replaced entirely
+   * while the "collectionObverser" will trigger on collection changes (`push`, `unshift`, `splice`, ...)
+   */
+  protected watchCollectionChanges(): void {
+    // subscribe to the "collection" changes (array replace)
+    this.subscriptions.push(
+      this.bindingEngine
+        .propertyObserver(this.columnFilter, 'collection')
+        .subscribe((newVal) => {
+          // simply recreate/re-render the Select (dropdown) DOM Element
+          this.renderDomElement(newVal);
+        })
+    );
+
+    // subscribe to the "collection" changes (array `push`, `unshift`, `splice`, ...)
+    if (this.columnFilter && this.columnFilter.collection) {
+      this.subscriptions.push(
+        this.bindingEngine
+          .collectionObserver(this.columnFilter.collection)
+          .subscribe((changes: { index: number, addedCount: number, removed: any[] }[]) => {
+            if (Array.isArray(changes) && changes.length > 0) {
+              // simply recreate/re-render the Select (dropdown) DOM Element
+              const updatedCollection = this.columnFilter.collection || [];
+              this.renderDomElement(updatedCollection);
             }
-        };
-        if (this.isMultipleSelect) {
-            options.single = false;
-            options.okButton = true;
-            options.addTitle = true; // show tooltip of all selected items while hovering the filter
-            options.countSelected = this.i18n.tr('X_OF_Y_SELECTED');
-            options.allSelected = this.i18n.tr('ALL_SELECTED');
-            options.selectAllText = this.i18n.tr('SELECT_ALL');
-            options.selectAllDelimiter = ['', '']; // remove default square brackets of default text "[Select All]" => "Select All"
-        }
-        this.defaultOptions = options;
+          })
+      );
+    }
+  }
+
+  protected renderDomElement(collection: any[]) {
+    if (!Array.isArray(collection) && this.collectionOptions && this.collectionOptions.collectionInObjectProperty) {
+      collection = getDescendantProperty(collection, this.collectionOptions.collectionInObjectProperty);
+    }
+    if (!Array.isArray(collection)) {
+      throw new Error('The "collection" passed to the Select Filter is not a valid array');
     }
 
-    /** Getter for the Collection Options */
-    protected get collectionOptions(): CollectionOption {
-        return this.columnDef && this.columnDef.filter && this.columnDef.filter.collectionOptions || {};
+    // user can optionally add a blank entry at the beginning of the collection
+    if (this.collectionOptions && this.collectionOptions.addBlankEntry) {
+      collection.unshift(this.createBlankEntry());
     }
 
-    /** Getter for the Filter Operator */
-    get columnFilter(): ColumnFilter {
-        return this.columnDef && this.columnDef.filter || {};
+    // assign the collection to a temp variable before filtering/sorting the collection
+    let newCollection = collection;
+
+    // user might want to filter and/or sort certain items of the collection
+    newCollection = this.filterCollection(newCollection);
+    newCollection = this.sortCollection(newCollection);
+
+    // step 1, create HTML string template
+    const filterTemplate = this.buildTemplateHtmlString(newCollection, this.searchTerms);
+
+    // step 2, create the DOM Element of the filter & pre-load search terms
+    // also subscribe to the onClose event
+    this.createDomElement(filterTemplate);
+  }
+
+  /**
+   * Create the HTML template as a string
+   */
+  protected buildTemplateHtmlString(optionCollection: any[], searchTerms: SearchTerm[]): string {
+    let options = '';
+    const separatorBetweenLabels = this.collectionOptions && this.collectionOptions.separatorBetweenTextLabels || '';
+    const isRenderHtmlEnabled = this.columnFilter && this.columnFilter.enableRenderHtml || false;
+    const sanitizedOptions = this.gridOptions && this.gridOptions.sanitizeHtmlOptions || {};
+
+    optionCollection.forEach((option: SelectOption) => {
+      if (!option || (option[this.labelName] === undefined && option.labelKey === undefined)) {
+        throw new Error(`A collection with value/label (or value/labelKey when using Locale) is required to populate the Select list, for example:: { filter: model: Filters.multipleSelect, collection: [ { value: '1', label: 'One' } ]')`);
+      }
+      const labelKey = (option.labelKey || option[this.labelName]) as string;
+      const selected = (searchTerms.findIndex((term) => term === option[this.valueName]) >= 0) ? 'selected' : '';
+      const labelText = ((option.labelKey || this.enableTranslateLabel) && this.i18n && typeof this.i18n.tr === 'function') ? this.i18n.tr(labelKey || ' ') : labelKey;
+      const prefixText = option[this.labelPrefixName] || '';
+      const suffixText = option[this.labelSuffixName] || '';
+      let optionText = (prefixText + separatorBetweenLabels + labelText + separatorBetweenLabels + suffixText);
+
+      // if user specifically wants to render html text, he needs to opt-in else it will stripped out by default
+      // also, the 3rd party lib will saninitze any html code unless it's encoded, so we'll do that
+      if (isRenderHtmlEnabled) {
+        // sanitize any unauthorized html tags like script and others
+        // for the remaining allowed tags we'll permit all attributes
+        const sanitizedText = DOMPurify.sanitize(optionText, sanitizedOptions);
+        optionText = htmlEncode(sanitizedText);
+      }
+
+      // html text of each select option
+      options += `<option value="${option[this.valueName]}" ${selected}>${optionText}</option>`;
+
+      // if there's a search term, we will add the "filled" class for styling purposes
+      if (selected) {
+        this.isFilled = true;
+      }
+    });
+
+    return `<select class="ms-filter search-filter" multiple="multiple">${options}</select>`;
+  }
+
+  /** Create a blank entry that can be added to the collection. It will also reuse the same collection structure provided by the user */
+  protected createBlankEntry(): any {
+    const blankEntry = {
+      [this.labelName]: '',
+      [this.valueName]: ''
+    };
+    if (this.labelPrefixName) {
+      blankEntry[this.labelPrefixName] = '';
+    }
+    if (this.labelSuffixName) {
+      blankEntry[this.labelSuffixName] = '';
+    }
+    return blankEntry;
+  }
+
+  /**
+   * From the html template string, create a DOM element of the Multiple/Single Select Filter
+   * Subscribe to the onClose event and run the callback when that happens
+   * @param filterTemplate
+   */
+  protected createDomElement(filterTemplate: string) {
+    const fieldId = this.columnDef && this.columnDef.field || this.columnDef && this.columnDef.id;
+
+    // provide the name attribute to the DOM element which will be needed to auto-adjust drop position (dropup / dropdown)
+    this.elementName = `filter_${fieldId}`;
+    this.defaultOptions.name = this.elementName;
+
+    const $headerElm = this.grid.getHeaderRowColumn(this.columnDef.id);
+    $($headerElm).empty();
+
+    // create the DOM element & add an ID and filter class
+    this.$filterElm = $(filterTemplate);
+    if (typeof this.$filterElm.multipleSelect !== 'function') {
+      throw new Error(`multiple-select.js was not found, make sure to read the HOWTO Wiki on how to install it`);
+    }
+    this.$filterElm.attr('id', this.elementName);
+    this.$filterElm.data('columnId', fieldId);
+
+    // if there's a search term, we will add the "filled" class for styling purposes
+    if (this.isFilled) {
+      this.$filterElm.addClass('filled');
     }
 
-    /** Getter for the Custom Structure if exist */
-    get customStructure(): CollectionCustomStructure | undefined {
-        return this.columnDef && this.columnDef.filter && this.columnDef.filter.customStructure;
+    // append the new DOM element to the header row
+    if (this.$filterElm && typeof this.$filterElm.appendTo === 'function') {
+      this.$filterElm.appendTo($headerElm);
     }
 
-    /** Getter for the Grid Options pulled through the Grid Object */
-    get gridOptions(): GridOption {
-        return (this.grid && this.grid.getOptions) ? this.grid.getOptions() : {};
-    }
-
-    /** Getter for the Filter Operator */
-    get operator(): OperatorType | OperatorString {
-        return (this.columnDef && this.columnDef.filter && this.columnDef.filter.operator) || OperatorType.in;
-    }
-
-    /**
-     * Initialize the filter template
-     */
-    async init(args: FilterArguments) {
-        if (!args) {
-            throw new Error('[Aurelia-SlickGrid] A filter must always have an "init()" with valid arguments.');
-        }
-        this.grid = args.grid;
-        this.callback = args.callback;
-        this.columnDef = args.columnDef;
-        this.searchTerms = args.searchTerms || [];
-
-        if (!this.grid || !this.columnDef || !this.columnFilter || (!this.columnFilter.collection && !this.columnFilter.collectionAsync)) {
-            throw new Error(`[Aurelia-SlickGrid] You need to pass a "collection" (or "collectionAsync") for the MultipleSelect Filter to work correctly. Also each option should include a value/label pair (or value/labelKey when using Locale). For example:: { filter: model: Filters.multipleSelect, collection: [{ value: true, label: 'True' }, { value: false, label: 'False'}] }`);
-        }
-
-        this.enableTranslateLabel = this.columnFilter && this.columnFilter.enableTranslateLabel || false;
-        this.labelName = this.customStructure && this.customStructure.label || 'label';
-        this.labelPrefixName = this.customStructure && this.customStructure.labelPrefix || 'labelPrefix';
-        this.labelSuffixName = this.customStructure && this.customStructure.labelSuffix || 'labelSuffix';
-        this.valueName = this.customStructure && this.customStructure.value || 'value';
-
-        // always render the Select (dropdown) DOM element, even if user passed a "collectionAsync",
-        // if that is the case, the Select will simply be without any options but we still have to render it (else SlickGrid would throw an error)
-        let newCollection = this.columnFilter.collection || [];
-        this.renderDomElement(newCollection);
-
-        const collectionAsync = this.columnFilter.collectionAsync;
-        if (collectionAsync) {
-            newCollection = await this.renderOptionsAsync(collectionAsync);
-        }
-
-        // subscribe to both CollectionObserver and PropertyObserver
-        // any collection changes will trigger a re-render of the DOM element filter
-        if (collectionAsync || (this.columnFilter.enableCollectionWatch)) {
-            this.watchCollectionChanges();
-        }
-    }
-
-    /**
-     * Clear the filter values
-     */
-    clear() {
-        if (this.$filterElm && this.$filterElm.multipleSelect) {
-            // reload the filter element by it's id, to make sure it's still a valid element (because of some issue in the GraphQL example)
-            this.$filterElm.multipleSelect('setSelects', []);
-            this.$filterElm.removeClass('filled');
-            this.searchTerms = [];
-            this.callback(undefined, { columnDef: this.columnDef, clearFilterTriggered: true });
-        }
-    }
-
-    /**
-     * destroy the filter
-     */
-    destroy() {
-        if (this.$filterElm) {
-            // remove event watcher
-            this.$filterElm.off().remove();
-
-            // also dispose of all Subscriptions
-            this.subscriptions = disposeAllSubscriptions(this.subscriptions);
-        }
-    }
-
-    /**
-     * Set value(s) on the DOM element
-     */
-    setValues(values: SearchTerm | SearchTerm[]) {
-        if (values) {
-            values = Array.isArray(values) ? values : [values];
-            this.$filterElm.multipleSelect('setSelects', values);
-        }
-    }
-
-    //
-    // protected functions
-    // ------------------
-
-    /**
-     * user might want to filter certain items of the collection
-     * @param inputCollection
-     * @return outputCollection filtered and/or sorted collection
-     */
-    protected filterCollection(inputCollection: any[]): any[] {
-        let outputCollection = inputCollection;
-
-        // user might want to filter certain items of the collection
-        if (this.columnFilter && this.columnFilter.collectionFilterBy) {
-            const filterBy = this.columnFilter.collectionFilterBy;
-            outputCollection = this.collectionService.filterCollection(outputCollection, filterBy);
-        }
-
-        return outputCollection;
-    }
-
-    /**
-     * user might want to sort the collection in a certain way
-     * @param inputCollection
-     * @return outputCollection filtered and/or sorted collection
-     */
-    protected sortCollection(inputCollection: any[]): any[] {
-        let outputCollection = inputCollection;
-
-        // user might want to sort the collection
-        if (this.columnFilter && this.columnFilter.collectionSortBy) {
-            const sortBy = this.columnFilter.collectionSortBy;
-            outputCollection = this.collectionService.sortCollection(outputCollection, sortBy, this.enableTranslateLabel);
-        }
-
-        return outputCollection;
-    }
-
-    protected async renderOptionsAsync(collectionAsync: Promise<HttpResponseMessage | Response | any[]>): Promise<any[]> {
-        let awaitedCollection: any = [];
-
-        if (collectionAsync) {
-            // wait for the "collectionAsync", once resolved we will save it into the "collection"
-            const response: HttpResponseMessage | Response | any[] = await collectionAsync;
-
-            if (response instanceof Response && typeof response['json'] === 'function') {
-                awaitedCollection = await response['json']();
-            } else if (response instanceof HttpResponseMessage) {
-                awaitedCollection = response['content'];
-            } else {
-                awaitedCollection = response;
-            }
-
-            if (!Array.isArray(awaitedCollection)) {
-                throw new Error('Something went wrong while trying to pull the collection from the "collectionAsync" call');
-            }
-
-            // copy over the array received from the async call to the "collection" as the new collection to use
-            // this has to be BEFORE the `collectionObserver().subscribe` to avoid going into an infinite loop
-            this.columnFilter.collection = awaitedCollection;
-
-            // recreate Multiple Select after getting async collection
-            this.renderDomElement(awaitedCollection);
-        }
-
-        return awaitedCollection;
-    }
-
-    /**
-     * Subscribe to both CollectionObserver & PropertyObserver with BindingEngine.
-     * They each have their own purpose, the "propertyObserver" will trigger once the collection is replaced entirely
-     * while the "collectionObverser" will trigger on collection changes (`push`, `unshift`, `splice`, ...)
-     */
-    protected watchCollectionChanges(): void {
-        // subscribe to the "collection" changes (array replace)
-        this.subscriptions.push(
-            this.bindingEngine
-                .propertyObserver(this.columnFilter, 'collection')
-                .subscribe((newVal) => {
-                    // simply recreate/re-render the Select (dropdown) DOM Element
-                    this.renderDomElement(newVal);
-                })
-        );
-
-        // subscribe to the "collection" changes (array `push`, `unshift`, `splice`, ...)
-        if (this.columnFilter && this.columnFilter.collection) {
-            this.subscriptions.push(
-                this.bindingEngine
-                    .collectionObserver(this.columnFilter.collection)
-                    .subscribe((changes: { index: number, addedCount: number, removed: any[] }[]) => {
-                        if (Array.isArray(changes) && changes.length > 0) {
-                            // simply recreate/re-render the Select (dropdown) DOM Element
-                            const updatedCollection = this.columnFilter.collection || [];
-                            this.renderDomElement(updatedCollection);
-                        }
-                    })
-            );
-        }
-    }
-
-    protected renderDomElement(collection: any[]) {
-        if (!Array.isArray(collection) && this.collectionOptions && this.collectionOptions.collectionInObjectProperty) {
-            collection = getDescendantProperty(collection, this.collectionOptions.collectionInObjectProperty);
-        }
-        if (!Array.isArray(collection)) {
-            throw new Error('The "collection" passed to the Select Filter is not a valid array');
-        }
-
-        // user can optionally add a blank entry at the beginning of the collection
-        if (this.collectionOptions && this.collectionOptions.addBlankEntry) {
-            collection.unshift(this.createBlankEntry());
-        }
-
-        // assign the collection to a temp variable before filtering/sorting the collection
-        let newCollection = collection;
-
-        // user might want to filter and/or sort certain items of the collection
-        newCollection = this.filterCollection(newCollection);
-        newCollection = this.sortCollection(newCollection);
-
-        // step 1, create HTML string template
-        const filterTemplate = this.buildTemplateHtmlString(newCollection, this.searchTerms);
-
-        // step 2, create the DOM Element of the filter & pre-load search terms
-        // also subscribe to the onClose event
-        this.createDomElement(filterTemplate);
-    }
-
-    /**
-     * Create the HTML template as a string
-     */
-    protected buildTemplateHtmlString(optionCollection: any[], searchTerms: SearchTerm[]): string {
-        let options = '';
-        const separatorBetweenLabels = this.collectionOptions && this.collectionOptions.separatorBetweenTextLabels || '';
-        const isRenderHtmlEnabled = this.columnFilter && this.columnFilter.enableRenderHtml || false;
-        const sanitizedOptions = this.gridOptions && this.gridOptions.sanitizeHtmlOptions || {};
-
-        optionCollection.forEach((option: SelectOption) => {
-            if (!option || (option[this.labelName] === undefined && option.labelKey === undefined)) {
-                throw new Error(`A collection with value/label (or value/labelKey when using Locale) is required to populate the Select list, for example:: { filter: model: Filters.multipleSelect, collection: [ { value: '1', label: 'One' } ]')`);
-            }
-            const labelKey = (option.labelKey || option[this.labelName]) as string;
-            const selected = (searchTerms.findIndex((term) => term === option[this.valueName]) >= 0) ? 'selected' : '';
-            const labelText = ((option.labelKey || this.enableTranslateLabel) && this.i18n && typeof this.i18n.tr === 'function') ? this.i18n.tr(labelKey || ' ') : labelKey;
-            const prefixText = option[this.labelPrefixName] || '';
-            const suffixText = option[this.labelSuffixName] || '';
-            let optionText = (prefixText + separatorBetweenLabels + labelText + separatorBetweenLabels + suffixText);
-
-            // if user specifically wants to render html text, he needs to opt-in else it will stripped out by default
-            // also, the 3rd party lib will saninitze any html code unless it's encoded, so we'll do that
-            if (isRenderHtmlEnabled) {
-                // sanitize any unauthorized html tags like script and others
-                // for the remaining allowed tags we'll permit all attributes
-                const sanitizedText = DOMPurify.sanitize(optionText, sanitizedOptions);
-                optionText = htmlEncode(sanitizedText);
-            }
-
-            // html text of each select option
-            options += `<option value="${option[this.valueName]}" ${selected}>${optionText}</option>`;
-
-            // if there's a search term, we will add the "filled" class for styling purposes
-            if (selected) {
-                this.isFilled = true;
-            }
-        });
-
-        return `<select class="ms-filter search-filter" multiple="multiple">${options}</select>`;
-    }
-
-    /** Create a blank entry that can be added to the collection. It will also reuse the same collection structure provided by the user */
-    protected createBlankEntry(): any {
-        const blankEntry = {
-            [this.labelName]: '',
-            [this.valueName]: ''
-        };
-        if (this.labelPrefixName) {
-            blankEntry[this.labelPrefixName] = '';
-        }
-        if (this.labelSuffixName) {
-            blankEntry[this.labelSuffixName] = '';
-        }
-        return blankEntry;
-    }
-
-    /**
-     * From the html template string, create a DOM element of the Multiple/Single Select Filter
-     * Subscribe to the onClose event and run the callback when that happens
-     * @param filterTemplate
-     */
-    protected createDomElement(filterTemplate: string) {
-        const fieldId = this.columnDef && this.columnDef.field || this.columnDef && this.columnDef.id;
-
-        // provide the name attribute to the DOM element which will be needed to auto-adjust drop position (dropup / dropdown)
-        this.elementName = `filter_${fieldId}`;
-        this.defaultOptions.name = this.elementName;
-
-        const $headerElm = this.grid.getHeaderRowColumn(this.columnDef.id);
-        $($headerElm).empty();
-
-        // create the DOM element & add an ID and filter class
-        this.$filterElm = $(filterTemplate);
-        if (typeof this.$filterElm.multipleSelect !== 'function') {
-            throw new Error(`multiple-select.js was not found, make sure to read the HOWTO Wiki on how to install it`);
-        }
-        this.$filterElm.attr('id', this.elementName);
-        this.$filterElm.data('columnId', fieldId);
-
-        // if there's a search term, we will add the "filled" class for styling purposes
-        if (this.isFilled) {
-            this.$filterElm.addClass('filled');
-        }
-
-        // append the new DOM element to the header row
-        if (this.$filterElm && typeof this.$filterElm.appendTo === 'function') {
-            this.$filterElm.appendTo($headerElm);
-        }
-
-        // merge options & attach multiSelect
-        const filterOptions = (this.columnFilter) ? this.columnFilter.filterOptions : {};
-        this.filterElmOptions = { ...this.defaultOptions, ...filterOptions };
-        this.$filterElm = this.$filterElm.multipleSelect(this.filterElmOptions);
-    }
+    // merge options & attach multiSelect
+    const filterOptions = (this.columnFilter) ? this.columnFilter.filterOptions : {};
+    this.filterElmOptions = { ...this.defaultOptions, ...filterOptions };
+    this.$filterElm = this.$filterElm.multipleSelect(this.filterElmOptions);
+  }
 }


### PR DESCRIPTION
This PR removes the `aurelia-http-client` dependencies. I tested and fixed both Filters & Editors (the latter is in `aurelia-slickgrid.ts`). 

I had to move the `Promise` check as the first check since incorrectly was getting caught by the other checks, after doing so it was all good. I tested with `console.log` on all 3 (Filter & Editor) and switch from `aurelia-http-client`, to `aurelia-fetch-client` to `Promise`.