### PR TITLE
fix(backend): clear empty filter by header menu not stopping spinner

### DIFF
--- a/cypress/integration/example1.spec.js
+++ b/cypress/integration/example1.spec.js
@@ -1,5 +1,3 @@
-/// <reference types="Cypress" />
-
 describe('Example 1 - Basic Grids', () => {
   const titles = ['Title', 'Duration (days)', '% Complete', 'Start', 'Finish', 'Effort Driven'];
 

--- a/cypress/integration/example6.spec.js
+++ b/cypress/integration/example6.spec.js
@@ -1,5 +1,3 @@
-/// <reference types="Cypress" />
-
 describe('Example 6 - GraphQL Grid', () => {
   it('should display Example 6 title', () => {
     cy.visit(`${Cypress.config('baseExampleUrl')}/example6`);
@@ -66,6 +64,57 @@ describe('Example 6 - GraphQL Grid', () => {
       .should(($span) => {
         const text = $span.text().replace(/\s/g, ''); // remove all white spaces
         expect(text).to.eq('query{users(first:30,offset:0,orderBy:[{field:"name",direction:ASC},{field:"company",direction:DESC}],filterBy:[{field:"gender",operator:EQ,value:"male"},{field:"name",operator:Contains,value:"JohnDoe"},{field:"company",operator:IN,value:"xyz"}],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{street,zip}}}}}');
+      });
+  });
+
+  it('should clear a single filter, that is not empty, by the header menu and expect query change', () => {
+    cy.get('#grid6')
+      .find('.slick-header-column:nth(1)')
+      .trigger('mouseover')
+      .children('.slick-header-menubutton')
+      .should('be.hidden')
+      .invoke('show')
+      .click();
+
+    cy.get('.slick-header-menu')
+      .should('be.visible')
+      .children('.slick-header-menuitem:nth-child(4)')
+      .children('.slick-header-menucontent')
+      .should('contain', 'Remove Filter')
+      .click();
+
+    // wait for the query to finish
+    cy.get('[data-test=status]').should('contain', 'done');
+
+    cy.get('[data-test=graphql-query-result]')
+      .should(($span) => {
+        const text = $span.text().replace(/\s/g, ''); // remove all white spaces
+        expect(text).to.eq('query{users(first:30,offset:0,orderBy:[{field:"name",direction:ASC},{field:"company",direction:DESC}],filterBy:[{field:"gender",operator:EQ,value:"male"},{field:"company",operator:IN,value:"xyz"}],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{street,zip}}}}}');
+      });
+  });
+
+  it('should try clearing same filter, which is now empty, by the header menu and expect same query without loading spinner', () => {
+    cy.get('#grid6')
+      .find('.slick-header-column:nth(1)')
+      .trigger('mouseover')
+      .children('.slick-header-menubutton')
+      .invoke('show')
+      .click();
+
+    cy.get('.slick-header-menu')
+      .should('be.visible')
+      .children('.slick-header-menuitem:nth-child(4)')
+      .children('.slick-header-menucontent')
+      .should('contain', 'Remove Filter')
+      .click();
+
+    // wait for the query to finish
+    cy.get('[data-test=status]').should('contain', 'done');
+
+    cy.get('[data-test=graphql-query-result]')
+      .should(($span) => {
+        const text = $span.text().replace(/\s/g, ''); // remove all white spaces
+        expect(text).to.eq('query{users(first:30,offset:0,orderBy:[{field:"name",direction:ASC},{field:"company",direction:DESC}],filterBy:[{field:"gender",operator:EQ,value:"male"},{field:"company",operator:IN,value:"xyz"}],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{street,zip}}}}}');
       });
   });
 

--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -1,5 +1,3 @@
-/// <reference types="Cypress" />
-
 describe('Home Page', () => {
   it('should display Home Page', () => {
     cy.visit(`${Cypress.config('baseUrl')}/home`);

--- a/src/aurelia-slickgrid/services/filter.service.ts
+++ b/src/aurelia-slickgrid/services/filter.service.ts
@@ -173,6 +173,14 @@ export class FilterService {
   }
 
   clearFilterByColumnId(event: Event, columnId: number | string) {
+    // get current column filter before clearing, this allow us to know if the filter was empty prior to calling the clear filter
+    const currentColumnFilters = Object.keys(this._columnFilters) as ColumnFilter[];
+    let currentColFilter: ColumnFilter;
+    if (Array.isArray(currentColumnFilters)) {
+      currentColFilter = currentColumnFilters.find((name) => name === columnId);
+    }
+
+    // find the filter object and call its clear method with true (the argument tells the method it was called by a clear filter)
     const colFilter: Filter = this._filtersMetadata.find((filter: Filter) => filter.columnDef.id === columnId);
     if (colFilter && colFilter.clear) {
       colFilter.clear(true);
@@ -181,10 +189,12 @@ export class FilterService {
     let emitter: EmitterType = EmitterType.local;
     const isBackendApi = this._gridOptions && this._gridOptions.backendServiceApi || false;
 
-    // when using a backend service, we need to manually trigger a filter change
+    // when using a backend service, we need to manually trigger a filter change but only if the filter was previously filled
     if (isBackendApi) {
       emitter = EmitterType.remote;
-      this.onBackendFilterChange(event as KeyboardEvent, { grid: this._grid, columnFilters: this._columnFilters });
+      if (currentColFilter) {
+        this.onBackendFilterChange(event as KeyboardEvent, { grid: this._grid, columnFilters: this._columnFilters });
+      }
     }
 
     // emit an event when filter is cleared

--- a/test/tsconfig.spec.json
+++ b/test/tsconfig.spec.json
@@ -5,6 +5,7 @@
     "outDir": "../out-tsc/spec",
     "baseUrl": "./",
     "types": [
+      "cypress",
       "jest",
       "jest-extended",
       "jquery",


### PR DESCRIPTION
- when trying to clear a filter that was empty, there is no reason to trigger a filter change
- to replicate the issue, you could go to the OData or GraphQL example and hover over a column with an empty filter, then choose "Clear Filter" from the header menu. The spinner should stop