### PR TITLE
feat(divider): add divider option to Grid Menu & Column Header Menu

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
@@ -125,6 +125,12 @@ export class HeaderMenuExtension implements Extension {
                 positionOrder: 51
               });
             }
+
+            // add a divider (separator) between the top sort commands and the other clear commands
+            if (!headerMenuOptions.hideSortCommandsDivider) {
+              columnHeaderMenuItems.push({ divider: true, command: '', positionOrder: 52 });
+            }
+
             if (!headerMenuOptions.hideClearSortCommand && columnHeaderMenuItems.filter((item: HeaderMenuItem) => item.command === 'clear-sort').length === 0) {
               columnHeaderMenuItems.push({
                 iconCssClass: headerMenuOptions.iconClearSortCommand || 'fa fa-unsorted',

--- a/aurelia-slickgrid/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
@@ -139,7 +139,7 @@ export class HeaderMenuExtension implements Extension {
                 iconCssClass: headerMenuOptions.iconClearSortCommand || 'fa fa-unsorted',
                 title: options.enableTranslate ? this.i18n.tr('REMOVE_SORT') : Constants.TEXT_REMOVE_SORT,
                 command: 'clear-sort',
-                positionOrder: 52
+                positionOrder: 53
               });
             }
           }
@@ -151,7 +151,7 @@ export class HeaderMenuExtension implements Extension {
                 iconCssClass: headerMenuOptions.iconClearFilterCommand || 'fa fa-filter',
                 title: options.enableTranslate ? this.i18n.tr('REMOVE_FILTER') : Constants.TEXT_REMOVE_FILTER,
                 command: 'clear-filter',
-                positionOrder: 53
+                positionOrder: 52
               });
             }
           }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/global-grid-options.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/global-grid-options.ts
@@ -83,7 +83,8 @@ export const GlobalGridOptions: GridOption = {
     iconColumnHideCommand: 'fa fa-times',
     hideColumnHideCommand: false,
     hideClearSortCommand: false,
-    hideSortCommands: false
+    hideSortCommands: false,
+    hideSortCommandsDivider: false
   },
   headerRowHeight: 35,
   multiColumnSort: true,

--- a/aurelia-slickgrid/src/aurelia-slickgrid/models/gridMenuItem.interface.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/models/gridMenuItem.interface.ts
@@ -11,6 +11,9 @@ export interface GridMenuItem {
   /** Defaults to false, whether the item is disabled. */
   disabled?: boolean;
 
+  /** Defaults to false, whether the command is actually a divider (separator). */
+  divider?: boolean;
+
   /** CSS class to be added to the menu item icon. */
   iconCssClass?: string;
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/models/headerMenu.interface.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/models/headerMenu.interface.ts
@@ -26,6 +26,12 @@ export interface HeaderMenu {
   /** Defaults to false, which will hide both Sort (Asc/Desc) commands in the Header Menu (Grid Option "enableHeaderMenu: true" has to be enabled) */
   hideSortCommands?: boolean;
 
+  /**
+   * Defaults to false, which will hide the Divider (separator) between the top sort commands and the other clear commands
+   * (Grid Option "enableHeaderMenu" and "enableSorting" have to be enabled)
+   */
+  hideSortCommandsDivider?: boolean;
+
   /** Defaults to false, which will hide the "Hide Column" command in the Header Menu (Grid Option "enableHeaderMenu: true" has to be enabled) */
   hideColumnHideCommand?: boolean;
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/models/headerMenuItem.interface.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/models/headerMenuItem.interface.ts
@@ -5,6 +5,9 @@ export interface HeaderMenuItem {
   /** Defaults to false, whether the item is disabled. */
   disabled?: boolean;
 
+  /** Defaults to false, whether the command is actually a divider (separator). */
+  divider?: boolean;
+
   /** CSS class to be added to the menu item icon. */
   iconCssClass?: string;
 

--- a/aurelia-slickgrid/src/aurelia-slickgrid/styles/_variables.scss
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/styles/_variables.scss
@@ -40,7 +40,7 @@ $cell-padding:                            5px 7.5834px !default;
 
 /* row */
 $row-mouse-hover-color:                   #eff5fc !default;
-$row-selected-color:                       #dae8f1 !default;
+$row-selected-color:                      #dae8f1 !default;
 $row-highlight-background-color:          darken($row-selected-color, 5%) !default;
 $row-highlight-fade-animation:            1.5s ease 1 !default;
 $row-checkbox-selector-background:        inherit !default;
@@ -161,7 +161,7 @@ $copied-cell-bg-color-transition:         rgba(0, 0, 255, 0.2) !default;
 $copied-cell-transition:                  0.5s background !default;
 
 /* Grid Menu - hamburger menu */
-$grid-menu-background-color:              #f8f8f8 !default;
+$grid-menu-background-color:              #fafafa !default;
 $grid-menu-border:                        1px solid #b8b8b8 !default;
 $grid-menu-border-radius:                 3px !default;
 $grid-menu-label-margin:                  4px !default;
@@ -169,13 +169,34 @@ $grid-menu-label-font-weight:             normal !default;
 $grid-menu-link-background-color:         #ffffff !default;
 $grid-menu-box-shadow:                    2px 2px 2px silver !default;
 $grid-menu-icon-font-size:                14px !default;
+$grid-menu-divider-height:                1px !default;
+$grid-menu-divider-margin:                8px 3px !default;
+$grid-menu-divider-color:                 #d8d8d8 !default;
+
+/* Header Menu Plugin */
+$header-menu-bg-color:                    #ffffff !default;
+$header-menu-button-bg-color:             #ffffff !default;
+$header-menu-border:                      1px solid #BFBDBD !default;
+$header-menu-button-border:               $header-menu-border !default;
+$header-menu-border-radius:               2px !default;
+$header-menu-min-width:                   175px !default;
+$header-menu-padding:                     4px !default;
+$header-menu-item-border:                 none !default;
+$header-menu-item-padding:                2px 4px !default;
+$header-menu-icon-height:                 16px !default;
+$header-menu-icon-margin-right:           4px !default;
+$header-menu-icon-hover-color:            rgb(243, 243, 243) !default;
+$header-menu-icon-width:                  16px !default;
+$header-menu-divider-height:              1px !default;
+$header-menu-divider-margin:              8px 3px !default;
+$header-menu-divider-color:               #e5e5e5 !default;
 
 /* Checkbox Selector / Row Selection */
 $checkbox-selector-color:                 $primary-color !default;
 $checkbox-selector-size:                  13px !default;
 $checkbox-selector-icon:                  "\f00c" !default;
 $checkbox-selector-opacity:               0.15 !default;
-$checkbox-selector-opacity-hover:          0.35 !default;
+$checkbox-selector-opacity-hover:         0.35 !default;
 
 /* Editors */
 $large-editor-background-color:           #ffffff !default;

--- a/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-controls.scss
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-controls.scss
@@ -151,6 +151,19 @@
     border-color: silver;
     background: white;
   }
+
+  &.slick-gridmenu-item-divider {
+    cursor: default;
+    border: none;
+    overflow: hidden;
+    padding: 0;
+    height: $header-menu-divider-height;
+    margin: $header-menu-divider-margin;
+    background-color: $header-menu-divider-color;
+  }
+}
+.slick-gridmenu-item-divider.slick-gridmenu-item:hover {
+  background-color: $header-menu-divider-color;
 }
 
 .slick-gridmenu-item-disabled {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/styles/slick-plugins.scss
@@ -73,19 +73,20 @@
   }
 }
 .slick-header-menu {
-  background: none repeat scroll 0 0 white;
-  border: 1px solid #BFBDBD;
-  min-width: 175px;
-  padding: 4px;
+  position: absolute;
+  margin: 0;
+  background: none repeat scroll 0 0 $header-menu-bg-color;
+  border: $header-menu-border;
+  border-radius: $header-menu-border-radius;
+  min-width: $header-menu-min-width;
+  padding: $header-menu-padding;
   z-index: 100000;
   cursor: default;
   display: inline-block;
-  margin: 0;
-  position: absolute;
 
   button {
-    border: 1px solid #BFBDBD;
-    background-color: white;
+    border: $header-menu-button-border;
+    background-color: $header-menu-button-bg-color;
     width: 45px;
     padding: 4px;
     margin: 4px 4px 4px 0;
@@ -116,21 +117,34 @@
 }
 
 .slick-header-menuitem {
-  border: 1px solid transparent;
-  padding: 2px 4px;
   cursor: pointer;
+  border: $header-menu-item-border;
+  padding: $header-menu-item-padding;
   list-style: none outside none;
   margin: 0;
+
+  &.slick-header-menuitem-divider {
+    cursor: default;
+    border: none;
+    overflow: hidden;
+    padding: 0;
+    height: $header-menu-divider-height;
+    margin: $header-menu-divider-margin;
+    background-color: $header-menu-divider-color;
+  }
+}
+.slick-header-menuitem-divider.slick-header-menuitem:hover {
+  background-color: $header-menu-divider-color;
 }
 
 .slick-header-menuicon {
   background-position: center center;
   background-repeat: no-repeat;
   display: inline-block;
-  height: 16px;
-  margin-right: 4px;
+  height: $header-menu-icon-height;
+  margin-right: $header-menu-icon-margin-right;
   vertical-align: middle;
-  width: 16px;
+  width: $header-menu-icon-width;
 
   /* Font Awesome sorting icons are not aligned in middle, let's align them ourselves */
   &.fa-sort-asc {
@@ -148,7 +162,7 @@
 
 .slick-header-menuitem:hover {
   border-color: #BFBDBD;
-  background-color: rgb(246, 246, 246);
+  background-color: $header-menu-icon-hover-color;
 }
 .slick-header-menuitem-disabled {
   border-color: transparent !important;

--- a/aurelia-slickgrid/src/examples/slickgrid/example8.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example8.ts
@@ -74,7 +74,13 @@ export class Example8 {
               titleKey: 'HELP', // use "title" as plain string OR "titleKey" when using a translation key
               command: 'help',
               positionOrder: 99
-            }
+            },
+            // you can also add divider between commands (command is a required property but you can set it to empty string)
+            {
+              divider: true,
+              command: '',
+              positionOrder: 98
+            },
           ]
         }
       };

--- a/aurelia-slickgrid/src/examples/slickgrid/example9.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example9.ts
@@ -106,6 +106,12 @@ export class Example9 {
             command: 'help',
             positionOrder: 99
           },
+          // you can also add divider between commands (command is a required property but you can set it to empty string)
+          {
+            divider: true,
+            command: '',
+            positionOrder: 98
+          },
           {
             title: 'Disabled command',
             disabled: true,

--- a/doc/github-demo/src/examples/slickgrid/example8.ts
+++ b/doc/github-demo/src/examples/slickgrid/example8.ts
@@ -73,7 +73,13 @@ export class Example8 {
               titleKey: 'HELP', // use "title" as plain string OR "titleKey" when using a translation key
               command: 'help',
               positionOrder: 99
-            }
+            },
+            // you can also add divider between commands (command is a required property but you can set it to empty string)
+            {
+              divider: true,
+              command: '',
+              positionOrder: 98
+            },
           ]
         }
       };

--- a/doc/github-demo/src/examples/slickgrid/example9.ts
+++ b/doc/github-demo/src/examples/slickgrid/example9.ts
@@ -106,6 +106,12 @@ export class Example9 {
             command: 'help',
             positionOrder: 99
           },
+          // you can also add divider between commands (command is a required property but you can set it to empty string)
+          {
+            divider: true,
+            command: '',
+            positionOrder: 98
+          },
           {
             title: 'Disabled command',
             disabled: true,


### PR DESCRIPTION
This PR requires the [SlickGrid PR #319](https://github.com/6pac/SlickGrid/pull/319) to be merged for this to work.