### PR TITLE
fix(queryField): queryFieldFilter and queryFieldSorter have precedence

### DIFF
--- a/src/aurelia-slickgrid/models/column.interface.ts
+++ b/src/aurelia-slickgrid/models/column.interface.ts
@@ -157,13 +157,22 @@ export interface Column {
   /** The previous column width in pixels (number only) */
   previousWidth?: number;
 
-  /** A query field which, when specified, will be used to query filterBy/orderBy and has precedence over field property to query. */
+  /**
+   * Useful when you want to display a certain field to the UI, but you want to use another field to query when Filtering/Sorting.
+   * Please note that it has higher precendence over the "field" property.
+   */
   queryField?: string;
 
-  /** Similar to "queryField" but only used with Filtering. Useful when you want to display a certain field to the UI, but you want to use another field to query for Filtering. */
+  /**
+   * Similar to "queryField" but only used when Filtering (please note that it has higher precendence over "queryField").
+   * Useful when you want to display a certain field to the UI, but you want to use another field to query for Filtering.
+   */
   queryFieldFilter?: string;
 
-  /** Similar to "queryField" but only used with Sorting. Useful when you want to display a certain field to the UI, but you want to use another field to query for Sorting. */
+  /**
+   * Similar to "queryField" but only used when Sorting (please note that it has higher precendence over "queryField").
+   * Useful when you want to display a certain field to the UI, but you want to use another field to query for Sorting.
+   */
   queryFieldSorter?: string;
 
   /** Is the column resizable, can we make it wider/thinner? A resize cursor will show on the right side of the column when enabled. */

--- a/src/aurelia-slickgrid/services/__tests__/graphql.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/graphql.service.spec.ts
@@ -821,8 +821,8 @@ describe('CollectionService', () => {
     });
 
     it('should return a query using a different field to query when the column has a "queryFieldFilter" defined in its definition', () => {
-      const expectation = `query{users(first:10, offset:0, filterBy:[{field:isFemale, operator:EQ, value:"female"}]) { totalCount,nodes{ id,company,gender,name } }}`;
-      const mockColumn = { id: 'gender', field: 'gender', queryFieldFilter: 'isFemale' } as Column;
+      const expectation = `query{users(first:10, offset:0, filterBy:[{field:hasPriority, operator:EQ, value:"female"}]) { totalCount,nodes{ id,company,gender,name } }}`;
+      const mockColumn = { id: 'gender', field: 'gender', queryField: 'isAfter', queryFieldFilter: 'hasPriority' } as Column;
       const mockColumnFilters = {
         gender: { columnId: 'gender', columnDef: mockColumn, searchTerms: ['female'], operator: 'EQ' },
       } as ColumnFilters;
@@ -914,7 +914,7 @@ describe('CollectionService', () => {
                             totalCount,nodes{ id, company, gender, name } }}`;
       const mockColumnSort = [
         { columnId: 'gender', sortCol: { id: 'gender', field: 'gender' }, sortAsc: false },
-        { columnId: 'name', sortCol: { id: 'name', field: 'name', queryFieldSorter: 'lastName' }, sortAsc: true }
+        { columnId: 'name', sortCol: { id: 'name', field: 'name', queryField: 'isAfter', queryFieldSorter: 'lastName' }, sortAsc: true }
       ] as ColumnSort[];
 
       service.init(serviceOptions, paginationOptions, gridStub);

--- a/src/aurelia-slickgrid/services/filter.service.ts
+++ b/src/aurelia-slickgrid/services/filter.service.ts
@@ -257,7 +257,7 @@ export class FilterService {
       }
 
       const dataKey = columnDef.dataKey;
-      const fieldName = columnDef.queryField || columnDef.queryFieldFilter || columnDef.field || '';
+      const fieldName = columnDef.queryFieldFilter || columnDef.queryField || columnDef.field || '';
       const fieldType = columnDef.type || FieldType.string;
       const filterSearchType = (columnDef.filterSearchType) ? columnDef.filterSearchType : null;
       let cellValue = item[fieldName];

--- a/src/aurelia-slickgrid/services/graphql.service.ts
+++ b/src/aurelia-slickgrid/services/graphql.service.ts
@@ -366,7 +366,7 @@ export class GraphqlService implements BackendService {
           throw new Error('[GraphQL Service]: Something went wrong in trying to get the column definition of the specified filter (or preset filters). Did you make a typo on the filter columnId?');
         }
 
-        const fieldName = columnDef.queryField || columnDef.queryFieldFilter || columnDef.field || columnDef.name || '';
+        const fieldName = columnDef.queryFieldFilter || columnDef.queryField || columnDef.field || columnDef.name || '';
         const searchTerms = columnFilter && columnFilter.searchTerms || [];
         let fieldSearchValue = (Array.isArray(searchTerms) && searchTerms.length === 1) ? searchTerms[0] : '';
         if (typeof fieldSearchValue === 'undefined') {
@@ -467,7 +467,7 @@ export class GraphqlService implements BackendService {
         const columnDef = this._columnDefinitions.find((column: Column) => column.id === sorter.columnId);
 
         graphqlSorters.push({
-          field: columnDef ? ((columnDef.queryField || columnDef.queryFieldSorter || columnDef.field) + '') : (sorter.columnId + ''),
+          field: columnDef ? ((columnDef.queryFieldSorter || columnDef.queryField || columnDef.field) + '') : (sorter.columnId + ''),
           direction: sorter.direction
         });
 
@@ -497,7 +497,7 @@ export class GraphqlService implements BackendService {
             });
 
             graphqlSorters.push({
-              field: (column.sortCol.queryField || column.sortCol.queryFieldSorter || column.sortCol.field) + '',
+              field: (column.sortCol.queryFieldSorter || column.sortCol.queryField || column.sortCol.field) + '',
               direction: column.sortAsc ? SortDirection.ASC : SortDirection.DESC
             });
           }

--- a/src/aurelia-slickgrid/services/grid-odata.service.ts
+++ b/src/aurelia-slickgrid/services/grid-odata.service.ts
@@ -210,7 +210,7 @@ export class GridOdataService implements BackendService {
           throw new Error('[Backend Service API]: Something went wrong in trying to get the column definition of the specified filter (or preset filters). Did you make a typo on the filter columnId?');
         }
 
-        let fieldName = columnDef.queryField || columnDef.queryFieldFilter || columnDef.field || columnDef.name || '';
+        let fieldName = columnDef.queryFieldFilter || columnDef.queryField || columnDef.field || columnDef.name || '';
         const fieldType = columnDef.type || 'string';
         const searchTerms = (columnFilter ? columnFilter.searchTerms : null) || [];
         let fieldSearchValue = (Array.isArray(searchTerms) && searchTerms.length === 1) ? searchTerms[0] : '';
@@ -363,7 +363,7 @@ export class GridOdataService implements BackendService {
         if (sortColumns) {
           for (const column of sortColumns) {
             if (column.sortCol) {
-              let fieldName = (column.sortCol.queryField || column.sortCol.queryFieldSorter || column.sortCol.field || column.sortCol.id) + '';
+              let fieldName = (column.sortCol.queryFieldSorter || column.sortCol.queryField || column.sortCol.field || column.sortCol.id) + '';
               let columnFieldName = (column.sortCol.field || column.sortCol.id) + '';
               if (this.odataService.options.caseType === CaseType.pascalCase) {
                 fieldName = String.titleCase(fieldName);

--- a/src/aurelia-slickgrid/services/sort.service.ts
+++ b/src/aurelia-slickgrid/services/sort.service.ts
@@ -257,7 +257,7 @@ export class SortService {
           const columnSortObj = sortColumns[i];
           if (columnSortObj && columnSortObj.sortCol) {
             const sortDirection = columnSortObj.sortAsc ? SortDirectionNumber.asc : SortDirectionNumber.desc;
-            const sortField = columnSortObj.sortCol.queryField || columnSortObj.sortCol.queryFieldSorter || columnSortObj.sortCol.field;
+            const sortField = columnSortObj.sortCol.queryFieldSorter || columnSortObj.sortCol.queryField || columnSortObj.sortCol.field;
             const fieldType = columnSortObj.sortCol.type || FieldType.string;
             let value1 = dataRow1[sortField];
             let value2 = dataRow2[sortField];


### PR DESCRIPTION
- both "queryFieldFilter" and "queryFieldSorter" should have precedence over "queryField", then "field". For example (1- "queryFieldFilter", if not found then 2- "queryField", if not found then "field"