### PR TITLE
fix(filter): all jquery .on bound event should also be unbound

### DIFF
--- a/aurelia-slickgrid/assets/lib/multiple-select/multiple-select.js
+++ b/aurelia-slickgrid/assets/lib/multiple-select/multiple-select.js
@@ -209,14 +209,15 @@
     this.selectItemName = 'data-name="selectItem' + name + '"';
 
     if (!this.options.keepOpen) {
-      $(document).click(function (e) {
+      $(document).off('click.multiple-select').on('click.multiple-select', function (e) {
         if ($(e.target)[0] === that.$choice[0] ||
           $(e.target).parents('.ms-choice')[0] === that.$choice[0]) {
           return;
         }
         if (($(e.target)[0] === that.$drop[0] ||
           $(e.target).parents('.ms-drop')[0] !== that.$drop[0] && e.target !== $el[0]) &&
-          that.options.isOpen) {
+          that.options.isOpen
+        ) {
           that.close();
         }
       });
@@ -264,8 +265,6 @@
       if (this.options.okButton) {
         this.$okButton = $('<button type="button" class="ms-ok-button">' + this.options.okButtonText + '</button>');
         this.$drop.append(this.$okButton);
-
-
       }
 
       var dropWidth = isNaN(this.options.width) ? this.options.width : this.options.width + 'px';

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/autoCompleteEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/autoCompleteEditor.ts
@@ -90,7 +90,7 @@ export class AutoCompleteEditor implements Editor {
   }
 
   destroy() {
-    this.$input.remove();
+    this.$input.off('keydown.nav').remove();
   }
 
   focus() {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/floatEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/floatEditor.ts
@@ -49,7 +49,7 @@ export class FloatEditor implements Editor {
   }
 
   destroy() {
-    this.$input.remove();
+    this.$input.off('keydown.nav').remove();
   }
 
   focus() {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/integerEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/integerEditor.ts
@@ -47,7 +47,7 @@ export class IntegerEditor implements Editor {
   }
 
   destroy() {
-    this.$input.remove();
+    this.$input.off('keydown.nav').remove();
   }
 
   focus() {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/longTextEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/longTextEditor.ts
@@ -18,7 +18,7 @@ import * as $ from 'jquery';
  */
 @inject(I18N)
 export class LongTextEditor implements Editor {
-  $input: any;
+  $textarea: any;
   $wrapper: any;
   defaultValue: any;
 
@@ -53,12 +53,12 @@ export class LongTextEditor implements Editor {
     const $container = $('body');
 
     this.$wrapper = $(`<div class="slick-large-editor-text editor-${columnId}" />`).appendTo($container);
-    this.$input = $(`<textarea hidefocus rows="5" placeholder="${placeholder}">`).appendTo(this.$wrapper);
+    this.$textarea = $(`<textarea hidefocus rows="5" placeholder="${placeholder}">`).appendTo(this.$wrapper);
 
     // aurelia-slickgrid does not get the focus out event for some reason
     // so register it here
     if (this.hasAutoCommitEdit) {
-      this.$input.on('focusout', () => this.save());
+      this.$textarea.on('focusout', () => this.save());
     }
 
     $(`<div class="editor-footer">
@@ -68,10 +68,10 @@ export class LongTextEditor implements Editor {
 
     this.$wrapper.find('button:first').on('click', () => this.save());
     this.$wrapper.find('button:last').on('click', () => this.cancel());
-    this.$input.on('keydown', this.handleKeyDown.bind(this));
+    this.$textarea.on('keydown', this.handleKeyDown.bind(this));
 
     this.position(this.args && this.args.position);
-    this.$input.focus().select();
+    this.$textarea.focus().select();
   }
 
   handleKeyDown(e: any) {
@@ -105,7 +105,7 @@ export class LongTextEditor implements Editor {
   }
 
   cancel() {
-    this.$input.val(this.defaultValue);
+    this.$textarea.val(this.defaultValue);
     if (this.args && this.args.cancelChanges) {
       this.args.cancelChanges();
     }
@@ -126,20 +126,21 @@ export class LongTextEditor implements Editor {
   }
 
   destroy() {
+    this.$textarea.off('keydown focusout');
     this.$wrapper.remove();
   }
 
   focus() {
-    this.$input.focus();
+    this.$textarea.focus();
   }
 
   loadValue(item: any) {
-    this.$input.val(this.defaultValue = item[this.columnDef.field]);
-    this.$input.select();
+    this.$textarea.val(this.defaultValue = item[this.columnDef.field]);
+    this.$textarea.select();
   }
 
   serializeValue() {
-    return this.$input.val();
+    return this.$textarea.val();
   }
 
   applyValue(item: any, state: any) {
@@ -147,12 +148,12 @@ export class LongTextEditor implements Editor {
   }
 
   isValueChanged() {
-    return (!(this.$input.val() === '' && this.defaultValue == null)) && (this.$input.val() !== this.defaultValue);
+    return (!(this.$textarea.val() === '' && this.defaultValue == null)) && (this.$textarea.val() !== this.defaultValue);
   }
 
   validate(): EditorValidatorOutput {
     if (this.validator) {
-      const value = this.$input && this.$input.val && this.$input.val();
+      const value = this.$textarea && this.$textarea.val && this.$textarea.val();
       const validationResults = this.validator(value, this.args);
       if (!validationResults.valid) {
         return validationResults;

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/sliderEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/sliderEditor.ts
@@ -77,7 +77,7 @@ export class SliderEditor implements Editor {
   }
 
   destroy() {
-    this.$editorElm.remove();
+    this.$editorElm.off('input change mouseup').remove();
   }
 
   focus() {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/textEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/textEditor.ts
@@ -44,7 +44,7 @@ export class TextEditor implements Editor {
   }
 
   destroy() {
-    this.$input.remove();
+    this.$input.off('keydown.nav').remove();
   }
 
   focus() {

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/compoundSliderFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/compoundSliderFilter.ts
@@ -127,7 +127,7 @@ export class CompoundSliderFilter implements Filter {
    */
   destroy() {
     if (this.$filterElm) {
-      this.$filterElm.off('change').remove();
+      this.$filterElm.off('input change').remove();
     }
   }
 

--- a/aurelia-slickgrid/src/examples/slickgrid/custom-inputEditor.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/custom-inputEditor.ts
@@ -45,7 +45,7 @@ export class CustomInputEditor implements Editor {
   }
 
   destroy() {
-    this.$input.remove();
+    this.$input.off('keydown.nav').remove();
   }
 
   focus() {

--- a/doc/github-demo/src/examples/slickgrid/custom-inputEditor.ts
+++ b/doc/github-demo/src/examples/slickgrid/custom-inputEditor.ts
@@ -45,7 +45,7 @@ export class CustomInputEditor implements Editor {
   }
 
   destroy() {
-    this.$input.remove();
+    this.$input.off('keydown.nav').remove();
   }
 
   focus() {


### PR DESCRIPTION
- to remove any weird behaviors but also for gabage collection
- the multiple-select.js was causing some weird behavior, if user would go on the GraphQL example, then choose a different company in the multiple select filter and click away (not on OK button) to simulate a blur, the spinner would never show up. The reason was because there was a click event bound to the document and was never unbound