### PR TITLE
refactor(formatter): Formatter can also return objects

### DIFF
--- a/aurelia-slickgrid/package.json
+++ b/aurelia-slickgrid/package.json
@@ -41,7 +41,7 @@
     "moment": "^2.19.1",
     "moment-mini": "^2.18.1",
     "nps": "^5.7.1",
-    "slickgrid": "github:6pac/SlickGrid",
+    "slickgrid": "^2.4.3",
     "text-encoding-utf-8": "^1.0.2"
   },
   "peerDependencies": {},

--- a/aurelia-slickgrid/src/aurelia-slickgrid/extensions/cellExternalCopyManagerExtension.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/extensions/cellExternalCopyManagerExtension.ts
@@ -43,7 +43,8 @@ export class CellExternalCopyManagerExtension implements Extension {
             if (columnDef.formatter && isEvaluatingFormatter) {
               const formattedOutput = columnDef.formatter(0, 0, item[columnDef.field], columnDef, item, this.sharedService.grid);
               if (columnDef.sanitizeDataExport || (this.sharedService.gridOptions.exportOptions && this.sharedService.gridOptions.exportOptions.sanitizeDataExport)) {
-                return sanitizeHtmlToText(formattedOutput);
+                const outputString = typeof formattedOutput === 'string' ? formattedOutput : formattedOutput && formattedOutput.text;
+                return sanitizeHtmlToText(outputString);
               }
               return formattedOutput;
             }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/formatters/decimalFormatter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/formatters/decimalFormatter.ts
@@ -4,8 +4,8 @@ import { decimalFormatted } from './../services/utilities';
 
 export const decimalFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any) => {
   const params = columnDef.params || {};
-  const minDecimalPlaces = params.minDecimalPlaces || params.decimalPlaces || 2;
-  const maxDecimalPlaces = params.maxDecimalPlaces || 2;
+  const minDecimalPlaces = (params.minDecimalPlaces !== null && params.minDecimalPlaces) || (params.decimalPlaces !== null && params.decimalPlaces) || 2;
+  const maxDecimalPlaces = (params.maxDecimalPlaces !== null && params.maxDecimalPlaces) || 2;
   const isNumber = (value === null || value === undefined) ? false : !isNaN(+value);
 
   return !isNumber ? value : `${decimalFormatted(value, minDecimalPlaces, maxDecimalPlaces)}`;

--- a/aurelia-slickgrid/src/aurelia-slickgrid/models/formatter.interface.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/models/formatter.interface.ts
@@ -1,3 +1,4 @@
 import { Column } from './column.interface';
+import { FormatterResultObject } from './formatterResultObject.interface';
 
-export type Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid?: any) => string;
+export type Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid?: any) => string | FormatterResultObject;

--- a/aurelia-slickgrid/src/aurelia-slickgrid/models/formatterResultObject.interface.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/models/formatterResultObject.interface.ts
@@ -1,6 +1,13 @@
 export interface FormatterResultObject {
+  /** Optional CSS classes to add to the cell div */
   addClasses?: string;
+
+  /** Optional CSS classes to remove from the cell div */
   removeClasses?: string;
+
+  /** Text to be displayed in the cell, basically the formatter output */
   text: string;
+
+  /** Optional tooltip text */
   toolTip?: string;
 }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/models/formatterResultObject.interface.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/models/formatterResultObject.interface.ts
@@ -1,0 +1,6 @@
+export interface FormatterResultObject {
+  addClasses?: string;
+  removeClasses?: string;
+  text: string;
+  toolTip?: string;
+}

--- a/aurelia-slickgrid/src/aurelia-slickgrid/models/index.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/models/index.ts
@@ -45,6 +45,7 @@ export * from './filterConditionOption.interface';
 export * from './filterMultiplePassType.enum';
 export * from './filterMultiplePassTypeString';
 export * from './formatter.interface';
+export * from './formatterResultObject.interface';
 export * from './graphqlDatasetFilter.interface';
 export * from './graphqlCursorPaginationOption.interface';
 export * from './graphqlFilteringOption.interface';

--- a/aurelia-slickgrid/src/examples/slickgrid/example2.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example2.ts
@@ -7,8 +7,10 @@ import {
 } from '../../aurelia-slickgrid';
 
 // create my custom Formatter with the Formatter type
-const myCustomCheckmarkFormatter: Formatter = (row, cell, value, columnDef, dataContext) =>
-  value ? `<i class="fa fa-fire" aria-hidden="true"></i>` : '<i class="fa fa-snowflake-o" aria-hidden="true"></i>';
+const myCustomCheckmarkFormatter: Formatter = (row, cell, value, columnDef, dataContext) => {
+  // you can return a string of a object (of type FormatterResultObject), the 2 types are shown below
+  return value ? `<i class="fa fa-fire red" aria-hidden="true"></i>` : { text: '<i class="fa fa-snowflake-o" aria-hidden="true"></i>', addClasses: 'lightblue', toolTip: 'Freezing' };
+};
 
 export class Example2 {
   title = 'Example 2: Formatters';
@@ -42,7 +44,7 @@ export class Example2 {
     this.columnDefinitions = [
       { id: 'title', name: 'Title', field: 'title', sortable: true, type: FieldType.string, width: 70 },
       { id: 'phone', name: 'Phone Number using mask', field: 'phone', sortable: true, type: FieldType.number, minWidth: 100, formatter: Formatters.mask, params: { mask: '(000) 000-0000' } },
-      { id: 'duration', name: 'Duration (days)', field: 'duration', formatter: Formatters.decimal, params: { minDecimalPlaces: 1, maxDecimalPlaces: 2 }, sortable: true, type: FieldType.number, minWidth: 90 },
+      { id: 'duration', name: 'Duration (days)', field: 'duration', formatter: Formatters.decimal, params: { minDecimalPlaces: 1, maxDecimalPlaces: 2 }, sortable: true, type: FieldType.number, minWidth: 90, exportWithFormatter: true },
       { id: 'complete', name: '% Complete', field: 'percentComplete', formatter: Formatters.percentCompleteBar, type: FieldType.number, sortable: true, minWidth: 100 },
       { id: 'percent2', name: '% Complete', field: 'percentComplete2', formatter: Formatters.progressBar, type: FieldType.number, sortable: true, minWidth: 100 },
       { id: 'start', name: 'Start', field: 'start', formatter: Formatters.dateIso, sortable: true, type: FieldType.date, minWidth: 90, exportWithFormatter: true },

--- a/aurelia-slickgrid/src/examples/slickgrid/example2.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example2.ts
@@ -1,12 +1,13 @@
 import {
   Column,
   FieldType,
+  Formatter,
   Formatters,
   GridOption,
 } from '../../aurelia-slickgrid';
 
 // create my custom Formatter with the Formatter type
-const myCustomCheckmarkFormatter = (row, cell, value, columnDef, dataContext) =>
+const myCustomCheckmarkFormatter: Formatter = (row, cell, value, columnDef, dataContext) =>
   value ? `<i class="fa fa-fire" aria-hidden="true"></i>` : '<i class="fa fa-snowflake-o" aria-hidden="true"></i>';
 
 export class Example2 {

--- a/aurelia-slickgrid/src/styles.css
+++ b/aurelia-slickgrid/src/styles.css
@@ -10,6 +10,9 @@ body {
 .faded:hover {
   opacity: 0.5;
 }
+.lightblue {
+  color: lightblue;
+}
 .red {
   color: red;
 }

--- a/doc/github-demo/src/examples/slickgrid/example2.ts
+++ b/doc/github-demo/src/examples/slickgrid/example2.ts
@@ -7,8 +7,10 @@ import {
 } from 'aurelia-slickgrid';
 
 // create my custom Formatter with the Formatter type
-const myCustomCheckmarkFormatter: Formatter = (row, cell, value, columnDef, dataContext) =>
-  value ? `<i class="fa fa-fire" aria-hidden="true"></i>` : '<i class="fa fa-snowflake-o" aria-hidden="true"></i>';
+const myCustomCheckmarkFormatter: Formatter = (row, cell, value, columnDef, dataContext) => {
+  // you can return a string of a object (of type FormatterResultObject), the 2 types are shown below
+  return value ? `<i class="fa fa-fire red" aria-hidden="true"></i>` : { text: '<i class="fa fa-snowflake-o" aria-hidden="true"></i>', addClasses: 'lightblue', toolTip: 'Freezing' };
+};
 
 export class Example2 {
   title = 'Example 2: Formatters';

--- a/doc/github-demo/src/examples/slickgrid/example2.ts
+++ b/doc/github-demo/src/examples/slickgrid/example2.ts
@@ -1,12 +1,13 @@
 import {
   Column,
   FieldType,
+  Formatter,
   Formatters,
   GridOption,
 } from 'aurelia-slickgrid';
 
 // create my custom Formatter with the Formatter type
-const myCustomCheckmarkFormatter = (row, cell, value, columnDef, dataContext) =>
+const myCustomCheckmarkFormatter: Formatter = (row, cell, value, columnDef, dataContext) =>
   value ? `<i class="fa fa-fire" aria-hidden="true"></i>` : '<i class="fa fa-snowflake-o" aria-hidden="true"></i>';
 
 export class Example2 {

--- a/doc/github-demo/src/styles/styles.css
+++ b/doc/github-demo/src/styles/styles.css
@@ -10,6 +10,9 @@ body {
 .faded:hover {
   opacity: 0.5;
 }
+.lightblue {
+  color: lightblue;
+}
 .red {
   color: red;
 }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "lodash.isequal": "^4.5.0",
     "moment": ">=2.18.1",
     "moment-mini": ">=2.18.1",
-    "slickgrid": "github:6pac/SlickGrid",
+    "slickgrid": "^2.4.3",
     "text-encoding-utf-8": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
- using the object return format, you can add css classes directly to the cell instead of having to create separate `<div>`
- since PR in SlickGrid core lib got merged it now accepts tooltip:: 6pac/SlickGrid#330
- also addClasses & removeClasses should be optional types