### PR TITLE
fix(presets): Grid State & Presets stopped working for columns

### DIFF
--- a/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -232,7 +232,7 @@ export class AureliaSlickgridCustomElement {
       this.bindBackendCallbackFunctions(this.gridOptions);
     }
 
-    this.gridStateService.init(this.grid, this.extensionService, this.filterService, this.sortService);
+    this.gridStateService.init(this.grid);
 
     // create the Aurelia Grid Instance with reference to all Services
     const aureliaElementInstance: AureliaGridInstance = {

--- a/src/aurelia-slickgrid/extensions/__tests__/headerMenuExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/headerMenuExtension.spec.ts
@@ -17,6 +17,7 @@ const filterServiceStub = {
 
 const sortServiceStub = {
   clearSorting: jest.fn(),
+  emitSortChanged: jest.fn(),
   getCurrentColumnSorts: jest.fn(),
   onBackendSortChanged: jest.fn(),
   onLocalSortChanged: jest.fn(),
@@ -56,6 +57,7 @@ Slick.Plugins = {
 describe('headerMenuExtension', () => {
   const columnsMock: Column[] = [{ id: 'field1', field: 'field1', width: 100, headerKey: 'TITLE' }, { id: 'field2', field: 'field2', width: 75 }];
   let extensionUtility: ExtensionUtility;
+  let ea: EventAggregator;
   let i18n: I18N;
   let extension: HeaderMenuExtension;
   let sharedService: SharedService;
@@ -91,10 +93,11 @@ describe('headerMenuExtension', () => {
 
   describe('with I18N Service', () => {
     beforeEach(() => {
+      ea = new EventAggregator();
       sharedService = new SharedService();
-      i18n = new I18N(new EventAggregator(), new BindingSignaler());
+      i18n = new I18N(ea, new BindingSignaler());
       extensionUtility = new ExtensionUtility(i18n, sharedService);
-      extension = new HeaderMenuExtension(extensionUtility, filterServiceStub, i18n, sharedService, sortServiceStub);
+      extension = new HeaderMenuExtension(ea, extensionUtility, filterServiceStub, i18n, sharedService, sortServiceStub);
       i18n.setup({
         resources: {
           en: {
@@ -510,7 +513,7 @@ describe('headerMenuExtension', () => {
   describe('without I18N Service', () => {
     beforeEach(() => {
       i18n = null;
-      extension = new HeaderMenuExtension({} as ExtensionUtility, {} as FilterService, i18n, { gridOptions: { enableTranslate: true } } as SharedService, {} as SortService);
+      extension = new HeaderMenuExtension(ea, {} as ExtensionUtility, {} as FilterService, i18n, { gridOptions: { enableTranslate: true } } as SharedService, {} as SortService);
     });
 
     it('should throw an error if "enableTranslate" is set but the I18N Service is null', () => {

--- a/src/aurelia-slickgrid/extensions/columnPickerExtension.ts
+++ b/src/aurelia-slickgrid/extensions/columnPickerExtension.ts
@@ -52,7 +52,7 @@ export class ColumnPickerExtension implements Extension {
       this.sharedService.gridOptions.columnPicker.forceFitTitle = this.sharedService.gridOptions.columnPicker.forceFitTitle || forceFitTitle;
       this.sharedService.gridOptions.columnPicker.syncResizeTitle = this.sharedService.gridOptions.columnPicker.syncResizeTitle || syncResizeTitle;
 
-      this._addon = new Slick.Controls.ColumnPicker(this.sharedService.columnDefinitions, this.sharedService.grid, this.sharedService.gridOptions);
+      this._addon = new Slick.Controls.ColumnPicker(this.sharedService.allColumns, this.sharedService.grid, this.sharedService.gridOptions);
       if (this.sharedService.grid && this.sharedService.gridOptions.enableColumnPicker) {
         if (this.sharedService.gridOptions.columnPicker.onExtensionRegistered) {
           this.sharedService.gridOptions.columnPicker.onExtensionRegistered(this._addon);

--- a/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
@@ -102,7 +102,7 @@ export class GridMenuExtension implements Extension {
       this.extensionUtility.translateItems(this.sharedService.gridOptions.gridMenu.customItems, 'titleKey', 'title');
       this.extensionUtility.sortItems(this.sharedService.gridOptions.gridMenu.customItems, 'positionOrder');
 
-      this._addon = new Slick.Controls.GridMenu(this.sharedService.columnDefinitions, this.sharedService.grid, this.sharedService.gridOptions);
+      this._addon = new Slick.Controls.GridMenu(this.sharedService.allColumns, this.sharedService.grid, this.sharedService.gridOptions);
 
       // hook all events
       if (this.sharedService.grid && this.sharedService.gridOptions.gridMenu) {

--- a/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
@@ -1,9 +1,12 @@
 import { inject, Optional, singleton } from 'aurelia-framework';
+import { EventAggregator } from 'aurelia-event-aggregator';
 import { I18N } from 'aurelia-i18n';
 import { Constants } from '../constants';
 import {
   Column,
   ColumnSort,
+  CurrentSorter,
+  EmitterType,
   Extension,
   ExtensionName,
   GridOption,
@@ -24,6 +27,7 @@ declare var Slick: any;
 
 @singleton(true)
 @inject(
+  EventAggregator,
   ExtensionUtility,
   FilterService,
   Optional.of(I18N),
@@ -36,6 +40,7 @@ export class HeaderMenuExtension implements Extension {
   private _locales: Locale;
 
   constructor(
+    private ea: EventAggregator,
     private extensionUtility: ExtensionUtility,
     private filterService: FilterService,
     private i18n: I18N,
@@ -205,6 +210,7 @@ export class HeaderMenuExtension implements Extension {
       const visibleColumns = this.extensionUtility.arrayRemoveItemByIndex(currentColumns, columnIndex);
       this.sharedService.visibleColumns = visibleColumns;
       this.sharedService.grid.setColumns(visibleColumns);
+      this.ea.publish('headerMenu:columnHide', { columns: visibleColumns });
     }
   }
 
@@ -343,12 +349,16 @@ export class HeaderMenuExtension implements Extension {
       // get previously sorted columns
       const sortedColsWithoutCurrent: ColumnSort[] = this.sortService.getCurrentColumnSorts(args.column.id + '');
 
+      let emitterType: EmitterType;
+
       // add to the column array, the column sorted by the header menu
       sortedColsWithoutCurrent.push({ sortCol: args.column, sortAsc: isSortingAsc });
       if (this.sharedService.gridOptions.backendServiceApi) {
         this.sortService.onBackendSortChanged(event, { multiColumnSort: true, sortCols: sortedColsWithoutCurrent, grid: this.sharedService.grid });
+        emitterType = EmitterType.remote;
       } else if (this.sharedService.dataView) {
         this.sortService.onLocalSortChanged(this.sharedService.grid, this.sharedService.dataView, sortedColsWithoutCurrent);
+        emitterType = EmitterType.local;
       } else {
         // when using customDataView, we will simply send it as a onSort event with notify
         const isMultiSort = this.sharedService && this.sharedService.gridOptions && this.sharedService.gridOptions.multiColumnSort || false;
@@ -364,7 +374,23 @@ export class HeaderMenuExtension implements Extension {
           sortCol: col && col.sortCol,
         };
       });
-      this.sharedService.grid.setSortColumns(newSortColumns); // add sort icon in UI
+
+      // add sort icon in UI
+      this.sharedService.grid.setSortColumns(newSortColumns);
+
+      // if we have an emitter type set, we will emit a sort changed
+      // for the Grid State Service to see the change.
+      // We also need to pass current sorters changed to the emitSortChanged method
+      if (emitterType) {
+        const currentLocalSorters: CurrentSorter[] = [];
+        newSortColumns.forEach((sortCol) => {
+          currentLocalSorters.push({
+            columnId: sortCol.columnId + '',
+            direction: sortCol.sortAsc ? 'ASC' : 'DESC'
+          });
+        });
+        this.sortService.emitSortChanged(emitterType, currentLocalSorters);
+      }
     }
   }
 }

--- a/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
@@ -210,7 +210,7 @@ export class HeaderMenuExtension implements Extension {
       const visibleColumns = this.extensionUtility.arrayRemoveItemByIndex(currentColumns, columnIndex);
       this.sharedService.visibleColumns = visibleColumns;
       this.sharedService.grid.setColumns(visibleColumns);
-      this.ea.publish('headerMenu:columnHide', { columns: visibleColumns });
+      this.ea.publish('headerMenu:onColumnsChanged', { columns: visibleColumns });
     }
   }
 

--- a/src/aurelia-slickgrid/services/__tests__/extension.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/extension.service.spec.ts
@@ -85,13 +85,13 @@ describe('ExtensionService', () => {
         extensionStub as unknown as DraggableGroupingExtension,
         extensionGridMenuStub as unknown as GridMenuExtension,
         extensionGroupItemMetaStub as unknown as GroupItemMetaProviderExtension,
-        i18n,
         extensionStub as unknown as HeaderButtonExtension,
         extensionHeaderMenuStub as unknown as HeaderMenuExtension,
         extensionStub as unknown as RowDetailViewExtension,
         extensionStub as unknown as RowMoveManagerExtension,
         extensionStub as unknown as RowSelectionExtension,
         sharedService,
+        i18n,
       );
     });
 
@@ -588,6 +588,9 @@ describe('ExtensionService', () => {
         });
 
       it('should re-register the Column Picker when enable and method is called with new column definition collection provided as argument', () => {
+        const instanceMock = { onColumnsChanged: jest.fn() };
+        const extensionMock = { name: ExtensionName.columnPicker, addon: null, instance: null, class: null } as ExtensionModel;
+        const expectedExtension = { name: ExtensionName.columnPicker, addon: instanceMock, instance: instanceMock, class: null } as ExtensionModel;
         const gridOptionsMock = { enableColumnPicker: true } as GridOption;
         const columnsMock = [
           { id: 'field1', field: 'field1', headerKey: 'HELLO' },
@@ -595,6 +598,7 @@ describe('ExtensionService', () => {
         ] as Column[];
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
         jest.spyOn(SharedService.prototype, 'grid', 'get').mockReturnValue(gridStub);
+        const spyGetExt = jest.spyOn(service, 'getExtensionByName').mockReturnValue(extensionMock);
         const spyCpDispose = jest.spyOn(extensionColumnPickerStub, 'dispose');
         const spyCpRegister = jest.spyOn(extensionColumnPickerStub, 'register');
         const spyAllCols = jest.spyOn(SharedService.prototype, 'allColumns', 'set');
@@ -609,20 +613,29 @@ describe('ExtensionService', () => {
       });
 
       it('should re-register the Grid Menu when enable and method is called with new column definition collection provided as argument', () => {
+        const instanceMock = { onColumnsChanged: jest.fn() };
+        const extensionMock = { name: ExtensionName.gridMenu, addon: null, instance: null, class: null } as ExtensionModel;
+        const expectedExtension = { name: ExtensionName.gridMenu, addon: instanceMock, instance: instanceMock, class: null } as ExtensionModel;
         const gridOptionsMock = { enableGridMenu: true } as GridOption;
         const columnsMock = [
           { id: 'field1', field: 'field1', headerKey: 'HELLO' },
           { id: 'field2', field: 'field2', headerKey: 'WORLD' }
         ] as Column[];
+
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
         jest.spyOn(SharedService.prototype, 'grid', 'get').mockReturnValue(gridStub);
+        const spyGetExt = jest.spyOn(service, 'getExtensionByName').mockReturnValue(extensionMock);
         const spyGmDispose = jest.spyOn(extensionGridMenuStub, 'dispose');
-        const spyGmRegister = jest.spyOn(extensionGridMenuStub, 'register');
+        const spyGmRegister = jest.spyOn(extensionGridMenuStub, 'register').mockReturnValue(instanceMock);
         const spyAllCols = jest.spyOn(SharedService.prototype, 'allColumns', 'set');
         const setColumnsSpy = jest.spyOn(gridStub, 'setColumns');
 
         service.renderColumnHeaders(columnsMock);
 
+        expect(expectedExtension).toEqual(expectedExtension);
+        expect(spyGetExt).toHaveBeenCalled();
+        expect(expectedExtension).toEqual(expectedExtension);
+        expect(spyGetExt).toHaveBeenCalled();
         expect(spyGmDispose).toHaveBeenCalled();
         expect(spyGmRegister).toHaveBeenCalled();
         expect(spyAllCols).toHaveBeenCalledWith(columnsMock);
@@ -643,13 +656,13 @@ describe('ExtensionService', () => {
         extensionStub as unknown as DraggableGroupingExtension,
         extensionGridMenuStub as unknown as GridMenuExtension,
         extensionGroupItemMetaStub as unknown as GroupItemMetaProviderExtension,
-        i18n,
         extensionStub as unknown as HeaderButtonExtension,
         extensionHeaderMenuStub as unknown as HeaderMenuExtension,
         extensionStub as unknown as RowDetailViewExtension,
         extensionStub as unknown as RowMoveManagerExtension,
         extensionStub as unknown as RowSelectionExtension,
         sharedService,
+        i18n,
       );
 
       const gridOptionsMock = { enableTranslate: true } as GridOption;

--- a/src/aurelia-slickgrid/services/__tests__/gridState.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/gridState.service.spec.ts
@@ -55,8 +55,8 @@ describe('GridStateService', () => {
 
   beforeEach(() => {
     ea = new EventAggregator();
-    service = new GridStateService(ea);
-    service.init(gridStub, extensionServiceStub, filterServiceStub, sortServiceStub);
+    service = new GridStateService(ea, extensionServiceStub, filterServiceStub, sortServiceStub);
+    service.init(gridStub);
   });
 
   afterEach(() => {
@@ -82,7 +82,7 @@ describe('GridStateService', () => {
       const gridStateSpy = jest.spyOn(service, 'subscribeToAllGridChanges');
       const eaSpy = jest.spyOn(ea, 'subscribe');
 
-      service.init(gridStub, extensionServiceStub, filterServiceStub, sortServiceStub);
+      service.init(gridStub);
 
       expect(gridStateSpy).toHaveBeenCalled();
       expect(eaSpy).toHaveBeenCalledTimes(5);
@@ -127,7 +127,7 @@ describe('GridStateService', () => {
         const gridStateSpy = jest.spyOn(service, 'getCurrentGridState').mockReturnValue(gridStateMock);
         const extensionSpy = jest.spyOn(extensionServiceStub, 'getExtensionByName').mockReturnValue(extensionMock);
 
-        service.init(gridStub, extensionServiceStub, filterServiceStub, sortServiceStub);
+        service.init(gridStub);
         slickgridEvent.notify({ columns: columnsMock }, new Slick.EventData(), gridStub);
 
         expect(gridStateSpy).toHaveBeenCalled();
@@ -150,7 +150,7 @@ describe('GridStateService', () => {
         const gridColumnResizeSpy = jest.spyOn(gridStub.onColumnsResized, 'subscribe');
         const gridStateSpy = jest.spyOn(service, 'getCurrentGridState').mockReturnValue(gridStateMock);
 
-        service.init(gridStub, extensionServiceStub, filterServiceStub, sortServiceStub);
+        service.init(gridStub);
         gridStub.onColumnsReordered.notify({ impactedColumns: columnsMock }, new Slick.EventData(), gridStub);
         service.resetColumns();
 
@@ -464,7 +464,7 @@ describe('GridStateService', () => {
       expect(eaSpy).toHaveBeenNthCalledWith(2, `gridStateService:changed`, stateChangeMock);
     });
 
-    it('should trigger a "gridStateService:changed" event when "headerMenu:columnHide" is triggered', () => {
+    it('should trigger a "gridStateService:changed" event when "headerMenu:onColumnsChanged" is triggered', () => {
       const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
       const currentColumnsMock = [{ columnId: 'field1', cssClass: 'red', headerCssClass: '', width: 100 }] as CurrentColumn[];
       const gridStateMock = { columns: currentColumnsMock, filters: [], sorters: [] } as GridState;
@@ -473,7 +473,7 @@ describe('GridStateService', () => {
       const getCurGridStateSpy = jest.spyOn(service, 'getCurrentGridState').mockReturnValue(gridStateMock);
       const getAssocCurColSpy = jest.spyOn(service, 'getAssociatedCurrentColumns').mockReturnValue(currentColumnsMock);
 
-      ea.publish('headerMenu:columnHide', columnsMock);
+      ea.publish('headerMenu:onColumnsChanged', columnsMock);
 
       expect(getCurGridStateSpy).toHaveBeenCalled();
       expect(getAssocCurColSpy).toHaveBeenCalled();

--- a/src/aurelia-slickgrid/services/__tests__/gridState.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/gridState.service.spec.ts
@@ -85,7 +85,7 @@ describe('GridStateService', () => {
       service.init(gridStub, extensionServiceStub, filterServiceStub, sortServiceStub);
 
       expect(gridStateSpy).toHaveBeenCalled();
-      expect(eaSpy).toHaveBeenCalledTimes(4);
+      expect(eaSpy).toHaveBeenCalledTimes(5);
       // expect(eaSpy).toHaveBeenNthCalledWith(1, `filterService:filterChanged`, () => { });
     });
 
@@ -461,6 +461,22 @@ describe('GridStateService', () => {
       const eaSpy = jest.spyOn(ea, 'publish');
 
       ea.publish('sortService:sortCleared', sorterMock);
+      expect(eaSpy).toHaveBeenNthCalledWith(2, `gridStateService:changed`, stateChangeMock);
+    });
+
+    it('should trigger a "gridStateService:changed" event when "headerMenu:columnHide" is triggered', () => {
+      const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
+      const currentColumnsMock = [{ columnId: 'field1', cssClass: 'red', headerCssClass: '', width: 100 }] as CurrentColumn[];
+      const gridStateMock = { columns: currentColumnsMock, filters: [], sorters: [] } as GridState;
+      const stateChangeMock = { change: { newValues: currentColumnsMock, type: GridStateType.columns }, gridState: gridStateMock } as GridStateChange;
+      const eaSpy = jest.spyOn(ea, 'publish');
+      const getCurGridStateSpy = jest.spyOn(service, 'getCurrentGridState').mockReturnValue(gridStateMock);
+      const getAssocCurColSpy = jest.spyOn(service, 'getAssociatedCurrentColumns').mockReturnValue(currentColumnsMock);
+
+      ea.publish('headerMenu:columnHide', columnsMock);
+
+      expect(getCurGridStateSpy).toHaveBeenCalled();
+      expect(getAssocCurColSpy).toHaveBeenCalled();
       expect(eaSpy).toHaveBeenNthCalledWith(2, `gridStateService:changed`, stateChangeMock);
     });
   });

--- a/src/aurelia-slickgrid/services/__tests__/sort.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/sort.service.spec.ts
@@ -259,7 +259,7 @@ describe('SortService', () => {
       service.emitSortChanged(EmitterType.local, [localSorterMock]);
       const currentLocalSorters = service.getCurrentLocalSorters();
 
-      expect(currentLocalSorters).toEqual(localSorterMock);
+      expect(currentLocalSorters).toEqual([localSorterMock]);
       expect(eaSpy).toHaveBeenCalledWith(`sortService:sortChanged`, currentLocalSorters);
     });
   });

--- a/src/aurelia-slickgrid/services/__tests__/sort.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/sort.service.spec.ts
@@ -8,6 +8,7 @@ import {
   SlickEventHandler,
   SortChangedArgs,
   FieldType,
+  EmitterType,
 } from '../../models';
 import { Sorters } from '../../sorters';
 import { SortService } from '../sort.service';
@@ -247,6 +248,19 @@ describe('SortService', () => {
       expect(spyBackendProcessSort).toHaveBeenCalled();
       expect(spyPreProcess).toHaveBeenCalled();
       expect(eaSpy).toHaveBeenCalledWith(`sortService:sortChanged`, expectedSortCols);
+    });
+  });
+
+  describe('emitSortChanged method', () => {
+    it('should have same current sort changed when it is passed as argument to the emitSortChanged method', () => {
+      const localSorterMock = { columnId: 'field1', direction: 'DESC' } as CurrentSorter;
+      const eaSpy = jest.spyOn(ea, 'publish');
+
+      service.emitSortChanged(EmitterType.local, [localSorterMock]);
+      const currentLocalSorters = service.getCurrentLocalSorters();
+
+      expect(currentLocalSorters).toEqual(localSorterMock);
+      expect(eaSpy).toHaveBeenCalledWith(`sortService:sortChanged`, currentLocalSorters);
     });
   });
 

--- a/src/aurelia-slickgrid/services/extension.service.ts
+++ b/src/aurelia-slickgrid/services/extension.service.ts
@@ -36,13 +36,13 @@ import { SharedService } from './shared.service';
   DraggableGroupingExtension,
   GridMenuExtension,
   GroupItemMetaProviderExtension,
-  Optional.of(I18N),
   HeaderButtonExtension,
   HeaderMenuExtension,
   RowDetailViewExtension,
   RowMoveManagerExtension,
   RowSelectionExtension,
   SharedService,
+  Optional.of(I18N),
 )
 export class ExtensionService {
   private _extensionCreatedList: any[] = [];
@@ -56,13 +56,13 @@ export class ExtensionService {
     private draggableGroupingExtension: DraggableGroupingExtension,
     private gridMenuExtension: GridMenuExtension,
     private groupItemMetaExtension: GroupItemMetaProviderExtension,
-    private i18n: I18N,
     private headerButtonExtension: HeaderButtonExtension,
     private headerMenuExtension: HeaderMenuExtension,
     private rowDetailViewExtension: RowDetailViewExtension,
     private rowMoveManagerExtension: RowMoveManagerExtension,
     private rowSelectionExtension: RowSelectionExtension,
     private sharedService: SharedService,
+    private i18n: I18N,
   ) { }
 
   /** Dispose of all the controls & plugins */
@@ -371,20 +371,30 @@ export class ExtensionService {
     if (Array.isArray(collection) && this.sharedService.grid && this.sharedService.grid.setColumns) {
       if (collection.length > this.sharedService.allColumns.length) {
         this.sharedService.allColumns = collection;
-        this.sharedService.grid.setColumns(collection);
-      } else {
-        this.sharedService.grid.setColumns(this.sharedService.allColumns);
+      }
+      this.sharedService.grid.setColumns(collection);
+    }
+
+    // dispose of previous Column Picker instance, then re-register it and don't forget to overwrite previous instance ref
+    if (this.sharedService.gridOptions.enableColumnPicker) {
+      this.columnPickerExtension.dispose();
+      const instance = this.columnPickerExtension.register();
+      const extension = this.getExtensionByName(ExtensionName.columnPicker);
+      if (extension) {
+        extension.addon = instance;
+        extension.instance = instance;
       }
     }
 
-    if (this.sharedService.gridOptions.enableColumnPicker) {
-      this.columnPickerExtension.dispose();
-      this.columnPickerExtension.register();
-    }
-
+    // dispose of previous Grid Menu instance, then re-register it and don't forget to overwrite previous instance ref
     if (this.sharedService.gridOptions.enableGridMenu) {
       this.gridMenuExtension.dispose();
-      this.gridMenuExtension.register();
+      const instance = this.gridMenuExtension.register();
+      const extension = this.getExtensionByName(ExtensionName.gridMenu);
+      if (extension) {
+        extension.addon = instance;
+        extension.instance = instance;
+      }
     }
   }
 

--- a/src/aurelia-slickgrid/services/gridState.service.ts
+++ b/src/aurelia-slickgrid/services/gridState.service.ts
@@ -20,18 +20,20 @@ import { SortService } from './sort.service';
 declare var Slick: any;
 
 @singleton(true)
-@inject(EventAggregator)
+@inject(EventAggregator, ExtensionService, FilterService, SortService)
 export class GridStateService {
   private _eventHandler = new Slick.EventHandler();
   private _columns: Column[] = [];
   private _currentColumns: CurrentColumn[] = [];
   private _grid: any;
-  private extensionService: ExtensionService;
-  private filterService: FilterService;
-  private sortService: SortService;
   private subscriptions: Subscription[] = [];
 
-  constructor(private ea: EventAggregator) { }
+  constructor(
+    private ea: EventAggregator,
+    private extensionService: ExtensionService,
+    private filterService: FilterService,
+    private sortService: SortService
+  ) { }
 
   /** Getter for the Grid Options pulled through the Grid Object */
   private get _gridOptions(): GridOption {
@@ -41,15 +43,9 @@ export class GridStateService {
   /**
    * Initialize the Service
    * @param grid
-   * @param filterService
-   * @param sortService
    */
-  init(grid: any, extensionService: ExtensionService, filterService: FilterService, sortService: SortService): void {
+  init(grid: any): void {
     this._grid = grid;
-    this.extensionService = extensionService;
-    this.filterService = filterService;
-    this.sortService = sortService;
-
     this.subscribeToAllGridChanges(grid);
   }
 
@@ -265,7 +261,7 @@ export class GridStateService {
 
     // subscribe to HeaderMenu (hide column)
     this.subscriptions.push(
-      this.ea.subscribe('headerMenu:columnHide', (visibleColumns: Column[]) => {
+      this.ea.subscribe('headerMenu:onColumnsChanged', (visibleColumns: Column[]) => {
         const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(visibleColumns);
         this.ea.publish('gridStateService:changed', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
       })

--- a/src/aurelia-slickgrid/services/gridState.service.ts
+++ b/src/aurelia-slickgrid/services/gridState.service.ts
@@ -262,6 +262,14 @@ export class GridStateService {
     // subscribe to Column Resize & Reordering
     this.bindSlickGridEventToGridStateChange('onColumnsReordered', grid);
     this.bindSlickGridEventToGridStateChange('onColumnsResized', grid);
+
+    // subscribe to HeaderMenu (hide column)
+    this.subscriptions.push(
+      this.ea.subscribe('headerMenu:columnHide', (visibleColumns: Column[]) => {
+        const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(visibleColumns);
+        this.ea.publish('gridStateService:changed', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
+      })
+    );
   }
 
   // --

--- a/src/aurelia-slickgrid/services/sort.service.ts
+++ b/src/aurelia-slickgrid/services/sort.service.ts
@@ -134,6 +134,27 @@ export class SortService {
     this.ea.publish('sortService:sortCleared', true);
   }
 
+  /**
+   * A simple function that will be called to emit a change when a sort changes.
+   * Other services, like Pagination, can then subscribe to it.
+   * @param sender
+   */
+  emitSortChanged(sender: EmitterType, currentLocalSorters?: CurrentSorter[]) {
+    if (sender === EmitterType.remote && this._gridOptions && this._gridOptions.backendServiceApi) {
+      let currentSorters: CurrentSorter[] = [];
+      const backendService = this._gridOptions.backendServiceApi.service;
+      if (backendService && backendService.getCurrentSorters) {
+        currentSorters = backendService.getCurrentSorters() as CurrentSorter[];
+      }
+      this.ea.publish('sortService:sortChanged', currentSorters);
+    } else if (sender === EmitterType.local) {
+      if (currentLocalSorters) {
+        this._currentLocalSorters = currentLocalSorters;
+      }
+      this.ea.publish('sortService:sortChanged', this.getCurrentLocalSorters());
+    }
+  }
+
   getCurrentLocalSorters(): CurrentSorter[] {
     return this._currentLocalSorters;
   }
@@ -275,27 +296,5 @@ export class SortService {
       }
     }
     return SortDirectionNumber.neutral;
-  }
-
-  // --
-  // private functions
-  // -------------------
-
-  /**
-   * A simple function that will be called to emit a change when a sort changes.
-   * Other services, like Pagination, can then subscribe to it.
-   * @param sender
-   */
-  private emitSortChanged(sender: EmitterType) {
-    if (sender === EmitterType.remote && this._gridOptions && this._gridOptions.backendServiceApi) {
-      let currentSorters: CurrentSorter[] = [];
-      const backendService = this._gridOptions.backendServiceApi.service;
-      if (backendService && backendService.getCurrentSorters) {
-        currentSorters = backendService.getCurrentSorters() as CurrentSorter[];
-      }
-      this.ea.publish('sortService:sortChanged', currentSorters);
-    } else if (sender === EmitterType.local) {
-      this.ea.publish('sortService:sortChanged', this.getCurrentLocalSorters());
-    }
   }
 }

--- a/src/examples/slickgrid/example15.html
+++ b/src/examples/slickgrid/example15.html
@@ -1,35 +1,20 @@
 <template>
   <h2>${title}</h2>
-  <div class="subtitle"
-    innerhtml.bind="subTitle"></div>
+  <div class="subtitle" innerhtml.bind="subTitle"></div>
 
-  <button class="btn btn-default btn-sm"
-    data-test="reset-button"
-    click.delegate="clearGridStateFromLocalStorage()">
+  <button class="btn btn-default btn-sm" data-test="reset-button" click.delegate="clearGridStateFromLocalStorage()">
     <i class="fa fa-times"></i>
     Clear Grid State from Local Storage &amp; Reset Grid
   </button>
-  <button class="btn btn-default btn-sm"
-    data-test="language-button"
-    click.delegate="switchLanguage()">
+  <button class="btn btn-default btn-sm" data-test="language-button" click.delegate="switchLanguage()">
     <i class="fa fa-language"></i>
     Switch Language
   </button>
-  <b>Locale:</b> <span style="font-style: italic"
-    data-test="selected-locale">${selectedLanguage + '.json'}</span>
-  <span hidden.bind="!processing"
-    class.bind="status.class"
-    data-test="processing">
-    <i class="fa fa-refresh fa-spin fa-lg fa-fw"></i>
-  </span>
+  <b>Locale:</b> <span style="font-style: italic" data-test="selected-locale">${selectedLanguage + '.json'}</span>
 
 
-  <aurelia-slickgrid grid-id="grid15"
-    column-definitions.bind="columnDefinitions"
-    grid-options.bind="gridOptions"
-    dataset.bind="dataset"
-    asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
-    asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)"
-    sg-on-row-count-changed.delegate="onRowCountChanged($event.detail, $event.detail.args)">
+  <aurelia-slickgrid grid-id="grid15" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
+    dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
+    asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)">
   </aurelia-slickgrid>
 </template>

--- a/src/examples/slickgrid/example15.html
+++ b/src/examples/slickgrid/example15.html
@@ -1,22 +1,35 @@
 <template>
   <h2>${title}</h2>
-  <div class="subtitle" innerhtml.bind="subTitle"></div>
+  <div class="subtitle"
+    innerhtml.bind="subTitle"></div>
 
-  <button class="btn btn-default btn-sm" click.delegate="clearGridStateFromLocalStorage()">
+  <button class="btn btn-default btn-sm"
+    data-test="reset-button"
+    click.delegate="clearGridStateFromLocalStorage()">
     <i class="fa fa-times"></i>
     Clear Grid State from Local Storage &amp; Reset Grid
   </button>
-  <button class="btn btn-default btn-sm" click.delegate="switchLanguage()">
+  <button class="btn btn-default btn-sm"
+    data-test="language-button"
+    click.delegate="switchLanguage()">
     <i class="fa fa-language"></i>
     Switch Language
   </button>
+  <b>Locale:</b> <span style="font-style: italic"
+    data-test="selected-locale">${selectedLanguage + '.json'}</span>
+  <span hidden.bind="!processing"
+    class.bind="status.class"
+    data-test="processing">
+    <i class="fa fa-refresh fa-spin fa-lg fa-fw"></i>
+  </span>
 
-  <aurelia-slickgrid
-    grid-id="grid15"
+
+  <aurelia-slickgrid grid-id="grid15"
     column-definitions.bind="columnDefinitions"
     grid-options.bind="gridOptions"
     dataset.bind="dataset"
     asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
-    asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)">
+    asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)"
+    sg-on-row-count-changed.delegate="onRowCountChanged($event.detail, $event.detail.args)">
   </aurelia-slickgrid>
 </template>

--- a/src/examples/slickgrid/example15.ts
+++ b/src/examples/slickgrid/example15.ts
@@ -28,7 +28,6 @@ export class Example15 {
   gridOptions: GridOption;
   dataset: any[];
   selectedLanguage: string;
-  processing = true;
 
   constructor(private i18n: I18N) {
     const presets = JSON.parse(localStorage[LOCAL_STORAGE_KEY] || null);
@@ -54,7 +53,6 @@ export class Example15 {
 
   aureliaGridReady(aureliaGrid: AureliaGridInstance) {
     this.aureliaGrid = aureliaGrid;
-    this.processing = true;
   }
 
   /** Clear the Grid State from Local Storage and reset the grid to it's original state */
@@ -100,7 +98,6 @@ export class Example15 {
         filter: {
           collection: multiSelectFilterArray,
           model: Filters.multipleSelect,
-          searchTerms: [1, 33, 44, 50, 66], // default selection
           // we could add certain option(s) to the "multiple-select" plugin
           filterOptions: {
             maxHeight: 250,
@@ -223,10 +220,5 @@ export class Example15 {
         { columnId: 'complete', direction: 'ASC' }
       ],
     };
-  }
-
-  onRowCountChanged(event, args) {
-    console.log(args)
-    this.processing = false;
   }
 }

--- a/src/examples/slickgrid/example15.ts
+++ b/src/examples/slickgrid/example15.ts
@@ -28,15 +28,19 @@ export class Example15 {
   gridOptions: GridOption;
   dataset: any[];
   selectedLanguage: string;
+  processing = true;
 
   constructor(private i18n: I18N) {
     const presets = JSON.parse(localStorage[LOCAL_STORAGE_KEY] || null);
 
-    // use some Grid State preset defaults if you wish
+    // use some Grid State preset defaults if you wish or just restore from Locale Storage
     // presets = presets || this.useDefaultPresets();
-
     this.defineGrid(presets);
-    this.selectedLanguage = this.i18n.getLocale();
+
+    // always start with English for Cypress E2E tests to be consistent
+    const defaultLang = 'en';
+    this.i18n.setLocale(defaultLang);
+    this.selectedLanguage = defaultLang;
   }
 
   attached() {
@@ -50,6 +54,7 @@ export class Example15 {
 
   aureliaGridReady(aureliaGrid: AureliaGridInstance) {
     this.aureliaGrid = aureliaGrid;
+    this.processing = true;
   }
 
   /** Clear the Grid State from Local Storage and reset the grid to it's original state */
@@ -131,7 +136,13 @@ export class Example15 {
       enableCheckboxSelector: true,
       enableFiltering: true,
       enableTranslate: true,
-      i18n: this.i18n
+      i18n: this.i18n,
+      columnPicker: {
+        hideForceFitButton: true
+      },
+      gridMenu: {
+        hideForceFitButton: true
+      },
     };
 
     // reload the Grid State with the grid options presets
@@ -184,8 +195,8 @@ export class Example15 {
   }
 
   switchLanguage() {
-    this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
-    this.i18n.setLocale(this.selectedLanguage);
+    const nextLocale = (this.selectedLanguage === 'en') ? 'fr' : 'en';
+    this.i18n.setLocale(nextLocale).then(() => this.selectedLanguage = nextLocale);
   }
 
   useDefaultPresets() {
@@ -212,5 +223,10 @@ export class Example15 {
         { columnId: 'complete', direction: 'ASC' }
       ],
     };
+  }
+
+  onRowCountChanged(event, args) {
+    console.log(args)
+    this.processing = false;
   }
 }

--- a/test/cypress/integration/example15.spec.js
+++ b/test/cypress/integration/example15.spec.js
@@ -14,6 +14,7 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
     cy.visit(`${Cypress.config('baseExampleUrl')}/example15`);
     cy.get('h2').should('contain', 'Example 15: Grid State & Presets using Local Storage');
 
+    cy.clearLocalStorage();
     cy.get('[data-test=reset-button]').click();
   });
 
@@ -102,11 +103,41 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
       .click();
   });
 
-  it('should hover over the "Start" column and click on "Hide Column" remove the column from grid', () => {
-    const expectedTitles = ['', 'Description', 'Duration', 'Title', '% Complete', 'Completed'];
+  it('should filter certain tasks', () => {
+    cy.get('.grid-canvas')
+      .find('.slick-row')
+      .should('be.visible');
+
+    cy.get('.filter-title input')
+      .type('Task 1')
+  });
+
+  it('should click on "Title" column to sort it Ascending', () => {
+    const tasks = ['Task 1', 'Task 10', 'Task 100', 'Task 101'];
 
     cy.get('.slick-header-columns')
-      .children('.slick-header-column:nth(5)')
+      .children('.slick-header-column:nth(3)')
+      .click();
+
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(3)')
+      .find('.slick-sort-indicator.slick-sort-indicator-asc')
+      .should('be.visible');
+
+    cy.get('#grid15')
+      .find('.slick-row')
+      .each(($row, index) => {
+        if (index > tasks.length - 1) {
+          return;
+        }
+        cy.wrap($row).children('.slick-cell:nth(3)')
+          .should('contain', tasks[index]);
+      });
+  });
+
+  it('should hover over the "Duration" column click on "Sort Descending" command', () => {
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(2)')
       .trigger('mouseover')
       .children('.slick-header-menubutton')
       .should('be.hidden')
@@ -115,15 +146,27 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
 
     cy.get('.slick-header-menu')
       .should('be.visible')
-      .children('.slick-header-menuitem:nth-child(6)')
+      .children('.slick-header-menuitem:nth-child(2)')
       .children('.slick-header-menucontent')
-      .should('contain', 'Hide Column')
+      .should('contain', 'Sort Descending')
       .click();
 
-    cy.get('#grid15')
-      .find('.slick-header-columns')
-      .children()
-      .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(2)')
+      .find('.slick-sort-indicator.slick-sort-indicator-desc')
+      .should('be.visible');
+
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(2)')
+      .find('.slick-sort-indicator-numbered')
+      .should('be.visible')
+      .should('contain', '2');
+
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(3)')
+      .find('.slick-sort-indicator-numbered')
+      .should('be.visible')
+      .should('contain', '1');
 
     cy.reload();
   });
@@ -131,30 +174,15 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
   it('should expect the same Grid State to persist after the page got reloaded', () => {
     const expectedTitles = ['', 'Description', 'Duration', 'Title', '% Complete', 'Completed'];
 
-    // switch the language button and forth just to make sure that our page and grid finished loading
-    // I couldn't find any other ways of detecting that the grid finished loading other than that
-    cy.get('[data-test=language-button]')
-      .click();
-
-    cy.get('[data-test=selected-locale]')
-      .should('contain', 'fr.json');
-
-    cy.get('[data-test=language-button]')
-      .click();
-
-    cy.get('[data-test=selected-locale]')
-      .should('contain', 'en.json');
-
-    cy.get('[data-test=processing]')
-      .should('be.hidden');
-
     cy.get('#grid15')
+      .find('.grid-canvas')
+      .find('.slick-row')
       .should('be.visible');
 
     cy.get('#grid15')
       .find('.slick-header-columns')
       .children()
-      .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
+      .each(($child, index) => expect($child.find('.slick-column-name').text()).to.eq(expectedTitles[index]));
   });
 
   it('should have French titles in Column Picker after switching to Language', () => {
@@ -217,5 +245,62 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
       .find('span.close')
       .trigger('click')
       .click();
+  });
+
+  it('should hover over the "Terminé" column and click on "Cacher la colonne" remove the column from grid', () => {
+    const expectedTitles = ['', 'Description', 'Durée', 'Titre', '% Complete'];
+
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(5)')
+      .trigger('mouseover')
+      .children('.slick-header-menubutton')
+      .should('be.hidden')
+      .invoke('show')
+      .click();
+
+    cy.get('.slick-header-menu')
+      .should('be.visible')
+      .children('.slick-header-menuitem:nth-child(6)')
+      .children('.slick-header-menucontent')
+      .should('contain', 'Cacher la colonne')
+      .click();
+
+    cy.get('#grid15')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.find('.slick-column-name').text()).to.eq(expectedTitles[index]));
+
+    cy.reload();
+  });
+
+  it('should expect the same Grid State to persist after the page got reloaded, however we always load in English', () => {
+    const expectedTitles = ['', 'Description', 'Duration', 'Title', '% Complete'];
+
+    cy.get('#grid15')
+      .find('.grid-canvas')
+      .find('.slick-row')
+      .should('be.visible');
+
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(2)')
+      .find('.slick-sort-indicator-numbered')
+      .should('be.visible')
+      .should('contain', '2');
+
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(3)')
+      .find('.slick-sort-indicator.slick-sort-indicator-asc')
+      .should('be.visible');
+
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(3)')
+      .find('.slick-sort-indicator-numbered')
+      .should('be.visible')
+      .should('contain', '1');
+
+    cy.get('#grid15')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.find('.slick-column-name').text()).to.eq(expectedTitles[index]));
   });
 });

--- a/test/cypress/integration/example15.spec.js
+++ b/test/cypress/integration/example15.spec.js
@@ -1,0 +1,221 @@
+describe('Example 15: Grid State & Presets using Local Storage', () => {
+  const fullEnglishTitles = ['', 'Title', 'Description', 'Duration', '% Complete', 'Start', 'Completed'];
+  const fullFrenchTitles = ['', 'Titre', 'Description', 'Durée', '% Complete', 'Début', 'Terminé'];
+
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+  });
+
+  it('should display Example 15 title', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example15`);
+    cy.get('h2').should('contain', 'Example 15: Grid State & Presets using Local Storage');
+
+    cy.get('[data-test=reset-button]').click();
+  });
+
+  it('should have exact Column Titles in the grid', () => {
+    cy.get('#grid15')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullEnglishTitles[index]));
+  });
+
+  it('should drag "Title" column to 3rd position in the grid', () => {
+    const expectedTitles = ['', 'Description', 'Duration', 'Title', '% Complete', 'Start', 'Completed'];
+
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(1)')
+      .should('contain', 'Title')
+      .trigger('mousedown', 'bottom', { which: 1 });
+
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(3)')
+      .should('contain', 'Duration')
+      .trigger('mousemove', 'bottomRight')
+      .trigger('mouseup', 'bottomRight', { force: true });
+
+    cy.get('#grid15')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
+  });
+
+  // --
+  // Cypress does not yet implement the .hover() method and this test won't work until then
+  xit('should resize "Title" column and make it wider', () => {
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(3)')
+      .should('contain', 'Title');
+
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(3)')
+      .find('.slick-resizable-handle')
+      .trigger('mouseover', -2, 50, { force: true })
+      .should('be.visible')
+      .invoke('show')
+      .hover()
+      .trigger('mousedown', -2, 50, { which: 1, force: true });
+
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(5)')
+      .trigger('mousemove', 'bottomLeft')
+      .trigger('mouseup', 'bottomLeft', { force: true });
+  });
+
+  it('should hide the "Start" column from the Column Picker', () => {
+    const expectedTitles = ['', 'Description', 'Duration', 'Title', '% Complete', 'Start', 'Completed'];
+
+    cy.get('#grid15')
+      .find('.slick-header-column')
+      .first()
+      .trigger('mouseover')
+      .trigger('contextmenu')
+      .invoke('show');
+
+    cy.get('.slick-columnpicker')
+      .find('.slick-columnpicker-list')
+      .children()
+      .each(($child, index) => {
+        if (index === 0) {
+          expect($child[0].className).to.eq('hidden');
+          expect($child[0].offsetHeight).to.eq(0);
+          expect($child[0].offsetWidth).to.eq(0);
+        }
+
+        expect($child.text()).to.eq(expectedTitles[index]);
+      });
+
+    cy.get('.slick-columnpicker')
+      .find('.slick-columnpicker-list')
+      .children('li:nth-child(6)')
+      .children('label')
+      .should('contain', 'Start')
+      .click();
+
+    cy.get('.slick-columnpicker:visible')
+      .find('span.close')
+      .trigger('click')
+      .click();
+  });
+
+  it('should hover over the "Start" column and click on "Hide Column" remove the column from grid', () => {
+    const expectedTitles = ['', 'Description', 'Duration', 'Title', '% Complete', 'Completed'];
+
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(5)')
+      .trigger('mouseover')
+      .children('.slick-header-menubutton')
+      .should('be.hidden')
+      .invoke('show')
+      .click();
+
+    cy.get('.slick-header-menu')
+      .should('be.visible')
+      .children('.slick-header-menuitem:nth-child(6)')
+      .children('.slick-header-menucontent')
+      .should('contain', 'Hide Column')
+      .click();
+
+    cy.get('#grid15')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
+
+    cy.reload();
+  });
+
+  it('should expect the same Grid State to persist after the page got reloaded', () => {
+    const expectedTitles = ['', 'Description', 'Duration', 'Title', '% Complete', 'Completed'];
+
+    // switch the language button and forth just to make sure that our page and grid finished loading
+    // I couldn't find any other ways of detecting that the grid finished loading other than that
+    cy.get('[data-test=language-button]')
+      .click();
+
+    cy.get('[data-test=selected-locale]')
+      .should('contain', 'fr.json');
+
+    cy.get('[data-test=language-button]')
+      .click();
+
+    cy.get('[data-test=selected-locale]')
+      .should('contain', 'en.json');
+
+    cy.get('[data-test=processing]')
+      .should('be.hidden');
+
+    cy.get('#grid15')
+      .should('be.visible');
+
+    cy.get('#grid15')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
+  });
+
+  it('should have French titles in Column Picker after switching to Language', () => {
+    const expectedTitles = ['', 'Description', 'Durée', 'Titre', '% Complete', 'Début', 'Terminé'];
+
+    cy.get('[data-test=language-button]')
+      .click();
+
+    cy.get('[data-test=selected-locale]')
+      .should('contain', 'fr.json');
+
+    cy.get('#grid15')
+      .find('.slick-header-column')
+      .first()
+      .trigger('mouseover')
+      .trigger('contextmenu')
+      .invoke('show');
+
+    cy.get('.slick-columnpicker')
+      .find('.slick-columnpicker-list')
+      .children()
+      .each(($child, index) => {
+        if (index === 0) {
+          expect($child[0].className).to.eq('hidden');
+          expect($child[0].offsetHeight).to.eq(0);
+          expect($child[0].offsetWidth).to.eq(0);
+        }
+
+        expect($child.text()).to.eq(expectedTitles[index]);
+      });
+
+    cy.get('.slick-columnpicker:visible')
+      .find('span.close')
+      .trigger('click')
+      .click();
+  });
+
+  it('should have French titles in Grid Menu after switching to Language', () => {
+    const expectedTitles = ['', 'Description', 'Durée', 'Titre', '% Complete', 'Début', 'Terminé'];
+
+    cy.get('#grid15')
+      .find('button.slick-gridmenu-button')
+      .trigger('click')
+      .click();
+
+    cy.get('.slick-gridmenu')
+      .find('.slick-gridmenu-list')
+      .children()
+      .each(($child, index) => {
+        if (index === 0) {
+          expect($child[0].className).to.eq('hidden');
+          expect($child[0].offsetHeight).to.eq(0);
+          expect($child[0].offsetWidth).to.eq(0);
+        }
+
+        expect($child.text()).to.eq(expectedTitles[index]);
+      });
+
+    cy.get('.slick-gridmenu:visible')
+      .find('span.close')
+      .trigger('click')
+      .click();
+  });
+});

--- a/test/cypress/integration/example9.spec.js
+++ b/test/cypress/integration/example9.spec.js
@@ -2,12 +2,12 @@ describe('Example 9 - Grid Menu', () => {
   const fullEnglishTitles = ['Title', 'Duration', '% Complete', 'Start', 'Finish', 'Completed'];
   const fullFrenchTitles = ['Titre', 'Durée', '% Complete', 'Début', 'Fin', 'Terminé'];
 
-  describe('use English locale', () => {
-    it('should display Example 9 title', () => {
-      cy.visit(`${Cypress.config('baseExampleUrl')}/example9`);
-      cy.get('h2').should('contain', 'Example 9: Grid Menu Control');
-    });
+  it('should display Example 9 title', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example9`);
+    cy.get('h2').should('contain', 'Example 9: Grid Menu Control');
+  });
 
+  describe('use English locale', () => {
     it('should have exact Column Titles in the grid', () => {
       cy.get('#grid9')
         .find('.slick-header-columns')

--- a/test/cypress/integration/example9.spec.js
+++ b/test/cypress/integration/example9.spec.js
@@ -114,12 +114,6 @@ describe('Example 9 - Grid Menu', () => {
         .find('.slick-header-columns')
         .children()
         .each(($child, index) => expect($child.text()).to.eq(fullEnglishTitles[index]));
-
-      cy.get('#grid9')
-        .get('.slick-gridmenu:visible')
-        .find('span.close')
-        .trigger('click')
-        .click();
     });
   });
 
@@ -221,15 +215,15 @@ describe('Example 9 - Grid Menu', () => {
         .click();
 
       cy.get('#grid9')
-        .find('.slick-header-columns')
-        .children()
-        .each(($child, index) => expect($child.text()).to.eq(fullFrenchTitles[index]));
-
-      cy.get('#grid9')
         .get('.slick-gridmenu:visible')
         .find('span.close')
         .trigger('click')
         .click();
+
+      cy.get('#grid9')
+        .find('.slick-header-columns')
+        .children()
+        .each(($child, index) => expect($child.text()).to.eq(fullFrenchTitles[index]));
     });
   });
 });

--- a/test/cypress/package.json
+++ b/test/cypress/package.json
@@ -11,7 +11,7 @@
   "author": "Ghislain B.",
   "license": "MIT",
   "devDependencies": {
-    "cypress": "^3.4.0",
+    "cypress": "^3.4.1",
     "mocha": "^5.2.0",
     "mochawesome": "^3.1.2",
     "mochawesome-merge": "^1.0.7",

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -23,3 +23,35 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+Cypress.Commands.add('triggerHover', (elements) => {
+  console.log(elements)
+  elements.each((index, element) => {
+    fireEvent(element, 'mouseover');
+  });
+
+  function fireEvent(element, event) {
+    if (element.fireEvent) {
+      element.fireEvent('on' + event);
+    } else {
+      var evObj = document.createEvent('Events');
+
+      evObj.initEvent(event, true, false);
+
+      element.dispatchEvent(evObj);
+    }
+  }
+});
+
+let LOCAL_STORAGE_MEMORY = {};
+
+Cypress.Commands.add("saveLocalStorage", () => {
+  Object.keys(localStorage).forEach(key => {
+    LOCAL_STORAGE_MEMORY[key] = localStorage[key];
+  });
+});
+
+Cypress.Commands.add("restoreLocalStorage", () => {
+  Object.keys(LOCAL_STORAGE_MEMORY).forEach(key => {
+    localStorage.setItem(key, LOCAL_STORAGE_MEMORY[key]);
+  });
+});

--- a/test/cypress/tsconfig.json
+++ b/test/cypress/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    "../node_modules/cypress",
+    "*/*.ts"
+  ]
+}


### PR DESCRIPTION
- there was mainly 3 problems
1. ColumnPicker & GridMenu were re-registered but their instances were not overwritten and because of that, the onColumnsChanged in the GridState was never triggering anymore because the subscribe was on the instance that no longer existed
2. we were using the setColumns with allColumns, that was a regression introduced by previous commit, this in terms was cancelling any presets of columns from coming in
3. header menu was not triggering any changes, hiding a column and/or sorting a column had no effect on the Grid State.
- Example 15 is the reference for Grid State & Presets

- [x] Hide Column from Header Menu is not triggering a Grid State change
- [x] Sort Column from Header Menu was also not triggering a Grid State change
- [x] add Cypress E2E tests to cover all possibilities of Example 15
- [x] add Jest unit tests to cover all new code added
- [x] change event `headerMenu:columnHide` to `headerMenu:onColumnsChanged`
- [x] change GridStateService to use `constructor` instead of `init` for DI