### PR TITLE
fix(filter): select filter drop doesn't get removed on destroy

### DIFF
--- a/aurelia-slickgrid/src/aurelia-slickgrid/editors/selectEditor.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/editors/selectEditor.ts
@@ -246,6 +246,7 @@ export class SelectEditor implements Editor {
     if (this.$editorElm && this.$editorElm.multipleSelect) {
       this.$editorElm.multipleSelect('close');
       this.$editorElm.remove();
+      $(`[name=${this.elementName}].ms-drop`).remove();
     }
     this.subscriptions = disposeAllSubscriptions(this.subscriptions);
   }

--- a/aurelia-slickgrid/src/aurelia-slickgrid/filters/selectFilter.ts
+++ b/aurelia-slickgrid/src/aurelia-slickgrid/filters/selectFilter.ts
@@ -187,6 +187,7 @@ export class SelectFilter implements Filter {
     if (this.$filterElm) {
       // remove event watcher
       this.$filterElm.off().remove();
+      $(`[name=${this.elementName}].ms-drop`).remove();
 
       // also dispose of all Subscriptions
       this.subscriptions = disposeAllSubscriptions(this.subscriptions);

--- a/aurelia-slickgrid/src/examples/slickgrid/example6.ts
+++ b/aurelia-slickgrid/src/examples/slickgrid/example6.ts
@@ -83,7 +83,10 @@ export class Example6 {
         filterable: true,
         filter: {
           model: Filters.multipleSelect,
-          collection: [{ value: 'acme', label: 'Acme' }, { value: 'abc', label: 'Company ABC' }, { value: 'xyz', label: 'Company XYZ' }]
+          collection: [{ value: 'acme', label: 'Acme' }, { value: 'abc', label: 'Company ABC' }, { value: 'xyz', label: 'Company XYZ' }],
+          filterOptions: {
+            filter: true // adds a filter on top of the multi-select dropdown
+          }
         }
       },
       { id: 'billing.address.street', field: 'billing.address.street', headerKey: 'BILLING.ADDRESS.STREET', width: 60, filterable: true, sortable: true },

--- a/doc/github-demo/src/examples/slickgrid/example6.ts
+++ b/doc/github-demo/src/examples/slickgrid/example6.ts
@@ -83,7 +83,10 @@ export class Example6 {
         filterable: true,
         filter: {
           model: Filters.multipleSelect,
-          collection: [{ value: 'acme', label: 'Acme' }, { value: 'abc', label: 'Company ABC' }, { value: 'xyz', label: 'Company XYZ' }]
+          collection: [{ value: 'acme', label: 'Acme' }, { value: 'abc', label: 'Company ABC' }, { value: 'xyz', label: 'Company XYZ' }],
+          filterOptions: {
+            filter: true // adds a filter on top of the multi-select dropdown
+          }
         }
       },
       { id: 'billing.address.street', field: 'billing.address.street', headerKey: 'BILLING.ADDRESS.STREET', width: 60, filterable: true, sortable: true },


### PR DESCRIPTION
- since the `.ms-drop` element is pushed to the body (container) because of some SlickGrid limitation. So because it exist in the html body, we need to remove the drop in a separate jquery remove call