### PR TITLE
fix(header): use showHeaderRow flag correctly when defined by user

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/global-grid-options.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/global-grid-options.ts
@@ -82,7 +82,6 @@ export const GlobalGridOptions: GridOption = {
     hideSortCommands: false
   },
   headerRowHeight: 35,
-  showHeaderRow: false,
   multiColumnSort: true,
   numberedMultiColumnSort: true,
   tristateMultiColumnSort: false,


### PR DESCRIPTION
- user should be able to have `enableFiltering: true` and still hide the filter row on page load with `showHeaderRow: false`, doing this would still create all filters but it will also hide the filter row after page load, it's important to hide it AFTER, else the filters won't be created at all. 