### PR TITLE
fix(gridMenu): external grid menu was not triggering

### DIFF
--- a/src/aurelia-slickgrid/extensions/__tests__/autoTooltipExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/autoTooltipExtension.spec.ts
@@ -46,7 +46,10 @@ describe('autoTooltipExtension', () => {
       const pluginSpy = jest.spyOn(SharedService.prototype.grid, 'registerPlugin');
 
       const instance = extension.register();
+      const addonInstance = extension.getAddonInstance();
 
+      expect(instance).toBeTruthy();
+      expect(instance).toEqual(addonInstance);
       expect(mockAddon).toHaveBeenCalledWith({});
       expect(pluginSpy).toHaveBeenCalledWith(instance);
     });

--- a/src/aurelia-slickgrid/extensions/__tests__/cellExternalCopyManagerExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/cellExternalCopyManagerExtension.spec.ts
@@ -90,7 +90,10 @@ describe('cellExternalCopyManagerExtension', () => {
       const onRegisteredSpy = jest.spyOn(SharedService.prototype.gridOptions.excelCopyBufferOptions, 'onExtensionRegistered');
 
       const instance = extension.register();
+      const addonInstance = extension.getAddonInstance();
 
+      expect(instance).toBeTruthy();
+      expect(instance).toEqual(addonInstance);
       expect(onRegisteredSpy).toHaveBeenCalledWith(instance);
       expect(pluginSpy).toHaveBeenCalledWith(instance);
       expect(mockSelectionModel).toHaveBeenCalled();

--- a/src/aurelia-slickgrid/extensions/__tests__/checkboxSelectorExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/checkboxSelectorExtension.spec.ts
@@ -70,7 +70,10 @@ describe('checkboxSelectorExtension', () => {
 
       const instance = extension.create(columnsMock, gridOptionsMock);
       const selectionModel = extension.register();
+      const addonInstance = extension.getAddonInstance();
 
+      expect(instance).toBeTruthy();
+      expect(instance).toEqual(addonInstance);
       expect(selectionModel).not.toBeNull();
       expect(mockAddon).toHaveBeenCalledWith({});
       expect(mockSelectionModel).toHaveBeenCalledWith({});

--- a/src/aurelia-slickgrid/extensions/__tests__/columnPickerExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/columnPickerExtension.spec.ts
@@ -84,8 +84,10 @@ describe('columnPickerExtension', () => {
     it('should register the addon', () => {
       const onRegisteredSpy = jest.spyOn(SharedService.prototype.gridOptions.columnPicker, 'onExtensionRegistered');
       const instance = extension.register();
+      const addonInstance = extension.getAddonInstance();
 
-      expect(instance).not.toBeNull();
+      expect(instance).toBeTruthy();
+      expect(instance).toEqual(addonInstance);
       expect(onRegisteredSpy).toHaveBeenCalledWith(instance);
       expect(mockAddon).toHaveBeenCalledWith(columnsMock, gridStub, gridOptionsMock);
     });

--- a/src/aurelia-slickgrid/extensions/__tests__/draggableGroupingExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/draggableGroupingExtension.spec.ts
@@ -65,6 +65,10 @@ describe('draggableGroupingExtension', () => {
       const instance = extension.create(gridOptionsMock);
       const addon = extension.register();
 
+      const addonInstance = extension.getAddonInstance();
+
+      expect(instance).toBeTruthy();
+      expect(instance).toEqual(addonInstance);
       expect(addon).not.toBeNull();
       expect(mockAddon).toHaveBeenCalledWith({
         deleteIconCssClass: 'class',

--- a/src/aurelia-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
@@ -168,8 +168,10 @@ describe('gridMenuExtension', () => {
     it('should register the addon', () => {
       const onRegisteredSpy = jest.spyOn(SharedService.prototype.gridOptions.gridMenu, 'onExtensionRegistered');
       const instance = extension.register();
+      const addonInstance = extension.getAddonInstance();
 
-      expect(instance).not.toBeNull();
+      expect(instance).toBeTruthy();
+      expect(instance).toEqual(addonInstance);
       expect(onRegisteredSpy).toHaveBeenCalledWith(instance);
       expect(mockAddon).toHaveBeenCalledWith(columnsMock, gridStub, gridOptionsMock);
     });

--- a/src/aurelia-slickgrid/extensions/__tests__/groupItemMetaProviderExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/groupItemMetaProviderExtension.spec.ts
@@ -40,16 +40,10 @@ describe('groupItemMetaProviderExtension', () => {
       const pluginSpy = jest.spyOn(SharedService.prototype.grid, 'registerPlugin');
 
       const instance = extension.register();
+      const addonInstance = extension.getAddonInstance();
 
-      expect(sharedService.groupItemMetadataProvider).toEqual(instance);
-      expect(pluginSpy).toHaveBeenCalledWith(instance);
-    });
-
-    it('should register the addon', () => {
-      const pluginSpy = jest.spyOn(SharedService.prototype.grid, 'registerPlugin');
-
-      const instance = extension.register();
-
+      expect(instance).toBeTruthy();
+      expect(instance).toEqual(addonInstance);
       expect(sharedService.groupItemMetadataProvider).toEqual(instance);
       expect(pluginSpy).toHaveBeenCalledWith(instance);
     });

--- a/src/aurelia-slickgrid/extensions/__tests__/headerButtonExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/headerButtonExtension.spec.ts
@@ -67,7 +67,10 @@ describe('headerButtonExtension', () => {
       const pluginSpy = jest.spyOn(SharedService.prototype.grid, 'registerPlugin');
 
       const instance = extension.register();
+      const addonInstance = extension.getAddonInstance();
 
+      expect(instance).toBeTruthy();
+      expect(instance).toEqual(addonInstance);
       expect(mockAddon).toHaveBeenCalledWith({
         onCommand: expect.anything(),
         onExtensionRegistered: expect.anything(),

--- a/src/aurelia-slickgrid/extensions/__tests__/headerMenuExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/headerMenuExtension.spec.ts
@@ -156,7 +156,10 @@ describe('headerMenuExtension', () => {
       const onRegisteredSpy = jest.spyOn(SharedService.prototype.gridOptions.headerMenu, 'onExtensionRegistered');
 
       const instance = extension.register();
+      const addonInstance = extension.getAddonInstance();
 
+      expect(instance).toBeTruthy();
+      expect(instance).toEqual(addonInstance);
       expect(mockAddon).toHaveBeenCalledWith({
         autoAlignOffset: 12,
         minWidth: 140,

--- a/src/aurelia-slickgrid/extensions/__tests__/rowDetailViewExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/rowDetailViewExtension.spec.ts
@@ -242,7 +242,10 @@ describe('rowDetailViewExtension', () => {
 
       const instance = extension.create(columnsMock, gridOptionsMock);
       extension.register();
+      const addonInstance = extension.getAddonInstance();
 
+      expect(instance).toBeTruthy();
+      expect(instance).toEqual(addonInstance);
       expect(onRegisteredSpy).toHaveBeenCalledWith(instance);
       expect(mockSelectionModel).toHaveBeenCalledWith({ selectActiveRow: true });
       expect(pluginSpy).toHaveBeenCalledWith(instance);

--- a/src/aurelia-slickgrid/extensions/__tests__/rowMoveManagerExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/rowMoveManagerExtension.spec.ts
@@ -70,7 +70,10 @@ describe('rowMoveManagerExtension', () => {
       const pluginSpy = jest.spyOn(SharedService.prototype.grid, 'registerPlugin');
 
       const instance = extension.register();
+      const addonInstance = extension.getAddonInstance();
 
+      expect(instance).toBeTruthy();
+      expect(instance).toEqual(addonInstance);
       expect(mockAddon).toHaveBeenCalledWith({
         onExtensionRegistered: expect.anything(),
         onBeforeMoveRows: expect.anything(),

--- a/src/aurelia-slickgrid/extensions/__tests__/rowSelectionExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/rowSelectionExtension.spec.ts
@@ -48,7 +48,10 @@ describe('rowSelectionExtension', () => {
       const pluginSpy = jest.spyOn(SharedService.prototype.grid, 'setSelectionModel');
 
       const instance = extension.register();
+      const addonInstance = extension.getAddonInstance();
 
+      expect(instance).toBeTruthy();
+      expect(instance).toEqual(addonInstance);
       expect(mockAddon).toHaveBeenCalledWith({});
       expect(pluginSpy).toHaveBeenCalledWith(instance);
     });

--- a/src/aurelia-slickgrid/extensions/autoTooltipExtension.ts
+++ b/src/aurelia-slickgrid/extensions/autoTooltipExtension.ts
@@ -19,6 +19,11 @@ export class AutoTooltipExtension implements Extension {
     }
   }
 
+  /** Get the instance of the SlickGrid addon (control or plugin). */
+  getAddonInstance() {
+    return this._addon;
+  }
+
   register(): any {
     if (this.sharedService && this.sharedService.grid && this.sharedService.gridOptions) {
       // dynamically import the SlickGrid plugin (addon) with RequireJS

--- a/src/aurelia-slickgrid/extensions/cellExternalCopyManagerExtension.ts
+++ b/src/aurelia-slickgrid/extensions/cellExternalCopyManagerExtension.ts
@@ -54,6 +54,11 @@ export class CellExternalCopyManagerExtension implements Extension {
     }
   }
 
+  /** Get the instance of the SlickGrid addon (control or plugin). */
+  getAddonInstance() {
+    return this._addon;
+  }
+
   /** Register the 3rd party addon (plugin) */
   register(): any {
     if (this.sharedService && this.sharedService.grid && this.sharedService.gridOptions) {

--- a/src/aurelia-slickgrid/extensions/checkboxSelectorExtension.ts
+++ b/src/aurelia-slickgrid/extensions/checkboxSelectorExtension.ts
@@ -45,6 +45,11 @@ export class CheckboxSelectorExtension implements Extension {
     return null;
   }
 
+  /** Get the instance of the SlickGrid addon (control or plugin). */
+  getAddonInstance() {
+    return this._addon;
+  }
+
   register(rowSelectionPlugin?: any) {
     if (this.sharedService && this.sharedService.grid && this.sharedService.gridOptions) {
       // the plugin has to be created BEFORE the grid (else it behaves oddly), but we can only watch grid events AFTER the grid is created

--- a/src/aurelia-slickgrid/extensions/columnPickerExtension.ts
+++ b/src/aurelia-slickgrid/extensions/columnPickerExtension.ts
@@ -32,6 +32,11 @@ export class ColumnPickerExtension implements Extension {
     }
   }
 
+  /** Get the instance of the SlickGrid addon (control or plugin). */
+  getAddonInstance() {
+    return this._addon;
+  }
+
   register(): any {
     if (this.sharedService && this.sharedService.grid && this.sharedService.gridOptions) {
       // dynamically import the SlickGrid plugin (addon) with RequireJS

--- a/src/aurelia-slickgrid/extensions/draggableGroupingExtension.ts
+++ b/src/aurelia-slickgrid/extensions/draggableGroupingExtension.ts
@@ -46,6 +46,11 @@ export class DraggableGroupingExtension implements Extension {
     return null;
   }
 
+  /** Get the instance of the SlickGrid addon (control or plugin). */
+  getAddonInstance() {
+    return this._addon;
+  }
+
   register(): any {
     if (this.sharedService && this.sharedService.grid && this.sharedService.gridOptions) {
       this.sharedService.grid.registerPlugin(this._addon);

--- a/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
@@ -66,6 +66,11 @@ export class GridMenuExtension implements Extension {
     }
   }
 
+  /** Get the instance of the SlickGrid addon (control or plugin). */
+  getAddonInstance() {
+    return this._addon;
+  }
+
   /** Show the Grid Menu typically from a button click since we need to know the event */
   showGridMenu(e: Event) {
     this._addon.showGridMenu(e);

--- a/src/aurelia-slickgrid/extensions/groupItemMetaProviderExtension.ts
+++ b/src/aurelia-slickgrid/extensions/groupItemMetaProviderExtension.ts
@@ -15,6 +15,11 @@ export class GroupItemMetaProviderExtension implements Extension {
     }
   }
 
+  /** Get the instance of the SlickGrid addon (control or plugin). */
+  getAddonInstance() {
+    return this._addon;
+  }
+
   /** register the group item metadata provider to add expand/collapse group handlers */
   register(): any {
     if (this.sharedService && this.sharedService.grid) {

--- a/src/aurelia-slickgrid/extensions/headerButtonExtension.ts
+++ b/src/aurelia-slickgrid/extensions/headerButtonExtension.ts
@@ -29,6 +29,11 @@ export class HeaderButtonExtension implements Extension {
     }
   }
 
+  /** Get the instance of the SlickGrid addon (control or plugin). */
+  getAddonInstance() {
+    return this._addon;
+  }
+
   // Header Button Plugin
   register(): any {
     if (this.sharedService && this.sharedService.grid && this.sharedService.gridOptions) {

--- a/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
@@ -56,6 +56,11 @@ export class HeaderMenuExtension implements Extension {
     }
   }
 
+  /** Get the instance of the SlickGrid addon (control or plugin). */
+  getAddonInstance() {
+    return this._addon;
+  }
+
   /**
    * Create the Header Menu and expose all the available hooks that user can subscribe (onCommand, onBeforeMenuShow, ...)
    * @param grid

--- a/src/aurelia-slickgrid/extensions/rowDetailViewExtension.ts
+++ b/src/aurelia-slickgrid/extensions/rowDetailViewExtension.ts
@@ -120,6 +120,11 @@ export class RowDetailViewExtension implements Extension {
     return null;
   }
 
+  /** Get the instance of the SlickGrid addon (control or plugin). */
+  getAddonInstance() {
+    return this._addon;
+  }
+
   register(rowSelectionPlugin?: any) {
     if (this.sharedService && this.sharedService.grid && this.sharedService.gridOptions) {
       // the plugin has to be created BEFORE the grid (else it behaves oddly), but we can only watch grid events AFTER the grid is created

--- a/src/aurelia-slickgrid/extensions/rowMoveManagerExtension.ts
+++ b/src/aurelia-slickgrid/extensions/rowMoveManagerExtension.ts
@@ -29,6 +29,11 @@ export class RowMoveManagerExtension implements Extension {
     }
   }
 
+  /** Get the instance of the SlickGrid addon (control or plugin). */
+  getAddonInstance() {
+    return this._addon;
+  }
+
   register(rowSelectionPlugin?: any): any {
     if (this.sharedService && this.sharedService.grid && this.sharedService.gridOptions) {
       // dynamically import the SlickGrid plugin (addon) with RequireJS

--- a/src/aurelia-slickgrid/extensions/rowSelectionExtension.ts
+++ b/src/aurelia-slickgrid/extensions/rowSelectionExtension.ts
@@ -19,6 +19,11 @@ export class RowSelectionExtension implements Extension {
     }
   }
 
+  /** Get the instance of the SlickGrid addon (control or plugin). */
+  getAddonInstance() {
+    return this._addon;
+  }
+
   register(): any {
     if (this.sharedService && this.sharedService.grid && this.sharedService.gridOptions) {
       // dynamically import the SlickGrid plugin (addon) with RequireJS

--- a/src/aurelia-slickgrid/models/extension.interface.ts
+++ b/src/aurelia-slickgrid/models/extension.interface.ts
@@ -1,4 +1,13 @@
 export interface Extension {
+  /** Dispose of the extension */
   dispose: () => void;
+
+  /** Get the instance of the SlickGrid addon (control or plugin). */
+  getAddonInstance: () => any;
+
+  /**
+   * Register the SlickGrid addon (control or plugin) and optionally expose all the available SlickEvent hooks that user can subscribe.
+   * Note that not every SlickGrid addons have SlickEvent
+   */
   register: () => any;
 }

--- a/src/aurelia-slickgrid/services/__tests__/extension.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/extension.service.spec.ts
@@ -40,6 +40,7 @@ const gridStub = {
 const extensionStub = {
   create: jest.fn(),
   dispose: jest.fn(),
+  getAddonInstance: jest.fn(),
   register: jest.fn()
 };
 const extensionGroupItemMetaStub = { ...extensionStub };
@@ -140,13 +141,31 @@ describe('ExtensionService', () => {
 
     it('should return extension addon when method is called with a valid and instantiated addon', () => {
       const instanceMock = { onColumnsChanged: jest.fn() };
-      const extensionMock = { name: ExtensionName.columnPicker, addon: instanceMock, instance: instanceMock, class: null } as ExtensionModel;
+      const extensionMock = { name: ExtensionName.columnPicker, addon: instanceMock, instance: instanceMock, class: {} } as ExtensionModel;
       const spy = jest.spyOn(service, 'getExtensionByName').mockReturnValue(extensionMock);
 
       const output = service.getSlickgridAddonInstance(ExtensionName.columnPicker);
 
       expect(spy).toHaveBeenCalled();
       expect(output).toEqual(instanceMock);
+    });
+
+    it('should register any addon and expect the instance returned from "getExtensionByName" equal the one returned from "getSlickgridAddonInstance"', () => {
+      const instanceMock = { onColumnsChanged: jest.fn() };
+      const gridOptionsMock = { enableGridMenu: true } as GridOption;
+      const extSpy = jest.spyOn(extensionGridMenuStub, 'register').mockReturnValue(instanceMock);
+      const getAddonSpy = jest.spyOn(extensionGridMenuStub, 'getAddonInstance').mockReturnValue(instanceMock);
+      const gridSpy = jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
+
+      service.bindDifferentExtensions();
+      const output = service.getExtensionByName(ExtensionName.gridMenu);
+      const instance = service.getSlickgridAddonInstance(ExtensionName.gridMenu);
+
+      expect(gridSpy).toHaveBeenCalled();
+      expect(getAddonSpy).toHaveBeenCalled();
+      expect(extSpy).toHaveBeenCalled();
+      expect(output.instance).toEqual(instance);
+      expect(output).toEqual({ name: ExtensionName.gridMenu, addon: instanceMock, instance: instanceMock, class: extensionGridMenuStub } as ExtensionModel);
     });
   });
 
@@ -214,13 +233,17 @@ describe('ExtensionService', () => {
     it('should register the GridMenu addon when "enableGridMenu" is set in the grid options', () => {
       const gridOptionsMock = { enableGridMenu: true } as GridOption;
       const extSpy = jest.spyOn(extensionGridMenuStub, 'register').mockReturnValue(instanceMock);
+      const getAddonSpy = jest.spyOn(extensionGridMenuStub, 'getAddonInstance').mockReturnValue(instanceMock);
       const gridSpy = jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
 
       service.bindDifferentExtensions();
       const output = service.getExtensionByName(ExtensionName.gridMenu);
+      const instance = service.getSlickgridAddonInstance(ExtensionName.gridMenu);
 
       expect(gridSpy).toHaveBeenCalled();
+      expect(getAddonSpy).toHaveBeenCalled();
       expect(extSpy).toHaveBeenCalled();
+      expect(output.instance).toEqual(instance);
       expect(output).toEqual({ name: ExtensionName.gridMenu, addon: instanceMock, instance: instanceMock, class: extensionGridMenuStub } as ExtensionModel);
     });
 
@@ -363,8 +386,13 @@ describe('ExtensionService', () => {
   });
 
   describe('createExtensionsBeforeGridCreation method', () => {
+    let instanceMock;
+
+    beforeEach(() => {
+      instanceMock = { onColumnsChanged: () => { } };
+    });
+
     it('should call checkboxSelectorExtension create when "enableCheckboxSelector" is set in the grid options provided', () => {
-      const instanceMock = { onColumnsChanged: () => { } };
       const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
       const gridOptionsMock = { enableCheckboxSelector: true } as GridOption;
       const extSpy = jest.spyOn(extensionStub, 'create').mockReturnValue(instanceMock);
@@ -376,7 +404,6 @@ describe('ExtensionService', () => {
     });
 
     it('should call rowDetailViewExtension create when "enableRowDetailView" is set in the grid options provided', () => {
-      const instanceMock = { onColumnsChanged: () => { } };
       const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
       const gridOptionsMock = { enableRowDetailView: true } as GridOption;
       const extSpy = jest.spyOn(extensionStub, 'create').mockReturnValue(instanceMock);
@@ -388,7 +415,6 @@ describe('ExtensionService', () => {
     });
 
     it('should call draggableGroupingExtension create when "enableDraggableGrouping" is set in the grid options provided', () => {
-      const instanceMock = { onColumnsChanged: () => { } };
       const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
       const gridOptionsMock = { enableDraggableGrouping: true } as GridOption;
       const extSpy = jest.spyOn(extensionStub, 'create').mockReturnValue(instanceMock);

--- a/src/aurelia-slickgrid/services/extension.service.ts
+++ b/src/aurelia-slickgrid/services/extension.service.ts
@@ -108,7 +108,10 @@ export class ExtensionService {
    */
   getSlickgridAddonInstance(name: ExtensionName): any {
     const extension = this.getExtensionByName(name);
-    if (extension && (extension.instance || extension.addon)) {
+    if (extension && extension.class && (extension.instance || extension.addon)) {
+      if (extension.class && extension.class.getAddonInstance) {
+        return extension.class.getAddonInstance();
+      }
       return extension.instance;
     }
     return null;


### PR DESCRIPTION
- add a new "getAddonInstance" method to all extension
- this new method returns the addon instance which is typically the same as the one returned from the register() method, but can be called at any time