### PR TITLE
feat(select): add option to use label as selected text

### DIFF
--- a/aurelia-slickgrid/assets/lib/multiple-select/multiple-select.js
+++ b/aurelia-slickgrid/assets/lib/multiple-select/multiple-select.js
@@ -7,7 +7,7 @@
  * This is a modified version of multiple-select
  * @author Ghislain B.
  *
- * Some minor changes were applied to the original with the following changes:
+ * Few changes were applied to the original with addition of the following properties/changes:
  * - "okButton" boolean flag which when set will add an "OK" button at the end of the list to make it convenient to the user to close the window
  * - "okButtonText" was also added to change locale
  * - made code changes to support re-styling of the radio/checkbox with Font-Awesome or any other font
@@ -23,6 +23,8 @@
  * - "domElmOkButtonHeight" defaults to 26 (as per CSS), that is the "OK" button element height in pixels inside the drop when using multiple-selection
  * - "domElmSelectSidePadding" defaults to 26 (as per CSS), that is the select DOM element padding in pixels (that is not the drop but the select itself, how tall is it)
  * - "domElmSelectAllHeight" defaults to 39 (as per CSS), that is the DOM element of the "Select All" text area
+ * - "useSelectOptionLabel" (defaults to False), when set to True it will use the <option label=""> that can be used to display selected options
+ * - "useSelectOptionLabelToHtml" (defaults to False), same as "useSelectOptionLabel" but will also render html
  */
 
 (function ($) {
@@ -142,6 +144,17 @@
     return str;
 
   };
+
+  var stripScripts = function (str) {
+    var div = document.createElement('div');
+    div.innerHTML = str;
+    var scripts = div.getElementsByTagName('script');
+    var i = scripts.length;
+    while (i--) {
+      scripts[i].parentNode.removeChild(scripts[i]);
+    }
+    return div.innerHTML;
+  }
 
   function MultipleSelect($el, options) {
     var that = this,
@@ -280,6 +293,7 @@
       var that = this,
         $elm = $(elm),
         classes = $elm.attr('class') || '',
+        label = sprintf('label="%s"', $elm.attr('label') || ''),
         title = sprintf('title="%s"', $elm.attr('title')),
         multiple = this.options.multiple ? 'multiple' : '',
         disabled,
@@ -295,7 +309,7 @@
         disabled = groupDisabled || $elm.prop('disabled');
 
         $el = $([
-          sprintf('<li class="%s %s" %s %s>', multiple, classes, title, style),
+          sprintf('<li class="%s %s" %s %s %s>', multiple, classes, title, style, label),
           sprintf('<label class="%s">', disabled ? 'disabled' : ''),
           sprintf('<input type="%s" %s%s%s%s>',
             type, this.selectItemName,
@@ -688,11 +702,22 @@
           .replace('#', selects.length)
           .replace('%', this.$selectItems.length + this.$disableItems.length));
       } else {
-        $span.removeClass('placeholder').text(selects.join(this.options.delimiter));
+        if (this.options.useSelectOptionLabel || this.options.useSelectOptionLabelToHtml) {
+          var labels = this.getSelects('label').join(this.options.delimiter);
+          if (this.options.useSelectOptionLabelToHtml) {
+            var sanitizedLabels = stripScripts(labels);
+            $span.removeClass('placeholder').html(sanitizedLabels);
+          } else {
+            $span.removeClass('placeholder').text(labels);
+          }
+        } else {
+          $span.removeClass('placeholder').text(selects.join(this.options.delimiter));
+        }
       }
 
       if (this.options.addTitle) {
-        $span.prop('title', this.getSelects('text'));
+        var selectType = (this.options.useSelectOptionLabel || this.options.useSelectOptionLabelToHtml) ? 'label' : 'text'
+        $span.prop('title', this.getSelects(selectType));
       }
 
       // set selects to select
@@ -737,9 +762,11 @@
     getSelects: function (type) {
       var that = this,
         texts = [],
+        labels = [],
         values = [];
       this.$drop.find(sprintf('input[%s]:checked', this.selectItemName)).each(function () {
         texts.push($(this).parents('li').first().text());
+        labels.push($(this).parents('li').attr('label') || '');
         values.push($(this).val());
       });
 
@@ -768,8 +795,41 @@
           html.push(']');
           texts.push(html.join(''));
         });
+      } else if (type === 'label' && this.$selectGroups.length) {
+        labels = [];
+        this.$selectGroups.each(function () {
+          var html = [],
+            label = $.trim($(this).attr('label') || ''),
+            group = $(this).parent().data('group'),
+            $children = that.$drop.find(sprintf('[%s][data-group="%s"]', that.selectItemName, group)),
+            $selected = $children.filter(':checked');
+
+          if (!$selected.length) {
+            return;
+          }
+
+          html.push('[');
+          html.push(label);
+          if ($children.length > $selected.length) {
+            var list = [];
+            $selected.each(function () {
+              list.push($(this).attr('label') || '');
+            });
+            html.push(': ' + list.join(', '));
+          }
+          html.push(']');
+          labels.push(html.join(''));
+        });
       }
-      return type === 'text' ? texts : values;
+
+      switch (type) {
+        case 'text':
+          return texts;
+        case 'label':
+          return labels;
+        default:
+          return values;
+      }
     },
 
     getScrollbarWidth: function () {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/selectEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/selectEditor.ts
@@ -45,6 +45,9 @@ export class SelectEditor implements Editor {
   /** The property name for a suffix that can be added to the labels in the collection */
   labelSuffixName: string;
 
+  /** A label that can be added to each option and can be used as an alternative to display selected options */
+  optionLabel: string;
+
   /** The property name for values in the collection */
   valueName: string;
 
@@ -192,6 +195,7 @@ export class SelectEditor implements Editor {
     this.labelName = this.customStructure && this.customStructure.label || 'label';
     this.labelPrefixName = this.customStructure && this.customStructure.labelPrefix || 'labelPrefix';
     this.labelSuffixName = this.customStructure && this.customStructure.labelSuffix || 'labelSuffix';
+    this.optionLabel = (this.customStructure) ? this.customStructure.optionLabel : 'value';
     this.valueName = this.customStructure && this.customStructure.value || 'value';
 
     // always render the Select (dropdown) DOM element, even if user passed a "collectionAsync",
@@ -356,6 +360,8 @@ export class SelectEditor implements Editor {
       const labelText = (option.labelKey || this.enableTranslateLabel) ? this.i18n.tr(labelKey || ' ') : labelKey;
       const prefixText = option[this.labelPrefixName] || '';
       const suffixText = option[this.labelSuffixName] || '';
+      let optionLabel = option[this.optionLabel] || '';
+      optionLabel = optionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
       let optionText = ('' + prefixText + separatorBetweenLabels + labelText + separatorBetweenLabels + suffixText);
 
       // if user specifically wants to render html text, he needs to opt-in else it will stripped out by default
@@ -367,7 +373,7 @@ export class SelectEditor implements Editor {
         optionText = htmlEncode(sanitizedText);
       }
 
-      options += `<option value="${option[this.valueName]}">${optionText}</option>`;
+      options += `<option value="${option[this.valueName]}" label="${optionLabel}">${optionText}</option>`;
     });
 
     return `<select id="${this.elementName}" class="ms-filter search-filter" ${this.isMultipleSelect ? 'multiple="multiple"' : ''}>${options}</select>`;

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/selectFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/selectFilter.ts
@@ -40,6 +40,7 @@ export class SelectFilter implements Filter {
   labelName: string;
   labelPrefixName: string;
   labelSuffixName: string;
+  optionLabel: string;
   valueName: string;
   enableTranslateLabel = false;
   subscriptions: Subscription[] = [];
@@ -133,6 +134,7 @@ export class SelectFilter implements Filter {
     this.labelName = this.customStructure && this.customStructure.label || 'label';
     this.labelPrefixName = this.customStructure && this.customStructure.labelPrefix || 'labelPrefix';
     this.labelSuffixName = this.customStructure && this.customStructure.labelSuffix || 'labelSuffix';
+    this.optionLabel = (this.customStructure) ? this.customStructure.optionLabel : 'value';
     this.valueName = this.customStructure && this.customStructure.value || 'value';
 
     // always render the Select (dropdown) DOM element, even if user passed a "collectionAsync",
@@ -335,6 +337,8 @@ export class SelectFilter implements Filter {
       const labelText = ((option.labelKey || this.enableTranslateLabel) && this.i18n && typeof this.i18n.tr === 'function') ? this.i18n.tr(labelKey || ' ') : labelKey;
       const prefixText = option[this.labelPrefixName] || '';
       const suffixText = option[this.labelSuffixName] || '';
+      let optionLabel = option[this.optionLabel] || '';
+      optionLabel = optionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
       let optionText = (prefixText + separatorBetweenLabels + labelText + separatorBetweenLabels + suffixText);
 
       // if user specifically wants to render html text, he needs to opt-in else it will stripped out by default
@@ -347,7 +351,7 @@ export class SelectFilter implements Filter {
       }
 
       // html text of each select option
-      options += `<option value="${option[this.valueName]}" ${selected}>${optionText}</option>`;
+      options += `<option value="${option[this.valueName]}" label="${optionLabel}" ${selected}>${optionText}</option>`;
 
       // if there's a search term, we will add the "filled" class for styling purposes
       if (selected) {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/models/collectionCustomStructure.interface.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/models/collectionCustomStructure.interface.ts
@@ -5,6 +5,12 @@ export interface CollectionCustomStructure {
   /** your custom property name to use for the "value" (equals of the "option" in a select dropdown) */
   value: string;
 
+  /**
+   * defaults to "value", optional text that can be added to each <option label=""> attribute, which can then be used when showing selected text
+   * Can be used with `filterOptions: { useSelectOptionTitle: true }` when user want to show different text as selected values
+   */
+  optionLabel?: string;
+
   /** an optional prefix that will be prepended before the label text */
   labelPrefix?: string;
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/models/multipleSelectOption.interface.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/models/multipleSelectOption.interface.ts
@@ -107,6 +107,9 @@ export interface MultipleSelectOption {
   /** Whether or not Multiple Select allows you to select only one option.By default this option is set to false. */
   single?: boolean;
 
+  /** Defaults to false, when set to True it will use the "title" that were defined in each select option */
+  useSelectOptionTitle?: boolean;
+
   /** Define the width property of the dropdown list, support a percentage setting.By default this option is set to undefined. Which is the same as the select input field. */
   width?: number | string;
 

--- a/aurelia-slickgrid/src/examples/slickgrid/example4.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example4.ts
@@ -113,6 +113,7 @@ export class Example4 {
           customStructure: {
             value: 'value',
             label: 'label',
+            optionLabel: 'value', // if selected text is too long, we can use option labels instead
             labelSuffix: 'text',
           },
           collectionOptions: {
@@ -122,7 +123,11 @@ export class Example4 {
           // we could add certain option(s) to the "multiple-select" plugin
           filterOptions: {
             maxHeight: 250,
-            width: 175
+            width: 175,
+
+            // if we want to display shorter text as the selected text (on the select filter itself, parent element)
+            // we can use "useSelectOptionLabel" or "useSelectOptionLabelToHtml" the latter will parse html
+            useSelectOptionLabelToHtml: true
           }
         }
       },


### PR DESCRIPTION
- in some cases the selected text might be too wide to show as selected text (on `<select>` element), this PR adds possibility to use a different property (of your collection objects) to display shorter text

```typescript
{ 
  id: 'duration', name: 'Duration (days)', field: 'duration', 
  filter: {
    collectionAsync: this.http.get<{ option: string; value: string; }[]>(URL_SAMPLE_COLLECTION_DATA),
   customStructure: {
    value: 'value',
    label: 'label',
    optionLabel: 'value', // if selected text is too long, we can use option labels instead
    labelSuffix: 'text',
  },
  model: Filters.multipleSelect,

  // we could add certain option(s) to the "multiple-select" plugin
  filterOptions: {
    // if we want to display shorter text as the selected text (on the select filter itself, parent element)
    useSelectOptionLabel: true // or "useSelectOptionLabelToHtml" the latter will parse html
  }
}
```

For example below we are showing just the value "(220, 10)" instead of the longer text "(220 days, 10 days)" (which would show by default). 

![shorter-label](https://user-images.githubusercontent.com/643976/46503497-fb7ead00-c7f8-11e8-9a5c-27f456f4e22d.png)
