### PR TITLE
fix(odata): use contains with OData version 4, closes #88 

### DIFF
--- a/src/aurelia-slickgrid/models/odataOption.interface.ts
+++ b/src/aurelia-slickgrid/models/odataOption.interface.ts
@@ -26,6 +26,9 @@ export interface OdataOption extends BackendServiceOption {
   /** Sorting string (or array of string) that must be a valid OData string */
   orderBy?: string | string[];
 
+  /** OData (or any other) version number (the query string is different between versions) */
+  version?: number;
+
   /** When accessed as an object */
   [key: string]: any;
 }

--- a/src/aurelia-slickgrid/services/__tests__/grid-odata.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/grid-odata.service.spec.ts
@@ -252,7 +252,7 @@ describe('GridOdataService', () => {
       const mockColumn = { id: 'gender', field: 'gender' } as Column;
       const mockColumnName = { id: 'firstName', field: 'firstName' } as Column;
       const mockColumnFilter = { columnDef: mockColumn, columnId: 'gender', operator: 'EQ', searchTerms: ['female'] } as ColumnFilter;
-      const mockColumnFilterName = { columnDef: mockColumnName, columnId: 'firstName', operator: 'startsWith', searchTerms: ['John'] } as ColumnFilter;
+      const mockColumnFilterName = { columnDef: mockColumnName, columnId: 'firstName', operator: 'StartsWith', searchTerms: ['John'] } as ColumnFilter;
       const mockFilterChangedArgs = {
         columnDef: mockColumn,
         columnId: 'gender',
@@ -272,7 +272,7 @@ describe('GridOdataService', () => {
       expect(resetSpy).toHaveBeenCalled();
       expect(currentFilters).toEqual([
         { columnId: 'gender', operator: 'EQ', searchTerms: ['female'] },
-        { columnId: 'firstName', operator: 'startsWith', searchTerms: ['John'] }
+        { columnId: 'firstName', operator: 'StartsWith', searchTerms: ['John'] }
       ]);
     });
   });
@@ -718,6 +718,29 @@ describe('GridOdataService', () => {
 
       expect(query).toBe(expectation);
       expect(currentFilters).toEqual([]);
+    });
+  });
+
+  describe('updateFilters method with OData version 4', () => {
+    beforeEach(() => {
+      serviceOptions.version = 4;
+      serviceOptions.columnDefinitions = [{ id: 'company', field: 'company' }, { id: 'gender', field: 'gender' }, { id: 'name', field: 'name' }];
+    });
+
+    it('should return a query with a date showing as DateTime as per OData requirement', () => {
+      const expectation = `$top=10&$filter=(contains(Company, 'abc') and UpdatedDate eq DateTime'2001-02-28T00:00:00Z')`;
+      const mockColumnCompany = { id: 'company', field: 'company' } as Column;
+      const mockColumnUpdated = { id: 'updatedDate', field: 'updatedDate', type: FieldType.date } as Column;
+      const mockColumnFilters = {
+        company: { columnId: 'company', columnDef: mockColumnCompany, searchTerms: ['abc'], operator: 'Contains' },
+        updatedDate: { columnId: 'updatedDate', columnDef: mockColumnUpdated, searchTerms: ['2001-02-28'], operator: 'EQ' },
+      } as ColumnFilters;
+
+      service.init(serviceOptions, paginationOptions, gridStub);
+      service.updateFilters(mockColumnFilters, false);
+      const query = service.buildQuery();
+
+      expect(query).toBe(expectation);
     });
   });
 

--- a/src/aurelia-slickgrid/services/grid-odata.service.ts
+++ b/src/aurelia-slickgrid/services/grid-odata.service.ts
@@ -340,12 +340,15 @@ export class GridOdataService implements BackendService {
           } else if (fieldType === FieldType.string) {
             // string field needs to be in single quotes
             if (operator === '' || operator === OperatorType.contains || operator === OperatorType.notContains) {
-              searchBy = `substringof('${searchValue}', ${fieldName})`;
+              if (this._odataService.options.version >= 4) {
+                searchBy = `contains(${fieldName}, '${searchValue}')`;
+              } else {
+                searchBy = `substringof('${searchValue}', ${fieldName})`;
+              }
               if (operator === OperatorType.notContains) {
                 searchBy = `not ${searchBy}`;
               }
             } else {
-              // searchBy = `substringof('${searchValue}', ${fieldNameCased}) ${this.mapOdataOperator(operator)} true`;
               searchBy = `${fieldName} ${this.mapOdataOperator(operator)} '${searchValue}'`;
             }
           } else {

--- a/src/examples/slickgrid/example3.html
+++ b/src/examples/slickgrid/example3.html
@@ -1,7 +1,7 @@
 <template>
   <h2>${title}</h2>
   <div class="subtitle"
-       innerhtml.bind="subTitle"></div>
+    innerhtml.bind="subTitle"></div>
 
   <div class="col-sm-6">
     <label>autoEdit setting</label>
@@ -10,56 +10,56 @@
       <div class="row">
 
         <label class="radio-inline control-label"
-               for="radioTrue">
+          for="radioTrue">
           <input type="radio"
-                 name="inlineRadioOptions"
-                 id="radioTrue"
-                 checked
-                 value.bind="isAutoEdit"
-                 click.delegate="setAutoEdit(true)"> ON
+            name="inlineRadioOptions"
+            id="radioTrue"
+            checked
+            value.bind="isAutoEdit"
+            click.delegate="setAutoEdit(true)"> ON
           (single-click)
         </label>
         <label class="radio-inline control-label"
-               for="radioFalse">
+          for="radioFalse">
           <input type="radio"
-                 name="inlineRadioOptions"
-                 id="radioFalse"
-                 value.bind="isAutoEdit"
-                 click.delegate="setAutoEdit(false)"> OFF
+            name="inlineRadioOptions"
+            id="radioFalse"
+            value.bind="isAutoEdit"
+            click.delegate="setAutoEdit(false)"> OFF
           (double-click)
         </label>
       </div>
       <div class="row">
         <button class="btn btn-default btn-sm"
-                click.delegate="undo()">
+          click.delegate="undo()">
           <i class="fa fa-undo"></i>
           Undo last edit(s)
         </button>
         <label class="checkbox-inline control-label"
-               for="autoCommitEdit">
+          for="autoCommitEdit">
           <input type="checkbox"
-                 id="autoCommitEdit"
-                 value.bind="gridOptions.autoCommitEdit"
-                 click.delegate="changeAutoCommit()">
+            id="autoCommitEdit"
+            value.bind="gridOptions.autoCommitEdit"
+            click.delegate="changeAutoCommit()">
           Auto Commit Edit
         </label>
       </div>
     </span>
     <div class="row"
-         style="margin-top: 5px">
+      style="margin-top: 5px">
       <button class="btn btn-default btn-sm"
-              click.delegate="aureliaGrid.filterService.clearFilters()">Clear Filters</button>
+        click.delegate="aureliaGrid.filterService.clearFilters()">Clear Filters</button>
       <button class="btn btn-default btn-sm"
-              click.delegate="aureliaGrid.sortService.clearSorting()">Clear Sorting</button>
+        click.delegate="aureliaGrid.sortService.clearSorting()">Clear Sorting</button>
       <button class="btn btn-default btn-sm btn-info"
-              click.delegate="addItem()"
-              title="Clear Filters &amp; Sorting to see it better">
+        click.delegate="addItem()"
+        title="Clear Filters &amp; Sorting to see it better">
         Add item
       </button>
       <button class="btn btn-default btn-sm btn-danger"
-              click.delegate="deleteItem()">Delete item</button>
+        click.delegate="deleteItem()">Delete item</button>
       <button class="btn btn-default btn-sm"
-              click.delegate="dynamicallyAddTitleHeader()">
+        click.delegate="dynamicallyAddTitleHeader()">
         <i class="fa fa-plus"></i>
         Dynamically Duplicate Title Column
       </button>
@@ -68,25 +68,25 @@
 
   <div class="col-sm-6">
     <div class="alert alert-info"
-         show.bind="updatedObject">
+      show.bind="updatedObject">
       <strong>Updated Item:</strong> ${updatedObject | stringify}
     </div>
     <div class="alert alert-warning"
-         show.bind="alertWarning">
+      show.bind="alertWarning">
       ${alertWarning}
     </div>
   </div>
 
   <div id="grid-container"
-       class="col-sm-12">
+    class="col-sm-12">
     <aurelia-slickgrid grid-id="grid1"
-                       column-definitions.bind="columnDefinitions"
-                       grid-options.bind="gridOptions"
-                       dataset.bind="dataset"
-                       sg-on-cell-change.delegate="onCellChanged($event.detail.eventData, $event.detail.args)"
-                       sg-on-click.delegate="onCellClicked($event.detail.eventData, $event.detail.args)"
-                       sg-on-validation-error.delegate="onCellValidation($event.detail.eventData, $event.detail.args)"
-                       asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)">
+      column-definitions.bind="columnDefinitions"
+      grid-options.bind="gridOptions"
+      dataset.bind="dataset"
+      sg-on-cell-change.delegate="onCellChanged($event.detail.eventData, $event.detail.args)"
+      sg-on-click.delegate="onCellClicked($event.detail.eventData, $event.detail.args)"
+      sg-on-validation-error.delegate="onCellValidation($event.detail.eventData, $event.detail.args)"
+      asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)">
     </aurelia-slickgrid>
   </div>
 </template>

--- a/src/examples/slickgrid/example5.html
+++ b/src/examples/slickgrid/example5.html
@@ -1,13 +1,13 @@
 <template>
   <h2>${title}</h2>
   <div class="subtitle"
-       innerhtml.bind="subTitle"></div>
+    innerhtml.bind="subTitle"></div>
 
   <div class="row">
     <div class="col-sm-4">
       <div class.bind="status.class"
-           role="alert"
-           data-test="status">
+        role="alert"
+        data-test="status">
         <strong>Status: </strong> ${status.text}
         <span hidden.bind="!processing">
           <i class="fa fa-refresh fa-spin fa-lg fa-fw"></i>
@@ -21,17 +21,39 @@
     </div>
     <div class="col-sm-8">
       <div class="alert alert-info"
-           data-test="alert-odata-query">
+        data-test="alert-odata-query">
         <strong>OData Query:</strong> <span data-test="odata-query-result">${odataQuery}</span>
       </div>
+      <label>OData Version: </label>
+      <span data-test="radioVersion">
+        <label class="radio-inline control-label"
+          for="radio2">
+          <input type="radio"
+            name="inlineRadioOptions"
+            data-test="version2"
+            id="radio2"
+            checked
+            value.bind="2"
+            click.delegate="setOdataVersion(2)"> 2
+        </label>
+        <label class="radio-inline control-label"
+          for="radio4">
+          <input type="radio"
+            name="inlineRadioOptions"
+            data-test="version4"
+            id="radio4"
+            value.bind="4"
+            click.delegate="setOdataVersion(4)"> 4
+        </label>
+      </span>
     </div>
   </div>
 
   <aurelia-slickgrid grid-id="grid5"
-                     column-definitions.bind="columnDefinitions"
-                     grid-options.bind="gridOptions"
-                     dataset.bind="dataset"
-                     asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
-                     asg-on-grid-state-changed.delegate="gridStateChanged($event)">
+    column-definitions.bind="columnDefinitions"
+    grid-options.bind="gridOptions"
+    dataset.bind="dataset"
+    asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
+    asg-on-grid-state-changed.delegate="gridStateChanged($event)">
   </aurelia-slickgrid>
 </template>

--- a/test/cypress/integration/example5.spec.js
+++ b/test/cypress/integration/example5.spec.js
@@ -1,5 +1,3 @@
-/// <reference types="Cypress" />
-
 describe('Example 5 - OData Grid', () => {
   it('should display Example 5 title', () => {
     cy.visit(`${Cypress.config('baseExampleUrl')}/example5`);
@@ -96,5 +94,44 @@ describe('Example 5 - OData Grid', () => {
       .should(($span) => {
         expect($span.text()).to.eq(`$top=10`);
       });
+  });
+
+  it('should use "substringof" when OData version is set to 2', () => {
+    cy.get('.search-filter.filter-name')
+      .find('input')
+      .type('John');
+
+    // wait for the query to finish
+    cy.get('[data-test=status]').should('contain', 'done');
+
+    cy.get('[data-test=odata-query-result]')
+      .should(($span) => {
+        expect($span.text()).to.eq(`$top=10&$filter=(substringof('John', Name))`);
+      });
+
+    cy.get('#grid5')
+      .find('.slick-row')
+      .should('have.length', 1);
+  });
+
+  it('should use "contains" when OData version is set to 4', () => {
+    cy.get('[data-test=version4]')
+      .click();
+
+    cy.get('.search-filter.filter-name')
+      .find('input')
+      .type('John');
+
+    // wait for the query to finish
+    cy.get('[data-test=status]').should('contain', 'done');
+
+    cy.get('[data-test=odata-query-result]')
+      .should(($span) => {
+        expect($span.text()).to.eq(`$top=10&$filter=(contains(Name, 'John'))`);
+      });
+
+    cy.get('#grid5')
+      .find('.slick-row')
+      .should('have.length', 1);
   });
 });


### PR DESCRIPTION
- defaults to OData version 2 (which uses substringof)
- ref #88 and Angular-Slickgrid issue [#263](https://github.com/ghiscoding/Angular-Slickgrid/issues/263)

- Tasks
  - [x] update Jest unit tests
  - [x] update Cypress E2E tests
  - [x] add radio box in Example 5 to demo the query string differences between the 2 OData versions

### OData Version 2
`$top=20&$orderby=Name asc&$filter=(Gender eq 'male' and substringof('John', Name))`

![image](https://user-images.githubusercontent.com/643976/62665946-3f799b80-b94f-11e9-9b40-3d802a242c14.png)

### OData Version 4
`$top=20&$orderby=Name asc&$filter=(contains(Name, 'John') and Gender eq 'male')`

![image](https://user-images.githubusercontent.com/643976/62666211-6edcd800-b950-11e9-92be-a4c66727c7b2.png)
