### PR TITLE
feat(backend): extract Pagination into its own Service to expose methods

### DIFF
--- a/src/aurelia-slickgrid/aurelia-slickgrid.html
+++ b/src/aurelia-slickgrid/aurelia-slickgrid.html
@@ -6,6 +6,8 @@
 
     <slick-pagination id="slickPagingContainer-${gridId}" if.bind="showPagination"
       asg-on-pagination-changed.delegate="paginationChanged($event.detail)" dataview.bind="dataview" grid.bind="grid"
+      enable-translate.bind="gridOptions.enableTranslate" options.bind="paginationOptions" locales.bind="locales"
+      total-items.bind="totalItems" backend-service-api.bind="backendServiceApi"
       grid-pagination-options.bind="gridPaginationOptions">
     </slick-pagination>
   </div>

--- a/src/aurelia-slickgrid/aurelia-slickgrid.html
+++ b/src/aurelia-slickgrid/aurelia-slickgrid.html
@@ -5,8 +5,7 @@
     </div>
 
     <slick-pagination id="slickPagingContainer-${gridId}" if.bind="showPagination"
-      asg-on-pagination-changed.delegate="paginationChanged($event.detail)"
-      dataview.bind="dataview"
+      asg-on-pagination-changed.delegate="paginationChanged($event.detail)" dataview.bind="dataview" grid.bind="grid"
       grid-pagination-options.bind="gridPaginationOptions">
     </slick-pagination>
   </div>

--- a/src/aurelia-slickgrid/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/aurelia-slickgrid.ts
@@ -32,6 +32,7 @@ import {
   GridService,
   GridStateService,
   GroupingAndColspanService,
+  PaginationService,
   ResizerService,
   SortService,
   toKebabCase,
@@ -59,6 +60,7 @@ const DEFAULT_SLICKGRID_EVENT_PREFIX = 'sg';
   GridService,
   GridStateService,
   GroupingAndColspanService,
+  PaginationService,
   ResizerService,
   SharedService,
   SortService,
@@ -102,6 +104,7 @@ export class AureliaSlickgridCustomElement {
     private gridService: GridService,
     private gridStateService: GridStateService,
     private groupingAndColspanService: GroupingAndColspanService,
+    private paginationService: PaginationService,
     private resizerService: ResizerService,
     private sharedService: SharedService,
     private sortService: SortService,
@@ -114,6 +117,7 @@ export class AureliaSlickgridCustomElement {
       gridService,
       gridStateService,
       groupingAndColspanService,
+      paginationService,
       resizerService,
       sortService
     ];
@@ -252,6 +256,7 @@ export class AureliaSlickgridCustomElement {
       gridService: this.gridService,
       groupingService: this.groupingAndColspanService,
       extensionService: this.extensionService,
+      paginationService: this.paginationService,
 
       /** @deprecated please use "extensionService" instead */
       pluginService: this.extensionService,

--- a/src/aurelia-slickgrid/editors/longTextEditor.ts
+++ b/src/aurelia-slickgrid/editors/longTextEditor.ts
@@ -41,7 +41,7 @@ export class LongTextEditor implements Editor {
     this.grid = args.grid;
     this.gridOptions = args.grid && args.grid.getOptions() as GridOption;
 
-    // get locales provided by user in forRoot or else use default English locales via the Constants
+    // get locales provided by user in main file or else use default English locales via the Constants
     this._locales = this.gridOptions && this.gridOptions.locales || Constants.locales;
 
     this.init();

--- a/src/aurelia-slickgrid/extensions/extensionUtility.ts
+++ b/src/aurelia-slickgrid/extensions/extensionUtility.ts
@@ -86,7 +86,7 @@ export class ExtensionUtility {
     const picker = this.sharedService.gridOptions && this.sharedService.gridOptions[pickerName] || {};
     const enableTranslate = this.sharedService.gridOptions && this.sharedService.gridOptions.enableTranslate || false;
 
-    // get locales provided by user in forRoot or else use default English locales via the Constants
+    // get locales provided by user in main file or else use default English locales via the Constants
     const locales = this.sharedService && this.sharedService.gridOptions && this.sharedService.gridOptions.locales || Constants.locales;
 
     const title = picker && picker[propName];

--- a/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
@@ -87,7 +87,7 @@ export class GridMenuExtension implements Extension {
     this._userOriginalGridMenu = { ...this.sharedService.gridOptions.gridMenu } as GridMenu;
 
     if (this.sharedService.gridOptions && this.sharedService.gridOptions.gridMenu) {
-      // get locales provided by user in forRoot or else use default English locales via the Constants
+      // get locales provided by user in main file or else use default English locales via the Constants
       this._locales = this.sharedService.gridOptions && this.sharedService.gridOptions.locales || Constants.locales;
 
       // dynamically import the SlickGrid plugin (addon) with RequireJS

--- a/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
@@ -80,7 +80,7 @@ export class HeaderMenuExtension implements Extension {
     }
 
     if (this.sharedService && this.sharedService.grid && this.sharedService.gridOptions) {
-      // get locales provided by user in forRoot or else use default English locales via the Constants
+      // get locales provided by user in main file or else use default English locales via the Constants
       this._locales = this.sharedService.gridOptions && this.sharedService.gridOptions.locales || Constants.locales;
 
       // dynamically import the SlickGrid plugin (addon) with RequireJS

--- a/src/aurelia-slickgrid/filters/compoundInputFilter.ts
+++ b/src/aurelia-slickgrid/filters/compoundInputFilter.ts
@@ -77,7 +77,7 @@ export class CompoundInputFilter implements Filter {
     this.operator = args.operator || '';
     this.searchTerms = (args.hasOwnProperty('searchTerms') ? args.searchTerms : []) || [];
 
-    // get locales provided by user in forRoot or else use default English locales via the Constants
+    // get locales provided by user in main file or else use default English locales via the Constants
     this._locales = this.gridOptions && this.gridOptions.locales || Constants.locales;
 
     // filter input can only have 1 search term, so we will use the 1st array index if it exist

--- a/src/aurelia-slickgrid/filters/selectFilter.ts
+++ b/src/aurelia-slickgrid/filters/selectFilter.ts
@@ -122,7 +122,7 @@ export class SelectFilter implements Filter {
       throw new Error(`[select-filter] The i18n Service is required for the Select Filter to work correctly when "enableTranslateLabel" is set.`);
     }
 
-    // get locales provided by user in forRoot or else use default English locales via the Constants
+    // get locales provided by user in main file or else use default English locales via the Constants
     this._locales = this.gridOptions && this.gridOptions.locales || Constants.locales;
 
     // create the multiple select element

--- a/src/aurelia-slickgrid/models/aureliaGridInstance.interface.ts
+++ b/src/aurelia-slickgrid/models/aureliaGridInstance.interface.ts
@@ -7,6 +7,7 @@ import {
   GridEventService,
   GridStateService,
   GroupingAndColspanService,
+  PaginationService,
   ResizerService,
   SortService
 } from '../services/index';
@@ -52,6 +53,9 @@ export interface AureliaGridInstance {
 
   /** Grouping (and colspan) Service */
   groupingService: GroupingAndColspanService;
+
+  /** Pagination Service (allows you to programmatically go to first/last page, etc...) */
+  paginationService: PaginationService;
 
   /** Resizer Service (including auto-resize) */
   resizerService: ResizerService;

--- a/src/aurelia-slickgrid/models/index.ts
+++ b/src/aurelia-slickgrid/models/index.ts
@@ -93,6 +93,7 @@ export * from './odataSortingOption.interface';
 export * from './onEventArgs.interface';
 export * from './operatorString';
 export * from './operatorType.enum';
+export * from './pager.interface';
 export * from './pagination.interface';
 export * from './paginationChangedArgs.interface';
 export * from './queryArgument.interface';

--- a/src/aurelia-slickgrid/models/pager.interface.ts
+++ b/src/aurelia-slickgrid/models/pager.interface.ts
@@ -1,0 +1,9 @@
+export interface Pager {
+  from: number;
+  to: number;
+  itemsPerPage: number;
+  pageCount: number;
+  pageNumber: number;
+  availablePageSizes: number[];
+  totalItems: number;
+}

--- a/src/aurelia-slickgrid/models/pagination.interface.ts
+++ b/src/aurelia-slickgrid/models/pagination.interface.ts
@@ -2,5 +2,5 @@ export interface Pagination {
   pageNumber?: number;
   pageSizes: number[];
   pageSize: number;
-  totalItems: number;
+  totalItems?: number;
 }

--- a/src/aurelia-slickgrid/services/__tests__/backend-utilities.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/backend-utilities.spec.ts
@@ -19,7 +19,7 @@ describe('backend-utilities', () => {
       const now = new Date();
       gridOptionMock.backendServiceApi.internalPostProcess = jest.fn();
       const spy = jest.spyOn(gridOptionMock.backendServiceApi, 'internalPostProcess');
-      executeBackendProcessesCallback(now, { data: {} }, gridOptionMock.backendServiceApi, gridOptionMock);
+      executeBackendProcessesCallback(now, { data: {} }, gridOptionMock.backendServiceApi, 0);
 
       expect(spy).toHaveBeenCalled();
     });
@@ -49,7 +49,7 @@ describe('backend-utilities', () => {
       gridOptionMock.pagination = { totalItems: 1, pageSizes: [10, 25], pageSize: 10 };
 
       const spy = jest.spyOn(gridOptionMock.backendServiceApi, 'postProcess');
-      executeBackendProcessesCallback(now, mockResult, gridOptionMock.backendServiceApi, gridOptionMock);
+      executeBackendProcessesCallback(now, mockResult, gridOptionMock.backendServiceApi, 1);
 
       expect(spy).toHaveBeenCalledWith(expectaction);
     });

--- a/src/aurelia-slickgrid/services/__tests__/pagination.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/pagination.service.spec.ts
@@ -1,0 +1,578 @@
+import 'jest-extended';
+import { EventAggregator } from 'aurelia-event-aggregator';
+
+import { PaginationService } from './../pagination.service';
+import { FilterService, GridService } from '../index';
+import { Column, GridOption, CurrentFilter } from '../../models';
+import * as utilities from '../backend-utilities';
+
+const DEFAULT_AURELIA_EVENT_PREFIX = 'asg';
+
+const mockExecuteBackendProcess = jest.fn();
+// @ts-ignore
+utilities.executeBackendProcessesCallback = mockExecuteBackendProcess;
+
+const mockBackendError = jest.fn();
+// @ts-ignore
+utilities.onBackendError = mockBackendError;
+
+const dataviewStub = {
+  onRowCountChanged: jest.fn(),
+  onRowsChanged: jest.fn(),
+};
+
+const mockBackendService = {
+  resetPaginationOptions: jest.fn(),
+  buildQuery: jest.fn(),
+  updateOptions: jest.fn(),
+  processOnFilterChanged: jest.fn(),
+  processOnSortChanged: jest.fn(),
+  processOnPaginationChanged: jest.fn(),
+};
+
+const mockGridOption = {
+  enableAutoResize: true,
+  backendServiceApi: {
+    service: mockBackendService,
+    process: jest.fn(),
+    options: {
+      columnDefinitions: [{ id: 'name', field: 'name' }] as Column[],
+      datasetName: 'user',
+    }
+  },
+  pagination: {
+    pageSizes: [10, 15, 20, 25, 30, 40, 50, 75, 100],
+    pageSize: 25,
+    totalItems: 85
+  }
+} as GridOption;
+
+const gridStub = {
+  autosizeColumns: jest.fn(),
+  getColumnIndex: jest.fn(),
+  getOptions: () => mockGridOption,
+  getColumns: jest.fn(),
+  setColumns: jest.fn(),
+  onColumnsReordered: jest.fn(),
+  onColumnsResized: jest.fn(),
+  registerPlugin: jest.fn(),
+};
+
+const filterServiceStub = {
+  clearFilters: jest.fn(),
+} as unknown as FilterService;
+
+const gridServiceStub = {
+  resetColumns: jest.fn(),
+} as unknown as GridService;
+
+describe('PaginationService', () => {
+  let service: PaginationService;
+  const ea = new EventAggregator();
+
+  beforeEach(() => {
+    service = new PaginationService(ea, filterServiceStub, gridServiceStub);
+  });
+
+  afterEach(() => {
+    mockGridOption.pagination.pageSize = 25;
+    mockGridOption.pagination.pageNumber = 2;
+    mockGridOption.pagination.totalItems = 85;
+    service.dispose();
+    jest.clearAllMocks();
+  });
+
+  it('should create the service', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should initialize the service and call "refreshPagination" and trigger "onPaginationChanged" event', () => {
+    const refreshSpy = jest.spyOn(service, 'refreshPagination');
+    const eaSpy = jest.spyOn(ea, 'publish');
+    service.init(gridStub, dataviewStub, mockGridOption);
+
+    expect(service.gridPaginationOptions).toEqual(mockGridOption);
+    expect(service.pager).toBeTruthy();
+    expect(refreshSpy).toHaveBeenCalled();
+    expect(service.getCurrentPageNumber()).toBe(2);
+    expect(eaSpy).toHaveBeenCalledWith(`paginationService:on-pagination-changed`, {
+      from: 26, to: 50, itemsPerPage: 25, pageCount: 4, pageNumber: 2, totalItems: 85, availablePageSizes: mockGridOption.pagination.pageSizes
+    });
+  });
+
+  it('should initialize the service and be able to change the grid options by the SETTER and expect the GETTER to have updated options', () => {
+    const mockGridOptionCopy = { ...mockGridOption, options: null };
+    service.init(gridStub, dataviewStub, mockGridOptionCopy);
+    service.gridPaginationOptions = mockGridOption;
+
+    expect(service.gridPaginationOptions).toEqual(mockGridOption);
+    expect(service.pager).toBeTruthy();
+    expect(service.getCurrentPageNumber()).toBe(2);
+  });
+
+  describe('changeItemPerPage method', () => {
+    it('should be on page 0 when total items is 0', () => {
+      mockGridOption.pagination.totalItems = 0;
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.changeItemPerPage(30);
+
+      expect(service.getCurrentPageNumber()).toBe(0);
+      expect(service.getCurrentItemPerPageCount()).toBe(30);
+    });
+
+    it('should be on page 1 with 2 pages when total items is 51 and we set 50 per page', () => {
+      mockGridOption.pagination.pageSize = 25;
+      mockGridOption.pagination.pageNumber = 2;
+      mockGridOption.pagination.totalItems = 51;
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.changeItemPerPage(50);
+
+      expect(service.getCurrentPageNumber()).toBe(1);
+      expect(service.getCurrentItemPerPageCount()).toBe(50);
+    });
+
+    it('should be on page 1 with 2 pages when total items is 100 and we set 50 per page', () => {
+      mockGridOption.pagination.pageSize = 25;
+      mockGridOption.pagination.pageNumber = 2;
+      mockGridOption.pagination.totalItems = 100;
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.changeItemPerPage(50);
+
+      expect(service.getCurrentPageNumber()).toBe(1);
+      expect(service.getCurrentItemPerPageCount()).toBe(50);
+    });
+  });
+
+  describe('goToFirstPage method', () => {
+    it('should expect current page to be 1 and "processOnPageChanged" method to be called', () => {
+      const spy = jest.spyOn(service, 'processOnPageChanged');
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.goToFirstPage();
+
+      expect(service.pager.from).toBe(1);
+      expect(service.pager.to).toBe(25);
+      expect(service.getCurrentPageNumber()).toBe(1);
+      expect(spy).toHaveBeenCalledWith(1, undefined);
+    });
+  });
+
+  describe('goToLastPage method', () => {
+    it('should call "goToLastPage" method and expect current page to be last page and "processOnPageChanged" method to be called', () => {
+      const spy = jest.spyOn(service, 'processOnPageChanged');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.goToLastPage();
+
+      expect(service.pager.from).toBe(76);
+      expect(service.pager.to).toBe(85);
+      expect(service.getCurrentPageNumber()).toBe(4);
+      expect(spy).toHaveBeenCalledWith(4, undefined);
+    });
+  });
+
+  describe('goToNextPage method', () => {
+    it('should expect page to increment by 1 and "processOnPageChanged" method to be called', () => {
+      const spy = jest.spyOn(service, 'processOnPageChanged');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.goToNextPage();
+
+      expect(service.pager.from).toBe(51);
+      expect(service.pager.to).toBe(75);
+      expect(service.getCurrentPageNumber()).toBe(3);
+      expect(spy).toHaveBeenCalledWith(3, undefined);
+    });
+
+    it('should expect page to increment by 1 and "processOnPageChanged" method to be called', () => {
+      const spy = jest.spyOn(service, 'processOnPageChanged');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.goToNextPage();
+
+      expect(service.pager.from).toBe(51);
+      expect(service.pager.to).toBe(75);
+      expect(service.getCurrentPageNumber()).toBe(3);
+      expect(spy).toHaveBeenCalledWith(3, undefined);
+    });
+
+    it('should not expect "processOnPageChanged" method to be called when we are already on last page', () => {
+      const spy = jest.spyOn(service, 'processOnPageChanged');
+      mockGridOption.pagination.pageNumber = 4;
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.goToNextPage();
+
+      expect(service.pager.from).toBe(76);
+      expect(service.pager.to).toBe(85);
+      expect(service.getCurrentPageNumber()).toBe(4);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('goToPreviousPage method', () => {
+    it('should expect page to decrement by 1 and "processOnPageChanged" method to be called', () => {
+      const spy = jest.spyOn(service, 'processOnPageChanged');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.goToPreviousPage();
+
+      expect(service.pager.from).toBe(1);
+      expect(service.pager.to).toBe(25);
+      expect(service.getCurrentPageNumber()).toBe(1);
+      expect(spy).toHaveBeenCalledWith(1, undefined);
+    });
+
+    it('should not expect "processOnPageChanged" method to be called when we are already on first page', () => {
+      const spy = jest.spyOn(service, 'processOnPageChanged');
+      mockGridOption.pagination.pageNumber = 1;
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.goToPreviousPage();
+
+      expect(service.pager.from).toBe(1);
+      expect(service.pager.to).toBe(25);
+      expect(service.getCurrentPageNumber()).toBe(1);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('goToPageNumber', () => {
+    it('should expect page to decrement by 1 and "processOnPageChanged" method to be called', () => {
+      const spy = jest.spyOn(service, 'processOnPageChanged');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.goToPageNumber(4);
+
+      expect(service.pager.from).toBe(76);
+      expect(service.pager.to).toBe(85);
+      expect(service.getCurrentPageNumber()).toBe(4);
+      expect(spy).toHaveBeenCalledWith(4, undefined);
+    });
+
+    it('should expect to go to page 1 when input number is below 1', () => {
+      const spy = jest.spyOn(service, 'processOnPageChanged');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.goToPageNumber(0);
+
+      expect(service.pager.from).toBe(1);
+      expect(service.pager.to).toBe(25);
+      expect(service.getCurrentPageNumber()).toBe(1);
+      expect(spy).toHaveBeenCalledWith(1, undefined);
+    });
+
+    it('should expect to go to last page (4) when input number is bigger than the last page number', () => {
+      const spy = jest.spyOn(service, 'processOnPageChanged');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.goToPageNumber(10);
+
+      expect(service.pager.from).toBe(76);
+      expect(service.pager.to).toBe(85);
+      expect(service.getCurrentPageNumber()).toBe(4);
+      expect(spy).toHaveBeenCalledWith(4, undefined);
+    });
+
+    it('should not expect "processOnPageChanged" method to be called when we are already on same page', () => {
+      const spy = jest.spyOn(service, 'processOnPageChanged');
+      mockGridOption.pagination.pageNumber = 2;
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.goToPageNumber(2);
+
+      expect(service.pager.from).toBe(26);
+      expect(service.pager.to).toBe(50);
+      expect(service.getCurrentPageNumber()).toBe(2);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('processOnPageChanged method', () => {
+    beforeEach(() => {
+      mockGridOption.backendServiceApi = {
+        service: mockBackendService,
+        process: jest.fn(),
+        options: {
+          columnDefinitions: [{ id: 'name', field: 'name' }] as Column[],
+          datasetName: 'user',
+        }
+      };
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should throw an error when no backendServiceApi is provided', async () => {
+      service.init(gridStub, dataviewStub, mockGridOption);
+      mockGridOption.backendServiceApi = null;
+
+      await expect(service.processOnPageChanged(1)).rejects.toThrowError(`BackendServiceApi requires the following 2 properties "process" and "service" to be defined.`);
+    });
+
+    it('should execute "preProcess" method when defined', () => {
+      const spy = jest.fn();
+      mockGridOption.backendServiceApi.preProcess = spy;
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.processOnPageChanged(1);
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should execute "process" method and catch error when process Promise rejects', async () => {
+      const mockError = { error: '404' };
+      const postSpy = jest.fn();
+      mockGridOption.backendServiceApi.process = postSpy;
+      jest.spyOn(mockBackendService, 'processOnPaginationChanged').mockReturnValue('backend query');
+      const promise = new Promise((resolve, reject) => setTimeout(() => reject(mockError), 1));
+      jest.spyOn(mockGridOption.backendServiceApi, 'process').mockReturnValue(promise);
+
+      try {
+        service.init(gridStub, dataviewStub, mockGridOption);
+        await service.processOnPageChanged(1);
+      } catch (e) {
+        expect(mockBackendError).toHaveBeenCalledWith(mockError, mockGridOption.backendServiceApi);
+      }
+    });
+
+    it('should execute "process" method when defined', (done) => {
+      const postSpy = jest.fn();
+      mockGridOption.backendServiceApi.process = postSpy;
+      jest.spyOn(mockBackendService, 'processOnPaginationChanged').mockReturnValue('backend query');
+      const now = new Date();
+      const processResult = { users: [{ name: 'John' }], metrics: { startTime: now, endTime: now, executionTime: 0, totalItemCount: 0 } };
+      const promise = new Promise((resolve) => setTimeout(() => resolve(processResult), 1));
+      jest.spyOn(mockGridOption.backendServiceApi, 'process').mockReturnValue(promise);
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.processOnPageChanged(1);
+
+      setTimeout(() => {
+        expect(postSpy).toHaveBeenCalled();
+        expect(mockExecuteBackendProcess).toHaveBeenCalledWith(expect.toBeDate(), processResult, mockGridOption.backendServiceApi, mockGridOption);
+        done();
+      }, 10);
+    });
+  });
+
+  describe('recalculateFromToIndexes method', () => {
+    it('should recalculate the From/To as 0 when total items is 0', () => {
+      mockGridOption.pagination.pageSize = 25;
+      mockGridOption.pagination.pageNumber = 2;
+      mockGridOption.pagination.totalItems = 0;
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.recalculateFromToIndexes();
+
+      expect(service.pager.from).toBe(0);
+      expect(service.pager.to).toBe(0);
+    });
+
+    it('should recalculate the From/To within range', () => {
+      mockGridOption.pagination.pageSize = 25;
+      mockGridOption.pagination.pageNumber = 2;
+      mockGridOption.pagination.totalItems = 85;
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.recalculateFromToIndexes();
+
+      expect(service.pager.from).toBe(26);
+      expect(service.pager.to).toBe(50);
+    });
+
+    it('should recalculate the From/To within range and have the To equal the total items when total items is not a modulo of 1', () => {
+      mockGridOption.pagination.pageSize = 25;
+      mockGridOption.pagination.pageNumber = 4;
+      mockGridOption.pagination.totalItems = 85;
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      service.recalculateFromToIndexes();
+
+      expect(service.pager.from).toBe(76);
+      expect(service.pager.to).toBe(85);
+    });
+  });
+
+  describe('refreshPagination method', () => {
+    beforeEach(() => {
+      mockGridOption.backendServiceApi = {
+        service: mockBackendService,
+        process: jest.fn(),
+        options: {
+          columnDefinitions: [{ id: 'name', field: 'name' }] as Column[],
+          datasetName: 'user',
+        }
+      };
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should throw an error when no backendServiceApi is provided', (done) => {
+      try {
+        mockGridOption.backendServiceApi = null;
+        service.init(gridStub, dataviewStub, mockGridOption);
+        service.refreshPagination();
+      } catch (e) {
+        expect(e.toString()).toContain(`BackendServiceApi requires the following 2 properties "process" and "service" to be defined.`);
+        done();
+      }
+    });
+
+    it('should call refreshPagination when "onFilterCleared" is triggered', () => {
+      const eaSpy = jest.spyOn(ea, 'publish');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      ea.publish(`filterService:filterCleared`, true);
+
+      expect(eaSpy).toHaveBeenCalledWith(`paginationService:on-pagination-refreshed`, true);
+    });
+
+    it('should call refreshPagination when "onFilterChanged" is triggered', () => {
+      const eaSpy = jest.spyOn(ea, 'publish');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      ea.publish(`filterService:filterChanged`, { columnId: 'field1', operator: '=', searchTerms: [] });
+
+      expect(eaSpy).toHaveBeenCalledWith(`paginationService:on-pagination-refreshed`, true);
+    });
+  });
+
+  // processOnItemAddedOrRemoved is private but we can spy on recalculateFromToIndexes
+  describe('processOnItemAddedOrRemoved private method', () => {
+    afterEach(() => {
+      mockGridOption.pagination.pageSize = 25;
+      mockGridOption.pagination.pageNumber = 2;
+      mockGridOption.pagination.totalItems = 85;
+      jest.clearAllMocks();
+    });
+
+    it('should call "processOnItemAddedOrRemoved" and expect the (To) to be incremented by 1 when "onItemAdded" is triggered with a single item', (done) => {
+      const mockItems = { name: 'John' };
+      const eaSpy = jest.spyOn(ea, 'publish');
+      const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-added`, mockItems);
+
+      setTimeout(() => {
+        // called 2x times by init() then by processOnItemAddedOrRemoved()
+        expect(recalculateSpy).toHaveBeenCalledTimes(2);
+        expect(eaSpy).toHaveBeenCalledTimes(4); // 4x times (2x for onItemAdded then 2x for onPaginationChanged)
+        expect(eaSpy).toHaveBeenCalledWith(`paginationService:on-pagination-changed`, {
+          from: 26, to: 50, itemsPerPage: 25, pageCount: 4, pageNumber: 2, totalItems: 85, availablePageSizes: mockGridOption.pagination.pageSizes
+        });
+        expect(service.pager.from).toBe(26);
+        expect(service.pager.to).toBe(50 + 1);
+        done();
+      });
+    });
+
+    it('should call "processOnItemAddedOrRemoved" and expect the (To) to be incremented by 2 when "onItemAdded" is triggered with an array of 2 new items', (done) => {
+      const mockItems = [{ name: 'John' }, { name: 'Jane' }];
+      const eaSpy = jest.spyOn(ea, 'publish');
+      const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-added`, mockItems);
+
+      setTimeout(() => {
+        // called 2x times by init() then by processOnItemAddedOrRemoved()
+        expect(recalculateSpy).toHaveBeenCalledTimes(2);
+        expect(eaSpy).toHaveBeenCalledTimes(4); // 4x times (2x for onItemAdded then 2x for onPaginationChanged)
+        expect(eaSpy).toHaveBeenCalledWith(`paginationService:on-pagination-changed`, {
+          from: 26, to: 50, itemsPerPage: 25, pageCount: 4, pageNumber: 2, totalItems: 85, availablePageSizes: mockGridOption.pagination.pageSizes
+        });
+        expect(service.pager.from).toBe(26);
+        expect(service.pager.to).toBe(50 + mockItems.length);
+        done();
+      });
+    });
+
+    it('should call "processOnItemAddedOrRemoved" and expect the (To) to remain the same when "onItemAdded" is triggered without any items', (done) => {
+      const eaSpy = jest.spyOn(ea, 'publish');
+      const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-added`, null);
+
+      setTimeout(() => {
+        // called 1x time by init() only
+        expect(recalculateSpy).toHaveBeenCalledTimes(1);
+        expect(eaSpy).toHaveBeenCalledTimes(3); // 3x times (1x for onItemAdded then 2x for onPaginationChanged)
+        expect(eaSpy).toHaveBeenCalledWith(`paginationService:on-pagination-changed`, {
+          from: 26, to: 50, itemsPerPage: 25, pageCount: 4, pageNumber: 2, totalItems: 85, availablePageSizes: mockGridOption.pagination.pageSizes
+        });
+        expect(service.pager.from).toBe(26);
+        expect(service.pager.to).toBe(50);
+        done();
+      });
+    });
+
+    it('should call "processOnItemAddedOrRemoved" and expect the (To) to be decremented by 2 when "onItemDeleted" is triggered with a single item', (done) => {
+      const mockItems = { name: 'John' };
+      const eaSpy = jest.spyOn(ea, 'publish');
+      const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-deleted`, mockItems);
+
+      setTimeout(() => {
+        // called 2x times by init() then by processOnItemAddedOrRemoved()
+        expect(recalculateSpy).toHaveBeenCalledTimes(2);
+        expect(eaSpy).toHaveBeenCalledTimes(4); // 4x times (2x for onItemAdded then 2x for onPaginationChanged)
+        expect(eaSpy).toHaveBeenCalledWith(`paginationService:on-pagination-changed`, {
+          from: 26, to: 50, itemsPerPage: 25, pageCount: 4, pageNumber: 2, totalItems: 85, availablePageSizes: mockGridOption.pagination.pageSizes
+        });
+        expect(service.pager.from).toBe(26);
+        expect(service.pager.to).toBe(50 - 1);
+        done();
+      });
+    });
+
+    it('should call "processOnItemAddedOrRemoved" and expect the (To) to be decremented by 2 when "onItemDeleted" is triggered with an array of 2 new items', (done) => {
+      const mockItems = [{ name: 'John' }, { name: 'Jane' }];
+      const eaSpy = jest.spyOn(ea, 'publish');
+      const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-deleted`, mockItems);
+
+      setTimeout(() => {
+        // called 2x times by init() then by processOnItemAddedOrRemoved()
+        expect(recalculateSpy).toHaveBeenCalledTimes(2);
+        expect(eaSpy).toHaveBeenCalledTimes(4); // 4x times (2x for onItemAdded then 2x for onPaginationChanged)
+        expect(eaSpy).toHaveBeenCalledWith(`paginationService:on-pagination-changed`, {
+          from: 26, to: 50, itemsPerPage: 25, pageCount: 4, pageNumber: 2, totalItems: 85, availablePageSizes: mockGridOption.pagination.pageSizes
+        });
+        expect(service.pager.from).toBe(26);
+        expect(service.pager.to).toBe(50 - mockItems.length);
+        done();
+      });
+    });
+
+    it('should call "processOnItemAddedOrRemoved" and expect the (To) to remain the same when "onItemDeleted" is triggered without any items', (done) => {
+      const eaSpy = jest.spyOn(ea, 'publish');
+      const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
+
+      service.init(gridStub, dataviewStub, mockGridOption);
+      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-deleted`, null);
+
+      setTimeout(() => {
+        // called 1x time by init() only
+        expect(recalculateSpy).toHaveBeenCalledTimes(1);
+        expect(eaSpy).toHaveBeenCalledTimes(3); // 3x times (1x for onItemAdded then 2x for onPaginationChanged)
+        expect(eaSpy).toHaveBeenCalledWith(`paginationService:on-pagination-changed`, {
+          from: 26, to: 50, itemsPerPage: 25, pageCount: 4, pageNumber: 2, totalItems: 85, availablePageSizes: mockGridOption.pagination.pageSizes
+        });
+        expect(service.pager.from).toBe(26);
+        expect(service.pager.to).toBe(50);
+        done();
+      });
+    });
+  });
+});

--- a/src/aurelia-slickgrid/services/__tests__/pagination.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/pagination.service.spec.ts
@@ -89,9 +89,9 @@ describe('PaginationService', () => {
   it('should initialize the service and call "refreshPagination" and trigger "onPaginationChanged" event', () => {
     const refreshSpy = jest.spyOn(service, 'refreshPagination');
     const eaSpy = jest.spyOn(ea, 'publish');
-    service.init(gridStub, dataviewStub, mockGridOption);
+    service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
 
-    expect(service.gridPaginationOptions).toEqual(mockGridOption);
+    expect(service.paginationOptions).toEqual(mockGridOption.pagination);
     expect(service.pager).toBeTruthy();
     expect(refreshSpy).toHaveBeenCalled();
     expect(service.getCurrentPageNumber()).toBe(2);
@@ -102,18 +102,40 @@ describe('PaginationService', () => {
 
   it('should initialize the service and be able to change the grid options by the SETTER and expect the GETTER to have updated options', () => {
     const mockGridOptionCopy = { ...mockGridOption, options: null };
-    service.init(gridStub, dataviewStub, mockGridOptionCopy);
-    service.gridPaginationOptions = mockGridOption;
+    service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+    service.paginationOptions = mockGridOption.pagination;
 
-    expect(service.gridPaginationOptions).toEqual(mockGridOption);
+    expect(service.paginationOptions).toEqual(mockGridOption.pagination);
     expect(service.pager).toBeTruthy();
     expect(service.getCurrentPageNumber()).toBe(2);
+  });
+
+  it('should initialize the service and be able to change the totalItems by the SETTER and not expect the "refreshPagination" method to be called within the SETTER before initialization', () => {
+    const spy = jest.spyOn(service, 'refreshPagination');
+    service.totalItems = 125;
+    service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+
+    expect(service.totalItems).toEqual(125);
+    expect(service.pager).toBeTruthy();
+    expect(service.getCurrentPageNumber()).toBe(2);
+    expect(spy).toHaveBeenCalledTimes(1); // called 1x time inside the init() only
+  });
+
+  it('should be able to change the totalItems by the SETTER after the initialization and expect the "refreshPagination" method to be called', () => {
+    const spy = jest.spyOn(service, 'refreshPagination');
+    service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+    service.totalItems = 125;
+
+    expect(service.totalItems).toEqual(125);
+    expect(service.pager).toBeTruthy();
+    expect(service.getCurrentPageNumber()).toBe(2);
+    expect(spy).toHaveBeenCalledTimes(2); // called 2x times inside the init() and SETTER
   });
 
   describe('changeItemPerPage method', () => {
     it('should be on page 0 when total items is 0', () => {
       mockGridOption.pagination.totalItems = 0;
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.changeItemPerPage(30);
 
       expect(service.getCurrentPageNumber()).toBe(0);
@@ -125,7 +147,7 @@ describe('PaginationService', () => {
       mockGridOption.pagination.pageNumber = 2;
       mockGridOption.pagination.totalItems = 51;
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.changeItemPerPage(50);
 
       expect(service.getCurrentPageNumber()).toBe(1);
@@ -137,7 +159,7 @@ describe('PaginationService', () => {
       mockGridOption.pagination.pageNumber = 2;
       mockGridOption.pagination.totalItems = 100;
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.changeItemPerPage(50);
 
       expect(service.getCurrentPageNumber()).toBe(1);
@@ -148,7 +170,7 @@ describe('PaginationService', () => {
   describe('goToFirstPage method', () => {
     it('should expect current page to be 1 and "processOnPageChanged" method to be called', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.goToFirstPage();
 
       expect(service.pager.from).toBe(1);
@@ -162,7 +184,7 @@ describe('PaginationService', () => {
     it('should call "goToLastPage" method and expect current page to be last page and "processOnPageChanged" method to be called', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.goToLastPage();
 
       expect(service.pager.from).toBe(76);
@@ -176,7 +198,7 @@ describe('PaginationService', () => {
     it('should expect page to increment by 1 and "processOnPageChanged" method to be called', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.goToNextPage();
 
       expect(service.pager.from).toBe(51);
@@ -188,7 +210,7 @@ describe('PaginationService', () => {
     it('should expect page to increment by 1 and "processOnPageChanged" method to be called', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.goToNextPage();
 
       expect(service.pager.from).toBe(51);
@@ -201,7 +223,7 @@ describe('PaginationService', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
       mockGridOption.pagination.pageNumber = 4;
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.goToNextPage();
 
       expect(service.pager.from).toBe(76);
@@ -215,7 +237,7 @@ describe('PaginationService', () => {
     it('should expect page to decrement by 1 and "processOnPageChanged" method to be called', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.goToPreviousPage();
 
       expect(service.pager.from).toBe(1);
@@ -228,7 +250,7 @@ describe('PaginationService', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
       mockGridOption.pagination.pageNumber = 1;
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.goToPreviousPage();
 
       expect(service.pager.from).toBe(1);
@@ -242,7 +264,7 @@ describe('PaginationService', () => {
     it('should expect page to decrement by 1 and "processOnPageChanged" method to be called', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.goToPageNumber(4);
 
       expect(service.pager.from).toBe(76);
@@ -254,7 +276,7 @@ describe('PaginationService', () => {
     it('should expect to go to page 1 when input number is below 1', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.goToPageNumber(0);
 
       expect(service.pager.from).toBe(1);
@@ -266,7 +288,7 @@ describe('PaginationService', () => {
     it('should expect to go to last page (4) when input number is bigger than the last page number', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.goToPageNumber(10);
 
       expect(service.pager.from).toBe(76);
@@ -279,7 +301,7 @@ describe('PaginationService', () => {
       const spy = jest.spyOn(service, 'processOnPageChanged');
       mockGridOption.pagination.pageNumber = 2;
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.goToPageNumber(2);
 
       expect(service.pager.from).toBe(26);
@@ -305,18 +327,11 @@ describe('PaginationService', () => {
       jest.clearAllMocks();
     });
 
-    it('should throw an error when no backendServiceApi is provided', async () => {
-      service.init(gridStub, dataviewStub, mockGridOption);
-      mockGridOption.backendServiceApi = null;
-
-      await expect(service.processOnPageChanged(1)).rejects.toThrowError(`BackendServiceApi requires the following 2 properties "process" and "service" to be defined.`);
-    });
-
     it('should execute "preProcess" method when defined', () => {
       const spy = jest.fn();
       mockGridOption.backendServiceApi.preProcess = spy;
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.processOnPageChanged(1);
 
       expect(spy).toHaveBeenCalled();
@@ -331,7 +346,7 @@ describe('PaginationService', () => {
       jest.spyOn(mockGridOption.backendServiceApi, 'process').mockReturnValue(promise);
 
       try {
-        service.init(gridStub, dataviewStub, mockGridOption);
+        service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
         await service.processOnPageChanged(1);
       } catch (e) {
         expect(mockBackendError).toHaveBeenCalledWith(mockError, mockGridOption.backendServiceApi);
@@ -347,12 +362,12 @@ describe('PaginationService', () => {
       const promise = new Promise((resolve) => setTimeout(() => resolve(processResult), 1));
       jest.spyOn(mockGridOption.backendServiceApi, 'process').mockReturnValue(promise);
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.processOnPageChanged(1);
 
       setTimeout(() => {
         expect(postSpy).toHaveBeenCalled();
-        expect(mockExecuteBackendProcess).toHaveBeenCalledWith(expect.toBeDate(), processResult, mockGridOption.backendServiceApi, mockGridOption);
+        expect(mockExecuteBackendProcess).toHaveBeenCalledWith(expect.toBeDate(), processResult, mockGridOption.backendServiceApi, 85);
         done();
       }, 10);
     });
@@ -364,7 +379,7 @@ describe('PaginationService', () => {
       mockGridOption.pagination.pageNumber = 2;
       mockGridOption.pagination.totalItems = 0;
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.recalculateFromToIndexes();
 
       expect(service.pager.from).toBe(0);
@@ -376,7 +391,7 @@ describe('PaginationService', () => {
       mockGridOption.pagination.pageNumber = 2;
       mockGridOption.pagination.totalItems = 85;
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.recalculateFromToIndexes();
 
       expect(service.pager.from).toBe(26);
@@ -388,7 +403,7 @@ describe('PaginationService', () => {
       mockGridOption.pagination.pageNumber = 4;
       mockGridOption.pagination.totalItems = 85;
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.recalculateFromToIndexes();
 
       expect(service.pager.from).toBe(76);
@@ -415,7 +430,7 @@ describe('PaginationService', () => {
     it('should throw an error when no backendServiceApi is provided', (done) => {
       try {
         mockGridOption.backendServiceApi = null;
-        service.init(gridStub, dataviewStub, mockGridOption);
+        service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
         service.refreshPagination();
       } catch (e) {
         expect(e.toString()).toContain(`BackendServiceApi requires the following 2 properties "process" and "service" to be defined.`);
@@ -426,7 +441,7 @@ describe('PaginationService', () => {
     it('should call refreshPagination when "onFilterCleared" is triggered', () => {
       const eaSpy = jest.spyOn(ea, 'publish');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       ea.publish(`filterService:filterCleared`, true);
 
       expect(eaSpy).toHaveBeenCalledWith(`paginationService:on-pagination-refreshed`, true);
@@ -435,7 +450,7 @@ describe('PaginationService', () => {
     it('should call refreshPagination when "onFilterChanged" is triggered', () => {
       const eaSpy = jest.spyOn(ea, 'publish');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       ea.publish(`filterService:filterChanged`, { columnId: 'field1', operator: '=', searchTerms: [] });
 
       expect(eaSpy).toHaveBeenCalledWith(`paginationService:on-pagination-refreshed`, true);
@@ -456,7 +471,7 @@ describe('PaginationService', () => {
       const eaSpy = jest.spyOn(ea, 'publish');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-added`, mockItems);
 
       setTimeout(() => {
@@ -477,7 +492,7 @@ describe('PaginationService', () => {
       const eaSpy = jest.spyOn(ea, 'publish');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-added`, mockItems);
 
       setTimeout(() => {
@@ -497,7 +512,7 @@ describe('PaginationService', () => {
       const eaSpy = jest.spyOn(ea, 'publish');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-added`, null);
 
       setTimeout(() => {
@@ -518,7 +533,7 @@ describe('PaginationService', () => {
       const eaSpy = jest.spyOn(ea, 'publish');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-deleted`, mockItems);
 
       setTimeout(() => {
@@ -539,7 +554,7 @@ describe('PaginationService', () => {
       const eaSpy = jest.spyOn(ea, 'publish');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-deleted`, mockItems);
 
       setTimeout(() => {
@@ -559,7 +574,8 @@ describe('PaginationService', () => {
       const eaSpy = jest.spyOn(ea, 'publish');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
-      service.init(gridStub, dataviewStub, mockGridOption);
+      // service.totalItems = 85;
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-deleted`, null);
 
       setTimeout(() => {

--- a/src/aurelia-slickgrid/services/backend-utilities.ts
+++ b/src/aurelia-slickgrid/services/backend-utilities.ts
@@ -6,26 +6,24 @@ import { GridOption, EmitterType } from '../models/index';
  * Execute the backend callback, which are mainly the "process" & "postProcess" methods.
  * Also note that "preProcess" was executed prior to this callback
  */
-export async function executeBackendCallback(query: string, args: any, startTime: Date, gridOptions: GridOption, emitActionChangedCallback: (type: EmitterType) => void) {
-  const backendApi = gridOptions && gridOptions.backendServiceApi;
-
-  if (backendApi) {
+export async function executeBackendCallback(backendServiceApi: BackendServiceApi, query: string, args: any, startTime: Date, totalItems: number, emitActionChangedCallback: (type: EmitterType) => void) {
+  if (backendServiceApi) {
     // emit an onFilterChanged event when it's not called by a clear filter
     if (args && !args.clearFilterTriggered) {
       emitActionChangedCallback(EmitterType.remote);
     }
 
     // the processes can be Observables (like HttpClient) or Promises
-    const process = backendApi.process(query);
+    const process = backendServiceApi.process(query);
     if (process instanceof Promise && process.then) {
-      process.then((processResult: GraphqlResult | any) => executeBackendProcessesCallback(startTime, processResult, backendApi, gridOptions))
-        .catch((error: any) => onBackendError(error, backendApi));
+      process.then((processResult: GraphqlResult | any) => executeBackendProcessesCallback(startTime, processResult, backendServiceApi, totalItems))
+        .catch((error: any) => onBackendError(error, backendServiceApi));
     }
   }
 }
 
 /** Execute the Backend Processes Callback, that could come from an Observable or a Promise callback */
-export function executeBackendProcessesCallback(startTime: Date, processResult: GraphqlResult | any, backendApi: BackendServiceApi, gridOptions: GridOption): GraphqlResult | any {
+export function executeBackendProcessesCallback(startTime: Date, processResult: GraphqlResult | any, backendApi: BackendServiceApi, totalItems: number): GraphqlResult | any {
   const endTime = new Date();
 
   // define what our internal Post Process callback, only available for GraphQL Service for now
@@ -41,8 +39,8 @@ export function executeBackendProcessesCallback(startTime: Date, processResult: 
         startTime,
         endTime,
         executionTime: endTime.valueOf() - startTime.valueOf(),
-        itemCount: gridOptions && gridOptions.pagination && gridOptions.pagination.totalItems,
-        totalItemCount: gridOptions && gridOptions.pagination && gridOptions.pagination.totalItems
+        itemCount: totalItems,
+        totalItemCount: totalItems,
       };
       // @deprecated
       processResult.statistics = processResult.metrics;

--- a/src/aurelia-slickgrid/services/export.service.ts
+++ b/src/aurelia-slickgrid/services/export.service.ts
@@ -56,7 +56,7 @@ export class ExportService {
     this._dataView = dataView;
     this._aureliaEventPrefix = (this._gridOptions && this._gridOptions.defaultAureliaEventPrefix) ? this._gridOptions.defaultAureliaEventPrefix : DEFAULT_AURELIA_EVENT_PREFIX;
 
-    // get locales provided by user in forRoot or else use default English locales via the Constants
+    // get locales provided by user in main file or else use default English locales via the Constants
     this._locales = this._gridOptions && this._gridOptions.locales || Constants.locales;
 
     if (this._gridOptions.enableTranslate && (!this.i18n || !this.i18n.tr)) {

--- a/src/aurelia-slickgrid/services/filter.service.ts
+++ b/src/aurelia-slickgrid/services/filter.service.ts
@@ -224,11 +224,13 @@ export class FilterService {
       // @deprecated, processOnFilterChanged in the future should be return as a query string NOT a Promise
       if (queryResponse instanceof Promise && queryResponse.then) {
         queryResponse.then((query: string) => {
-          executeBackendCallback(query, callbackArgs, new Date(), this._gridOptions, this.emitFilterChanged.bind(this));
+          const totalItems = this._gridOptions && this._gridOptions.pagination && this._gridOptions.pagination.totalItems;
+          executeBackendCallback(backendApi, query, callbackArgs, new Date(), totalItems, this.emitFilterChanged.bind(this));
         });
       } else {
         const query = queryResponse as string;
-        executeBackendCallback(query, callbackArgs, new Date(), this._gridOptions, this.emitFilterChanged.bind(this));
+        const totalItems = this._gridOptions && this._gridOptions.pagination && this._gridOptions.pagination.totalItems;
+        executeBackendCallback(backendApi, query, callbackArgs, new Date(), totalItems, this.emitFilterChanged.bind(this));
       }
     }
 
@@ -424,11 +426,13 @@ export class FilterService {
         clearTimeout(timer);
         timer = setTimeout(async () => {
           const query = await backendApi.service.processOnFilterChanged(event, args);
-          executeBackendCallback(query, args, startTime, this._gridOptions, this.emitFilterChanged.bind(this));
+          const totalItems = this._gridOptions && this._gridOptions.pagination && this._gridOptions.pagination.totalItems;
+          executeBackendCallback(backendApi, query, args, startTime, totalItems, this.emitFilterChanged.bind(this));
         }, debounceTypingDelay);
       } else {
         const query = await backendApi.service.processOnFilterChanged(event, args);
-        executeBackendCallback(query, args, startTime, this._gridOptions, this.emitFilterChanged.bind(this));
+        const totalItems = this._gridOptions && this._gridOptions.pagination && this._gridOptions.pagination.totalItems;
+        executeBackendCallback(backendApi, query, args, startTime, totalItems, this.emitFilterChanged.bind(this));
       }
     }
   }

--- a/src/aurelia-slickgrid/services/graphql.service.ts
+++ b/src/aurelia-slickgrid/services/graphql.service.ts
@@ -239,7 +239,7 @@ export class GraphqlService implements BackendService {
       } as GraphqlCursorPaginationOption;
     } else {
       // first, last, offset
-      paginationOptions = (this.options.paginationOptions || this.getInitPaginationOptions()) as GraphqlPaginationOption;
+      paginationOptions = ((this.options && this.options.paginationOptions) || this.getInitPaginationOptions()) as GraphqlPaginationOption;
       (paginationOptions as GraphqlPaginationOption).offset = 0;
     }
 
@@ -451,7 +451,7 @@ export class GraphqlService implements BackendService {
     };
 
     let paginationOptions;
-    if (this.options.isWithCursor) {
+    if (this.options && this.options.isWithCursor) {
       paginationOptions = {
         first: pageSize
       };

--- a/src/aurelia-slickgrid/services/grid.service.ts
+++ b/src/aurelia-slickgrid/services/grid.service.ts
@@ -279,7 +279,7 @@ export class GridService {
    * Add an item (data item) to the datagrid, by default it will highlight (flashing) the inserted row but we can disable it too
    * @param item object which must contain a unique "id" property and any other suitable properties
    * @param options: provide the possibility to do certain actions after or during the upsert (highlightRow, resortGrid, selectRow, triggerEvent)
-   * @return rowIndex: typically index 0
+   * @return rowIndex: typically index 0 when adding to position "top" or a different number when adding to the "bottom"
    */
   addItem(item: any, options?: GridServiceInsertOption): number {
     options = { ...GridServiceInsertOptionDefaults, ...options };

--- a/src/aurelia-slickgrid/services/index.ts
+++ b/src/aurelia-slickgrid/services/index.ts
@@ -11,6 +11,7 @@ export * from './gridState.service';
 export * from './grid-odata.service';
 export * from './groupingAndColspan.service';
 export * from './odataQueryBuilder.service';
+export * from './pagination.service';
 export * from './resizer.service';
 export * from './shared.service';
 export * from './sort.service';

--- a/src/aurelia-slickgrid/services/pagination.service.ts
+++ b/src/aurelia-slickgrid/services/pagination.service.ts
@@ -1,0 +1,274 @@
+import { inject } from 'aurelia-framework';
+import { EventAggregator, Subscription } from 'aurelia-event-aggregator';
+
+import { GridOption, GraphqlResult, Pager } from '../models';
+import { FilterService } from './filter.service';
+import { GridService } from './grid.service';
+import { executeBackendProcessesCallback, onBackendError } from './backend-utilities';
+import { disposeAllSubscriptions } from './utilities';
+
+const DEFAULT_AURELIA_EVENT_PREFIX = 'asg';
+
+// using external non-typed js libraries
+declare var Slick: any;
+
+@inject(EventAggregator, FilterService, GridService)
+export class PaginationService {
+  set gridPaginationOptions(gridPaginationOptions: GridOption) {
+    this._gridPaginationOptions = gridPaginationOptions;
+  }
+  get gridPaginationOptions(): GridOption {
+    return this._gridPaginationOptions;
+  }
+
+  private _aureliaEventPrefix = DEFAULT_AURELIA_EVENT_PREFIX;
+  private _dataFrom = 1;
+  private _dataTo = 1;
+  private _itemsPerPage: number;
+  private _pageCount = 0;
+  private _pageNumber = 1;
+  private _totalItems = 0;
+  private _availablePageSizes = [25, 75, 100];
+  private _eventHandler = new Slick.EventHandler();
+  private _gridPaginationOptions: GridOption;
+  private _isFirstRender = true;
+  private _subscriptions: Subscription[] = [];
+
+  dataView: any;
+  grid: any;
+
+  /** Constructor */
+  constructor(private ea: EventAggregator, private filterService: FilterService, private gridService: GridService) { }
+
+  get pager(): Pager {
+    return {
+      from: this._dataFrom,
+      to: this._dataTo,
+      itemsPerPage: this._itemsPerPage,
+      pageCount: this._pageCount,
+      pageNumber: this._pageNumber,
+      availablePageSizes: this._availablePageSizes,
+      totalItems: this._totalItems,
+    };
+  }
+
+  init(grid: any, dataView: any, gridPaginationOptions: GridOption) {
+    this.dataView = dataView;
+    this.grid = grid;
+    this._gridPaginationOptions = gridPaginationOptions;
+
+    if (!this._gridPaginationOptions || !this._gridPaginationOptions.pagination || (this._gridPaginationOptions.pagination.totalItems !== this._totalItems)) {
+      this.refreshPagination();
+    }
+    this._isFirstRender = false;
+
+    // Subscribe to Filter Clear & Changed and go back to page 1 when that happen
+    this._subscriptions.push(this.ea.subscribe('filterService:filterChanged', () => this.refreshPagination(true)));
+    this._subscriptions.push(this.ea.subscribe('filterService:filterCleared', () => this.refreshPagination(true)));
+
+    // Subscribe to any dataview row count changed so that when Adding/Deleting item(s) through the DataView
+    // that would trigger a refresh of the pagination numbers
+    if (this.dataView) {
+      this._subscriptions.push(this.ea.subscribe(`${this._aureliaEventPrefix}:on-item-added`, (items: any | any[]) => this.processOnItemAddedOrRemoved(items, true)));
+      this._subscriptions.push(this.ea.subscribe(`${this._aureliaEventPrefix}:on-item-deleted`, (items: any | any[]) => this.processOnItemAddedOrRemoved(items, false)));
+    }
+  }
+
+  dispose() {
+    // unsubscribe all SlickGrid events
+    this._eventHandler.unsubscribeAll();
+
+    // also unsubscribe all Angular Subscriptions
+    this._subscriptions = disposeAllSubscriptions(this._subscriptions);
+  }
+
+  getCurrentPageNumber(): number {
+    return this._pageNumber;
+  }
+
+  getCurrentItemPerPageCount(): number {
+    return this._itemsPerPage;
+  }
+
+  changeItemPerPage(itemsPerPage: number, event?: any): Promise<any> {
+    this._pageCount = Math.ceil(this._totalItems / itemsPerPage);
+    this._pageNumber = (this._totalItems > 0) ? 1 : 0;
+    this._itemsPerPage = itemsPerPage;
+    return this.processOnPageChanged(this._pageNumber, event);
+  }
+
+  goToFirstPage(event?: any): Promise<any> {
+    this._pageNumber = 1;
+    return this.processOnPageChanged(this._pageNumber, event);
+  }
+
+  goToLastPage(event?: any): Promise<any> {
+    this._pageNumber = this._pageCount;
+    return this.processOnPageChanged(this._pageNumber, event);
+  }
+
+  goToNextPage(event?: any): Promise<any> {
+    if (this._pageNumber < this._pageCount) {
+      this._pageNumber++;
+      return this.processOnPageChanged(this._pageNumber, event);
+    } else {
+      return new Promise(resolve => resolve(false));
+    }
+  }
+
+  goToPageNumber(pageNumber: number, event?: any): Promise<any> {
+    const previousPageNumber = this._pageNumber;
+
+    if (pageNumber < 1) {
+      this._pageNumber = 1;
+    } else if (pageNumber > this._pageCount) {
+      this._pageNumber = this._pageCount;
+    } else {
+      this._pageNumber = pageNumber;
+    }
+
+    if (this._pageNumber !== previousPageNumber) {
+      return this.processOnPageChanged(this._pageNumber, event);
+    } else {
+      return new Promise(resolve => resolve(false));
+    }
+  }
+
+  goToPreviousPage(event?: any): Promise<any> {
+    if (this._pageNumber > 1) {
+      this._pageNumber--;
+      return this.processOnPageChanged(this._pageNumber, event);
+    } else {
+      return new Promise(resolve => resolve(false));
+    }
+  }
+
+  refreshPagination(isPageNumberReset: boolean = false) {
+    const backendApi = this._gridPaginationOptions && this._gridPaginationOptions.backendServiceApi;
+    if (!backendApi || !backendApi.service || !backendApi.process) {
+      throw new Error(`BackendServiceApi requires the following 2 properties "process" and "service" to be defined.`);
+    }
+
+    // trigger an event to inform subscribers
+    this.ea.publish(`paginationService:on-pagination-refreshed`, true);
+
+    if (this._gridPaginationOptions && this._gridPaginationOptions.pagination) {
+      const pagination = this._gridPaginationOptions.pagination;
+      // set the number of items per page if not already set
+      if (!this._itemsPerPage) {
+        this._itemsPerPage = +((backendApi && backendApi.options && backendApi.options.paginationOptions && backendApi.options.paginationOptions.first) ? backendApi.options.paginationOptions.first : this._gridPaginationOptions.pagination.pageSize);
+      }
+
+      // if totalItems changed, we should always go back to the first page and recalculation the From-To indexes
+      if (isPageNumberReset || this._totalItems !== pagination.totalItems) {
+        if (this._isFirstRender && pagination.pageNumber && pagination.pageNumber > 1) {
+          this._pageNumber = pagination.pageNumber || 1;
+        } else {
+          this._pageNumber = 1;
+        }
+
+        // when page number is set to 1 then also reset the "offset" of backend service
+        if (this._pageNumber === 1) {
+          backendApi.service.resetPaginationOptions();
+        }
+      }
+
+      // calculate and refresh the multiple properties of the pagination UI
+      this._availablePageSizes = this._gridPaginationOptions.pagination.pageSizes;
+      this._totalItems = this._gridPaginationOptions.pagination.totalItems;
+      this.recalculateFromToIndexes();
+    }
+    this._pageCount = Math.ceil(this._totalItems / this._itemsPerPage);
+    this.ea.publish(`paginationService:on-pagination-changed`, this.pager);
+  }
+
+  processOnPageChanged(pageNumber: number, event?: Event | undefined): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.recalculateFromToIndexes();
+
+      const backendApi = this._gridPaginationOptions.backendServiceApi;
+      if (!backendApi || !backendApi.service || !backendApi.process) {
+        const error = new Error(`BackendServiceApi requires the following 2 properties "process" and "service" to be defined.`);
+        reject(error);
+        throw error;
+      }
+
+      if (this._dataTo > this._totalItems) {
+        this._dataTo = this._totalItems;
+      } else if (this._totalItems < this._itemsPerPage) {
+        this._dataTo = this._totalItems;
+      }
+
+      if (backendApi) {
+        const itemsPerPage = +this._itemsPerPage;
+
+        // keep start time & end timestamps & return it after process execution
+        const startTime = new Date();
+
+        // run any pre-process, if defined, for example a spinner
+        if (backendApi.preProcess) {
+          backendApi.preProcess();
+        }
+
+        const query = backendApi.service.processOnPaginationChanged(event, { newPage: pageNumber, pageSize: itemsPerPage });
+
+        // the processes can be Promises or an Observables (like HttpClient)
+        const process = backendApi.process(query);
+        if (process instanceof Promise) {
+          process
+            .then((processResult: GraphqlResult | any) => {
+              executeBackendProcessesCallback(startTime, processResult, backendApi, this._gridPaginationOptions);
+              resolve(true);
+            })
+            .catch((error) => {
+              onBackendError(error, backendApi);
+              reject(process);
+            });
+        }
+        this.ea.publish(`paginationService:on-pagination-changed`, this.pager);
+      }
+    });
+  }
+
+  recalculateFromToIndexes() {
+    if (this._totalItems === 0) {
+      this._dataFrom = 0;
+      this._dataTo = 0;
+      this._pageNumber = 0;
+    } else {
+      this._dataFrom = (this._pageNumber * this._itemsPerPage) - this._itemsPerPage + 1;
+      this._dataTo = (this._totalItems < this._itemsPerPage) ? this._totalItems : (this._pageNumber * this._itemsPerPage);
+      if (this._dataTo > this._totalItems) {
+        this._dataTo = this._totalItems;
+      }
+    }
+  }
+
+  // --
+  // private functions
+  // --------------------
+
+  /**
+   * When item is added or removed, we will refresh the numbers on the pagination however we won't trigger a backend change
+   * This will have a side effect though, which is that the "To" count won't be matching the "items per page" count,
+   * that is a necessary side effect to avoid triggering a backend query just to refresh the paging,
+   * basically we assume that this offset is fine for the time being,
+   * until user does an action which will refresh the data hence the pagination which will then become normal again
+   */
+  private processOnItemAddedOrRemoved(items: any | any[], isItemAdded = true) {
+    if (items !== null) {
+      const previousDataTo = this._dataTo;
+      const itemCount = Array.isArray(items) ? items.length : 1;
+      const itemCountWithDirection = isItemAdded ? +itemCount : -itemCount;
+
+      // refresh the total count in the pagination and in the UI
+      this._totalItems += itemCountWithDirection;
+      this.recalculateFromToIndexes();
+
+      // finally refresh the "To" count and we know it might be different than the "items per page" count
+      // but this is necessary since we don't want an actual backend refresh
+      this._dataTo = previousDataTo + itemCountWithDirection;
+      this.ea.publish(`paginationService:on-pagination-changed`, this.pager);
+    }
+  }
+}

--- a/src/aurelia-slickgrid/services/pagination.service.ts
+++ b/src/aurelia-slickgrid/services/pagination.service.ts
@@ -1,7 +1,7 @@
 import { inject } from 'aurelia-framework';
 import { EventAggregator, Subscription } from 'aurelia-event-aggregator';
 
-import { GridOption, GraphqlResult, Pager } from '../models';
+import { BackendServiceApi, GraphqlResult, Pager, Pagination } from '../models/index';
 import { FilterService } from './filter.service';
 import { GridService } from './grid.service';
 import { executeBackendProcessesCallback, onBackendError } from './backend-utilities';
@@ -14,13 +14,25 @@ declare var Slick: any;
 
 @inject(EventAggregator, FilterService, GridService)
 export class PaginationService {
-  set gridPaginationOptions(gridPaginationOptions: GridOption) {
-    this._gridPaginationOptions = gridPaginationOptions;
+  set paginationOptions(paginationOptions: Pagination) {
+    this._paginationOptions = paginationOptions;
   }
-  get gridPaginationOptions(): GridOption {
-    return this._gridPaginationOptions;
+  get paginationOptions(): Pagination {
+    return this._paginationOptions;
   }
 
+  set totalItems(totalItems: number) {
+    this._totalItems = totalItems;
+    if (this._initialized) {
+      this.refreshPagination();
+    }
+  }
+  get totalItems(): number {
+    return this._totalItems;
+  }
+
+  private _initialized = false;
+  private _backendServiceApi: BackendServiceApi;
   private _aureliaEventPrefix = DEFAULT_AURELIA_EVENT_PREFIX;
   private _dataFrom = 1;
   private _dataTo = 1;
@@ -28,10 +40,9 @@ export class PaginationService {
   private _pageCount = 0;
   private _pageNumber = 1;
   private _totalItems = 0;
-  private _availablePageSizes = [25, 75, 100];
+  private _availablePageSizes: number[];
   private _eventHandler = new Slick.EventHandler();
-  private _gridPaginationOptions: GridOption;
-  private _isFirstRender = true;
+  private _paginationOptions: Pagination;
   private _subscriptions: Subscription[] = [];
 
   dataView: any;
@@ -52,15 +63,16 @@ export class PaginationService {
     };
   }
 
-  init(grid: any, dataView: any, gridPaginationOptions: GridOption) {
+  init(grid: any, dataView: any, paginationOptions: Pagination, backendServiceApi: BackendServiceApi) {
+    this._availablePageSizes = paginationOptions.pageSizes;
     this.dataView = dataView;
     this.grid = grid;
-    this._gridPaginationOptions = gridPaginationOptions;
+    this._backendServiceApi = backendServiceApi;
+    this._paginationOptions = paginationOptions;
 
-    if (!this._gridPaginationOptions || !this._gridPaginationOptions.pagination || (this._gridPaginationOptions.pagination.totalItems !== this._totalItems)) {
-      this.refreshPagination();
+    if (!backendServiceApi || !backendServiceApi.service || !backendServiceApi.process) {
+      throw new Error(`BackendServiceApi requires the following 2 properties "process" and "service" to be defined.`);
     }
-    this._isFirstRender = false;
 
     // Subscribe to Filter Clear & Changed and go back to page 1 when that happen
     this._subscriptions.push(this.ea.subscribe('filterService:filterChanged', () => this.refreshPagination(true)));
@@ -72,9 +84,16 @@ export class PaginationService {
       this._subscriptions.push(this.ea.subscribe(`${this._aureliaEventPrefix}:on-item-added`, (items: any | any[]) => this.processOnItemAddedOrRemoved(items, true)));
       this._subscriptions.push(this.ea.subscribe(`${this._aureliaEventPrefix}:on-item-deleted`, (items: any | any[]) => this.processOnItemAddedOrRemoved(items, false)));
     }
+
+    if (!this._paginationOptions || (this._paginationOptions.totalItems !== this._totalItems)) {
+      this.refreshPagination();
+    }
+    this._initialized = true;
   }
 
   dispose() {
+    this._initialized = false;
+
     // unsubscribe all SlickGrid events
     this._eventHandler.unsubscribeAll();
 
@@ -144,38 +163,35 @@ export class PaginationService {
   }
 
   refreshPagination(isPageNumberReset: boolean = false) {
-    const backendApi = this._gridPaginationOptions && this._gridPaginationOptions.backendServiceApi;
-    if (!backendApi || !backendApi.service || !backendApi.process) {
-      throw new Error(`BackendServiceApi requires the following 2 properties "process" and "service" to be defined.`);
-    }
-
     // trigger an event to inform subscribers
     this.ea.publish(`paginationService:on-pagination-refreshed`, true);
 
-    if (this._gridPaginationOptions && this._gridPaginationOptions.pagination) {
-      const pagination = this._gridPaginationOptions.pagination;
+    if (this._paginationOptions) {
+      const pagination = this._paginationOptions;
       // set the number of items per page if not already set
       if (!this._itemsPerPage) {
-        this._itemsPerPage = +((backendApi && backendApi.options && backendApi.options.paginationOptions && backendApi.options.paginationOptions.first) ? backendApi.options.paginationOptions.first : this._gridPaginationOptions.pagination.pageSize);
+        this._itemsPerPage = +((this._backendServiceApi && this._backendServiceApi.options && this._backendServiceApi.options.paginationOptions && this._backendServiceApi.options.paginationOptions.first) ? this._backendServiceApi.options.paginationOptions.first : this._paginationOptions.pageSize);
       }
 
       // if totalItems changed, we should always go back to the first page and recalculation the From-To indexes
       if (isPageNumberReset || this._totalItems !== pagination.totalItems) {
-        if (this._isFirstRender && pagination.pageNumber && pagination.pageNumber > 1) {
-          this._pageNumber = pagination.pageNumber || 1;
-        } else {
+        if (isPageNumberReset) {
           this._pageNumber = 1;
+        } else if (!this._initialized && pagination.pageNumber && pagination.pageNumber > 1) {
+          this._pageNumber = pagination.pageNumber || 1;
         }
 
         // when page number is set to 1 then also reset the "offset" of backend service
         if (this._pageNumber === 1) {
-          backendApi.service.resetPaginationOptions();
+          this._backendServiceApi.service.resetPaginationOptions();
         }
       }
 
       // calculate and refresh the multiple properties of the pagination UI
-      this._availablePageSizes = this._gridPaginationOptions.pagination.pageSizes;
-      this._totalItems = this._gridPaginationOptions.pagination.totalItems;
+      this._availablePageSizes = this._paginationOptions.pageSizes;
+      if (!this._totalItems && this._paginationOptions.totalItems) {
+        this._totalItems = this._paginationOptions.totalItems;
+      }
       this.recalculateFromToIndexes();
     }
     this._pageCount = Math.ceil(this._totalItems / this._itemsPerPage);
@@ -186,42 +202,35 @@ export class PaginationService {
     return new Promise((resolve, reject) => {
       this.recalculateFromToIndexes();
 
-      const backendApi = this._gridPaginationOptions.backendServiceApi;
-      if (!backendApi || !backendApi.service || !backendApi.process) {
-        const error = new Error(`BackendServiceApi requires the following 2 properties "process" and "service" to be defined.`);
-        reject(error);
-        throw error;
-      }
-
       if (this._dataTo > this._totalItems) {
         this._dataTo = this._totalItems;
       } else if (this._totalItems < this._itemsPerPage) {
         this._dataTo = this._totalItems;
       }
 
-      if (backendApi) {
+      if (this._backendServiceApi) {
         const itemsPerPage = +this._itemsPerPage;
 
         // keep start time & end timestamps & return it after process execution
         const startTime = new Date();
 
         // run any pre-process, if defined, for example a spinner
-        if (backendApi.preProcess) {
-          backendApi.preProcess();
+        if (this._backendServiceApi.preProcess) {
+          this._backendServiceApi.preProcess();
         }
 
-        const query = backendApi.service.processOnPaginationChanged(event, { newPage: pageNumber, pageSize: itemsPerPage });
+        const query = this._backendServiceApi.service.processOnPaginationChanged(event, { newPage: pageNumber, pageSize: itemsPerPage });
 
         // the processes can be Promises or an Observables (like HttpClient)
-        const process = backendApi.process(query);
+        const process = this._backendServiceApi.process(query);
         if (process instanceof Promise) {
           process
             .then((processResult: GraphqlResult | any) => {
-              executeBackendProcessesCallback(startTime, processResult, backendApi, this._gridPaginationOptions);
+              executeBackendProcessesCallback(startTime, processResult, this._backendServiceApi, this._totalItems);
               resolve(true);
             })
             .catch((error) => {
-              onBackendError(error, backendApi);
+              onBackendError(error, this._backendServiceApi);
               reject(process);
             });
         }

--- a/src/aurelia-slickgrid/services/sort.service.ts
+++ b/src/aurelia-slickgrid/services/sort.service.ts
@@ -245,7 +245,8 @@ export class SortService {
     }
 
     const query = backendApi.service.processOnSortChanged(event, args);
-    executeBackendCallback(query, args, startTime, gridOptions, this.emitSortChanged.bind(this));
+    const totalItems = gridOptions && gridOptions.pagination && gridOptions.pagination.totalItems;
+    executeBackendCallback(backendApi, query, args, startTime, totalItems, this.emitSortChanged.bind(this));
   }
 
   /** When a Sort Changes on a Local grid (JSON dataset) */

--- a/src/aurelia-slickgrid/slick-pagination.html
+++ b/src/aurelia-slickgrid/slick-pagination.html
@@ -1,24 +1,17 @@
 <template>
-  <div id="pager"
-       style="width:100%;">
-    <div class="slick-pagination">
+  <div id="pager" style="width:100%;">
+    <div class="slick-pagination" if.bind="pager">
       <div class="slick-pagination-nav">
         <nav aria-label="Page navigation">
           <ul class="pagination">
-            <li class="page-item"
-                class.bind="(pageNumber === 1 || totalItems === 0) ? 'disabled' : ''">
-              <a class="page-link icon-seek-first fa fa-angle-double-left"
-                 href=""
-                 aria-label="First"
-                 click.delegate="changeToFirstPage()">
+            <li class="page-item" class.bind="(pager.pageNumber === 1 || pager.totalItems === 0) ? 'disabled' : ''">
+              <a class="page-link icon-seek-first fa fa-angle-double-left" href="" aria-label="First"
+                click.delegate="changeToFirstPage($event)">
               </a>
             </li>
-            <li class="page-item"
-                class.bind="(pageNumber === 1 || totalItems === 0) ? 'disabled' : ''">
-              <a class="page-link icon-seek-prev fa fa-angle-left"
-                 href=""
-                 aria-label="Previous"
-                 click.delegate="changeToPreviousPage()">
+            <li class="page-item" class.bind="(pager.pageNumber === 1 || pager.totalItems === 0) ? 'disabled' : ''">
+              <a class="page-link icon-seek-prev fa fa-angle-left" href="" aria-label="Previous"
+                click.delegate="changeToPreviousPage($event)">
               </a>
             </li>
           </ul>
@@ -26,48 +19,38 @@
 
         <div class="slick-page-number">
           <span>${textPage}</span>
-          <input type="text"
-                 class="form-control"
-                 value.bind="pageNumber | asgNumber"
-                 size="1"
-                 readonly.bind="totalItems === 0"
-                 change.delegate="changeToCurrentPage($event)">
+          <input type="text" class="form-control" value.bind="pager.pageNumber | asgNumber" size="1"
+            readonly.bind="pager.totalItems === 0" change.delegate="changeToCurrentPage($event)">
           <span>${textOf}</span>
-          <span> ${pageCount}</span>
+          <span> ${pager.pageCount}</span>
         </div>
 
         <nav aria-label="Page navigation">
           <ul class="pagination">
             <li class="page-item"
-                class.bind="(pageNumber === pageCount || totalItems === 0) ? 'disabled' : ''">
-              <a class="page-link icon-seek-next fa fa-angle-right"
-                 href=""
-                 aria-label="Next"
-                 click.delegate="changeToNextPage()">
+              class.bind="(pager.pageNumber === pager.pageCount || pager.totalItems === 0) ? 'disabled' : ''">
+              <a class="page-link icon-seek-next fa fa-angle-right" href="" aria-label="Next"
+                click.delegate="changeToNextPage($event)">
               </a>
             </li>
             <li class="page-item"
-                class.bind="(pageNumber === pageCount || totalItems === 0) ? 'disabled' : ''">
-              <a class="page-link icon-seek-end fa fa-angle-double-right"
-                 href=""
-                 aria-label="Last"
-                 click.delegate="changeToLastPage()">
+              class.bind="(pager.pageNumber === pager.pageCount || pager.totalItems === 0) ? 'disabled' : ''">
+              <a class="page-link icon-seek-end fa fa-angle-double-right" href="" aria-label="Last"
+                click.delegate="changeToLastPage($event)">
               </a>
             </li>
           </ul>
         </nav>
       </div>
       <span class="slick-pagination-settings">
-        <select id="items-per-page-label"
-                value.bind="itemsPerPage | asgNumber"
-                change.delegate="onChangeItemPerPage($event)">
-          <option value="${pageSize}"
-                  repeat.for="pageSize of paginationPageSizes"
-                  model.bind="pageSize">${pageSize}</option>
+        <select id="items-per-page-label" value.bind="pager.itemsPerPage | asgNumber"
+          change.delegate="changeItemPerPage($event)">
+          <option value="${pageSize}" repeat.for="pageSize of pager.availablePageSizes" model.bind="pageSize">
+            ${pageSize}</option>
         </select>
         <span>${textItemsPerPage}</span>,
         <span class="slick-pagination-count">
-          <span>${dataFrom}-${dataTo} ${textOf} ${totalItems} ${textItems}</span>
+          <span>${pager.from}-${pager.to} ${textOf} ${pager.totalItems} ${textItems}</span>
         </span>
       </span>
     </div>

--- a/src/aurelia-slickgrid/slick-pagination.html
+++ b/src/aurelia-slickgrid/slick-pagination.html
@@ -1,6 +1,6 @@
 <template>
   <div id="pager" style="width:100%;">
-    <div class="slick-pagination" if.bind="pager">
+    <div class="slick-pagination" if.bind="pager && options">
       <div class="slick-pagination-nav">
         <nav aria-label="Page navigation">
           <ul class="pagination">
@@ -45,7 +45,7 @@
       <span class="slick-pagination-settings">
         <select id="items-per-page-label" value.bind="pager.itemsPerPage | asgNumber"
           change.delegate="changeItemPerPage($event)">
-          <option value="${pageSize}" repeat.for="pageSize of pager.availablePageSizes" model.bind="pageSize">
+          <option value="${pageSize}" repeat.for="pageSize of options.pageSizes" model.bind="pageSize">
             ${pageSize}</option>
         </select>
         <span>${textItemsPerPage}</span>,

--- a/src/aurelia-slickgrid/slick-pagination.ts
+++ b/src/aurelia-slickgrid/slick-pagination.ts
@@ -1,34 +1,26 @@
-import { bindable, inject } from 'aurelia-framework';
+import { bindable, inject, Optional } from 'aurelia-framework';
 import { EventAggregator, Subscription } from 'aurelia-event-aggregator';
 import { I18N } from 'aurelia-i18n';
+
 import { Constants } from './constants';
-import { GridOption, Locale } from './models/index';
+import { GridOption, Locale, Pager } from './models/index';
+import { PaginationService } from './services/pagination.service';
 import { disposeAllSubscriptions } from './services/utilities';
 
 const DEFAULT_AURELIA_EVENT_PREFIX = 'asg';
 
-// using external non-typed js libraries
-declare var Slick: any;
-
-@inject(Element, EventAggregator, I18N)
+@inject(Element, EventAggregator, PaginationService, Optional.of(I18N))
 export class SlickPaginationCustomElement {
   @bindable() dataview: any;
+  @bindable() grid: any;
   @bindable() gridPaginationOptions: GridOption;
+
   private _aureliaEventPrefix = DEFAULT_AURELIA_EVENT_PREFIX;
-  private _eventHandler = new Slick.EventHandler();
   private _gridPaginationOptions: GridOption;
   private _isFirstRender = true;
   private _locales: Locale;
-
-  dataFrom = 1;
-  dataTo = 1;
-  itemsPerPage: number;
-  pageCount = 0;
-  pageNumber = 1;
-  totalItems = 0;
-  paginationCallback: () => void;
-  paginationPageSizes = [25, 75, 100];
-  subscriptions: Subscription[] = [];
+  private _pager: Pager;
+  private _subscriptions: Subscription[] = [];
 
   // text translations (handled by i18n or by custom locale)
   textItemsPerPage: string;
@@ -36,11 +28,40 @@ export class SlickPaginationCustomElement {
   textOf: string;
   textPage: string;
 
-  constructor(private elm: Element, private ea: EventAggregator, private i18n: I18N) {
+  constructor(private elm: Element, private ea: EventAggregator, private paginationService: PaginationService, private i18n: I18N) {
     // when using I18N, we'll translate necessary texts in the UI
-    this.subscriptions.push(
+    this._subscriptions.push(
       this.ea.subscribe('i18n:locale:changed', () => this.translateAllUiTexts(this._locales))
     );
+
+    // translate all the text using I18N or custom locales
+    this._subscriptions.push(
+      this.ea.subscribe(`paginationService:on-pagination-refreshed`, () => this.translateAllUiTexts(this._locales))
+    );
+
+    this._subscriptions.push(
+      this.ea.subscribe(`paginationService:on-pagination-changed`, (pager: Pager) => {
+        this._pager = pager;
+
+        // emit the changes to the parent component with only necessary properties
+        if (!this._isFirstRender) {
+          // dispatch the changes to the parent component
+          this.elm.dispatchEvent(new CustomEvent(`${this._aureliaEventPrefix}-on-pagination-changed`, {
+            bubbles: true,
+            detail: {
+              pageNumber: this.pager.pageNumber,
+              pageSizes: this.pager.availablePageSizes,
+              pageSize: this.pager.itemsPerPage,
+              totalItems: this.pager.totalItems,
+            }
+          }));
+        }
+      })
+    );
+  }
+
+  get pager(): Pager {
+    return this._pager || this.paginationService.pager;
   }
 
   bind(binding: any, contexts: any) {
@@ -48,22 +69,16 @@ export class SlickPaginationCustomElement {
     if (this._gridPaginationOptions && this._gridPaginationOptions.enableTranslate && (!this.i18n || !this.i18n.tr)) {
       throw new Error('[Aurelia-Slickgrid] requires "I18N" to be installed and configured when the grid option "enableTranslate" is enabled.');
     }
-    this._aureliaEventPrefix = (this._gridPaginationOptions && this._gridPaginationOptions.defaultAureliaEventPrefix) ? this._gridPaginationOptions.defaultAureliaEventPrefix : DEFAULT_AURELIA_EVENT_PREFIX;
 
-    if (!binding.gridPaginationOptions || (binding.gridPaginationOptions.pagination && binding.gridPaginationOptions.pagination.totalItems !== this.totalItems)) {
+    if (!binding.gridPaginationOptions || (binding.gridPaginationOptions.pagination && binding.gridPaginationOptions.pagination.totalItems !== this.pager.totalItems)) {
       this.refreshPagination();
-    } else if (binding.gridPaginationOptions.pagination.totalItems === 0) {
-      this.recalculateFromToIndexes();
     }
 
-    // Subscribe to Filter Clear & Changed and go back to page 1 when that happen
-    this.subscriptions.push(this.ea.subscribe('filterService:filterChanged', () => this.refreshPagination(true)));
-    this.subscriptions.push(this.ea.subscribe('filterService:filterCleared', () => this.refreshPagination(true)));
+    // get locales provided by user in main file or else use default English locales via the Constants
+    this._locales = this._gridPaginationOptions && this._gridPaginationOptions.locales || Constants.locales;
+    this._aureliaEventPrefix = (this._gridPaginationOptions && this._gridPaginationOptions.defaultAureliaEventPrefix) ? this._gridPaginationOptions.defaultAureliaEventPrefix : DEFAULT_AURELIA_EVENT_PREFIX;
 
-    // Subscribe to any dataview row count changed so that when Adding/Deleting item(s) through the DataView
-    // that would trigger a refresh of the pagination numbers
-    this.subscriptions.push(this.ea.subscribe(`${this._aureliaEventPrefix}:on-item-added`, (items: any | any[]) => this.onItemAddedOrRemoved(items, true)));
-    this.subscriptions.push(this.ea.subscribe(`${this._aureliaEventPrefix}:on-item-deleted`, (items: any | any[]) => this.onItemAddedOrRemoved(items, false)));
+    this.paginationService.init(this.grid, this.dataview, this._gridPaginationOptions);
   }
 
   gridPaginationOptionsChanged(newGridOptions: GridOption) {
@@ -78,182 +93,49 @@ export class SlickPaginationCustomElement {
     this.dispose();
   }
 
-  ceil(number: number) {
-    return Math.ceil(number);
-  }
-
   changeToFirstPage(event: any) {
-    this.pageNumber = 1;
-    this.onPageChanged(event, this.pageNumber);
+    this.paginationService.goToFirstPage(event);
   }
 
   changeToLastPage(event: any) {
-    this.pageNumber = this.pageCount;
-    this.onPageChanged(event, this.pageNumber);
+    this.paginationService.goToLastPage(event);
   }
 
   changeToNextPage(event: any) {
-    if (this.pageNumber < this.pageCount) {
-      this.pageNumber++;
-      this.onPageChanged(event, this.pageNumber);
-    }
+    this.paginationService.goToNextPage(event);
   }
 
   changeToPreviousPage(event: any) {
-    if (this.pageNumber > 0) {
-      this.pageNumber--;
-      this.onPageChanged(event, this.pageNumber);
-    }
+    this.paginationService.goToPreviousPage(event);
   }
 
   changeToCurrentPage(event: any) {
-    this.pageNumber = +((event && event.target && event.target.value) ? event.target.value : 1);
-    if (this.pageNumber < 1) {
-      this.pageNumber = 1;
-    } else if (this.pageNumber > this.pageCount) {
-      this.pageNumber = this.pageCount;
+    let pageNumber = 1;
+    if (event && event.target && event.target.value) {
+      pageNumber = +(event.target.value);
     }
-    this.onPageChanged(event, this.pageNumber);
+    this.paginationService.goToPageNumber(pageNumber, event);
+  }
+
+  changeItemPerPage(event: any) {
+    let itemsPerPage = 1;
+    if (event && event.target && event.target.value) {
+      itemsPerPage = +(event.target.value);
+    }
+    this.paginationService.changeItemPerPage(itemsPerPage, event);
   }
 
   dispose() {
-    // unsubscribe all SlickGrid events
-    this._eventHandler.unsubscribeAll();
+    this.paginationService.dispose();
 
     // also dispose of all Subscriptions
-    this.subscriptions = disposeAllSubscriptions(this.subscriptions);
+    this._subscriptions = disposeAllSubscriptions(this._subscriptions);
   }
 
-  onChangeItemPerPage(event: any) {
-    const itemsPerPage = +event.target.value;
-    this.pageCount = Math.ceil(this.totalItems / itemsPerPage);
-    this.pageNumber = (this.totalItems > 0) ? 1 : 0;
-    this.itemsPerPage = itemsPerPage;
-    this.onPageChanged(event, this.pageNumber);
-  }
-
-  refreshPagination(isPageNumberReset: boolean = false) {
-    const backendApi = this._gridPaginationOptions.backendServiceApi;
-    if (!backendApi || !backendApi.service || !backendApi.process) {
-      throw new Error(`BackendServiceApi requires at least a "process" function and a "service" defined`);
-    }
-
-    // get locales provided by user in forRoot or else use default English locales via the Constants
-    this._locales = this._gridPaginationOptions && this._gridPaginationOptions.locales || Constants.locales;
-
-    // translate all the text using i18n or custom locales
-    this.translateAllUiTexts(this._locales);
-
-    if (this._gridPaginationOptions && this._gridPaginationOptions.pagination) {
-      const pagination = this._gridPaginationOptions.pagination;
-      // set the number of items per page if not already set
-      if (!this.itemsPerPage) {
-        this.itemsPerPage = +((backendApi && backendApi.options && backendApi.options.paginationOptions && backendApi.options.paginationOptions.first) ? backendApi.options.paginationOptions.first : this._gridPaginationOptions.pagination.pageSize);
-      }
-
-      // if totalItems changed, we should always go back to the first page and recalculation the From-To indexes
-      if (isPageNumberReset || this.totalItems !== pagination.totalItems) {
-        if (!isPageNumberReset && this._isFirstRender && pagination.pageNumber && pagination.pageNumber > 1) {
-          this.pageNumber = pagination.pageNumber || 1;
-          this._isFirstRender = false;
-        } else {
-          this.pageNumber = 1;
-        }
-
-        // when page number is set to 1 then also reset the "offset" of backend service
-        if (this.pageNumber === 1) {
-          backendApi.service.resetPaginationOptions();
-        }
-      }
-
-      // calculate and refresh the multiple properties of the pagination UI
-      this.paginationPageSizes = this._gridPaginationOptions.pagination.pageSizes;
-      this.totalItems = this._gridPaginationOptions.pagination.totalItems;
-      this.recalculateFromToIndexes();
-    }
-    this.pageCount = Math.ceil(this.totalItems / this.itemsPerPage);
-  }
-
-  async onPageChanged(event: Event | undefined, pageNumber: number) {
-    this.recalculateFromToIndexes();
-
-    const backendApi = this._gridPaginationOptions.backendServiceApi;
-    if (!backendApi || !backendApi.service || !backendApi.process) {
-      throw new Error(`BackendServiceApi requires at least a "process" function and a "service" defined`);
-    }
-
-    if (this.dataTo > this.totalItems) {
-      this.dataTo = this.totalItems;
-    } else if (this.totalItems < this.itemsPerPage) {
-      this.dataTo = this.totalItems;
-    }
-
-    if (backendApi) {
-      try {
-        const itemsPerPage = +this.itemsPerPage;
-
-        // keep start time & end timestamps & return it after process execution
-        const startTime = new Date();
-
-        if (backendApi.preProcess) {
-          backendApi.preProcess();
-        }
-
-        const query = backendApi.service.processOnPaginationChanged(event, { newPage: pageNumber, pageSize: itemsPerPage });
-
-        // await for the Promise to resolve the data
-        const processResult = await backendApi.process(query);
-        const endTime = new Date();
-
-        // from the result, call our internal post process to update the Dataset and Pagination info
-        if (processResult && backendApi.internalPostProcess) {
-          backendApi.internalPostProcess(processResult);
-        }
-
-        // send the response process to the postProcess callback
-        if (backendApi.postProcess) {
-          if (processResult instanceof Object) {
-            processResult.metrics = {
-              startTime,
-              endTime,
-              executionTime: endTime.valueOf() - startTime.valueOf(),
-              itemCount: this.totalItems,
-              totalItemCount: this.totalItems
-            };
-          }
-          backendApi.postProcess(processResult);
-        }
-      } catch (e) {
-        if (backendApi && backendApi.onError) {
-          backendApi.onError(e);
-        } else {
-          throw e;
-        }
-      }
-    } else {
-      throw new Error('Pagination with a backend service requires "BackendServiceApi" to be defined in your grid options');
-    }
-
-    // dispatch the changes to the parent component
-    this.elm.dispatchEvent(new CustomEvent(`${this._aureliaEventPrefix}-on-pagination-changed`, {
-      bubbles: true,
-      detail: {
-        pageNumber: this.pageNumber,
-        pageSizes: this.paginationPageSizes,
-        pageSize: this.itemsPerPage,
-        totalItems: this.totalItems
-      }
-    }));
-  }
-
-  recalculateFromToIndexes() {
-    if (this.totalItems === 0) {
-      this.dataFrom = 0;
-      this.dataTo = 0;
-      this.pageNumber = 0;
-    } else {
-      this.dataFrom = (this.pageNumber * this.itemsPerPage) - this.itemsPerPage + 1;
-      this.dataTo = (this.totalItems < this.itemsPerPage) ? this.totalItems : (this.pageNumber * this.itemsPerPage);
+  refreshPagination() {
+    if (this.paginationService) {
+      this.paginationService.gridPaginationOptions = this._gridPaginationOptions;
+      this.paginationService.refreshPagination();
     }
   }
 
@@ -273,28 +155,6 @@ export class SlickPaginationCustomElement {
       this.textItems = locales.TEXT_ITEMS || 'TEXT_ITEMS';
       this.textOf = locales.TEXT_OF || 'TEXT_OF';
       this.textPage = locales.TEXT_PAGE || 'TEXT_PAGE';
-    }
-  }
-
-  /**
-   * When item is added or removed, we will refresh the numbers on the pagination however we won't trigger a backend change
-   * This will have a side effect though, which is that the "To" count won't be matching the "items per page" count,
-   * that is a necessary side effect to avoid triggering a backend query just to refresh the paging,
-   * basically we assume that this offset is fine for the time being,
-   * until user does an action which will refresh the data hence the pagination which will then become normal again
-   */
-  private onItemAddedOrRemoved(items: any | any[], isItemAdded = true) {
-    if (items !== null) {
-      const previousDataTo = this.dataTo;
-      const itemCount = Array.isArray(items) ? items.length : 1;
-      const itemCountWithDirection = isItemAdded ? +itemCount : -itemCount;
-      // refresh the total count in the pagination and in the UI
-      this.totalItems += itemCountWithDirection;
-      this.recalculateFromToIndexes();
-
-      // finally refresh the "To" count and we know it might be different than the "items per page" count
-      // but this is necessary since we don't want an actual backend refresh
-      this.dataTo = previousDataTo + itemCountWithDirection;
     }
   }
 }

--- a/src/examples/slickgrid/example5.html
+++ b/src/examples/slickgrid/example5.html
@@ -38,6 +38,15 @@
       </label>
     </div>
   </div>
+  <div class="row col-md-12">
+    <label>Programmatically go to first/last page:</label>
+    <button class="btn btn-default btn-xs" click.delegate="goToFirstPage()">
+      <i class="fa fa-caret-left fa-lg"></i>
+    </button>
+    <button class="btn btn-default btn-xs" click.delegate="goToLastPage()">
+      <i class="fa fa-caret-right fa-lg"></i>
+    </button>
+  </div>
 
   <aurelia-slickgrid grid-id="grid5" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
     dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"

--- a/src/examples/slickgrid/example5.ts
+++ b/src/examples/slickgrid/example5.ts
@@ -278,6 +278,14 @@ export class Example5 {
     });
   }
 
+  goToFirstPage() {
+    this.aureliaGrid.paginationService.goToFirstPage();
+  }
+
+  goToLastPage() {
+    this.aureliaGrid.paginationService.goToLastPage();
+  }
+
   /** Dispatched event of a Grid State Changed event */
   gridStateChanged(gridStateChanges: GridStateChange) {
     console.log('Client sample, Grid State changed:: ', gridStateChanges);

--- a/src/examples/slickgrid/example6.html
+++ b/src/examples/slickgrid/example6.html
@@ -25,6 +25,15 @@
         ${metrics.totalItemCount}
         items
       </span>
+      <div class="row col-md-12">
+        <label>Programmatically go to first/last page:</label>
+        <button class="btn btn-default btn-xs" click.delegate="goToFirstPage()">
+          <i class="fa fa-caret-left fa-lg"></i>
+        </button>
+        <button class="btn btn-default btn-xs" click.delegate="goToLastPage()">
+          <i class="fa fa-caret-right fa-lg"></i>
+        </button>
+      </div>
     </div>
     <div class="col-sm-7">
       <div class="alert alert-info" data-test="alert-graphql-query">

--- a/src/examples/slickgrid/example6.ts
+++ b/src/examples/slickgrid/example6.ts
@@ -14,7 +14,6 @@ import {
   GraphqlServiceOption,
   GridOption,
   GridStateChange,
-  JQueryUiSliderOption,
   MultipleSelectOption,
   OperatorType,
   SortDirection,
@@ -230,6 +229,14 @@ export class Example6 {
         resolve(mockedResult);
       }, 250);
     });
+  }
+
+  goToFirstPage() {
+    this.aureliaGrid.paginationService.goToFirstPage();
+  }
+
+  goToLastPage() {
+    this.aureliaGrid.paginationService.goToLastPage();
   }
 
   /** Dispatched event of a Grid State Changed event */


### PR DESCRIPTION
- with this new Service, user can now programmatically change page from its application since the Pagination Service is now exposed to the outside
- manually adding items (via the grid service addItem()) shouldn't reset pagination to page 1
- completely change how we pass the options to the child pagination component
- no longer relying on the entire grid option to be passed to the pagination (which was error pron)
- now passes only the essential options required by the pagination