### PR TITLE
fix(editor): autocommit should not save if value is the same as before

### DIFF
--- a/src/aurelia-slickgrid/editors/__tests__/dateEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/dateEditor.spec.ts
@@ -196,19 +196,21 @@ describe('DateEditor', () => {
         mockItemData = { id: 1, startDate: '2001-01-02T11:02:02.000Z', isActive: true };
 
         editor = new DateEditor(i18n, editorArguments);
+        editor.loadValue(mockItemData);
         editor.focus();
         const editorInputElm = divContainer.querySelector<HTMLInputElement>('input.flatpickr');
-        editorInputElm.value = '2001-01-02T16:02:02.239Z';
+        editorInputElm.value = '2024-04-02T16:02:02.239Z';
         editorInputElm.dispatchEvent(new (window.window as any).KeyboardEvent('keydown', { keyCode: 13, bubbles: true, cancelable: true }));
 
         expect(editor.isValueChanged()).toBe(true);
       });
 
-      it('should return True when date in the picker is the same as the current date', () => {
+      it('should return False when date in the picker is the same as the current date', () => {
         mockItemData = { id: 1, startDate: '2001-01-02T11:02:02.000Z', isActive: true };
         mockColumn.internalColumnEditor.editorOptions = { allowInput: true }; // change to allow input value only for testing purposes
 
         editor = new DateEditor(i18n, editorArguments);
+        editor.loadValue(mockItemData);
         const editorInputElm = divContainer.querySelector<HTMLInputElement>('input.flatpickr-alt-input');
         editorInputElm.value = '2001-01-02T11:02:02.000Z';
         editorInputElm.dispatchEvent(new (window.window as any).KeyboardEvent('keydown', { keyCode: 13, bubbles: true, cancelable: true }));
@@ -316,6 +318,7 @@ describe('DateEditor', () => {
 
         editor = new DateEditor(i18n, editorArguments);
         editor.loadValue(mockItemData);
+        editor.setValue('2022-03-02T16:02:02.000+05:00');
         editor.save();
 
         expect(spy).toHaveBeenCalled();
@@ -328,6 +331,7 @@ describe('DateEditor', () => {
 
         editor = new DateEditor(i18n, editorArguments);
         editor.loadValue(mockItemData);
+        editor.setValue('2022-03-02T16:02:02.000+05:00');
         editor.save();
 
         expect(spy).toHaveBeenCalled();

--- a/src/aurelia-slickgrid/editors/__tests__/sliderEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/sliderEditor.spec.ts
@@ -194,8 +194,8 @@ describe('SliderEditor', () => {
       mockColumn.internalColumnEditor.params = { hideSliderNumber: false };
       mockItemData = { id: 1, price: 32, isActive: true };
       editor = new SliderEditor(editorArguments);
-      editor.setValue(17);
       editor.loadValue(mockItemData);
+      editor.setValue(17);
 
       const editorElm = divContainer.querySelector('.slider-container.slider-editor');
       const editorNumberElm = divContainer.querySelector<HTMLInputElement>('.input-group-text');
@@ -209,18 +209,21 @@ describe('SliderEditor', () => {
 
     describe('isValueChanged method', () => {
       it('should return True when previously dispatched change event is a different slider input number', () => {
+        mockColumn.internalColumnEditor.params = { sliderStartValue: 5 };
+        mockItemData = { id: 1, price: 32, isActive: true };
         editor = new SliderEditor(editorArguments);
-        editor.setValue(17);
+        editor.loadValue(mockItemData);
+        editor.setValue(45);
 
         const editorElm = divContainer.querySelector<HTMLInputElement>('.slider-editor input.editor-price');
         editorElm.dispatchEvent(DOM.createCustomEvent('change'));
-
         expect(editor.isValueChanged()).toBe(true);
       });
 
       it('should return False when previously dispatched change event is the same as default (0) slider input number', () => {
+        mockItemData = { id: 1, price: 0, isActive: true };
         editor = new SliderEditor(editorArguments);
-        editor.setValue(0);
+        editor.loadValue(mockItemData);
 
         const editorElm = divContainer.querySelector<HTMLInputElement>('.slider-editor input.editor-price');
         editorElm.dispatchEvent(DOM.createCustomEvent('change'));
@@ -229,8 +232,9 @@ describe('SliderEditor', () => {
       });
 
       it('should return False when previously dispatched change event is the same as default (0) slider input number but provided as a string', () => {
+        mockItemData = { id: 1, price: '0', isActive: true };
         editor = new SliderEditor(editorArguments);
-        editor.setValue('0');
+        editor.loadValue(mockItemData);
 
         const editorElm = divContainer.querySelector<HTMLInputElement>('.slider-editor input.editor-price');
         editorElm.dispatchEvent(DOM.createCustomEvent('change'));
@@ -240,8 +244,9 @@ describe('SliderEditor', () => {
 
       it('should return False when previously dispatched change event is the same input number as "sliderStartValue" provided by the user', () => {
         mockColumn.internalColumnEditor.params = { sliderStartValue: 5 };
+        mockItemData = { id: 1, price: 5, isActive: true };
         editor = new SliderEditor(editorArguments);
-        editor.setValue(5);
+        editor.loadValue(mockItemData);
 
         const editorElm = divContainer.querySelector<HTMLInputElement>('.slider-editor input.editor-price');
         editorElm.dispatchEvent(DOM.createCustomEvent('change'));
@@ -364,6 +369,7 @@ describe('SliderEditor', () => {
 
         editor = new SliderEditor(editorArguments);
         editor.loadValue(mockItemData);
+        editor.setValue(35);
         editor.save();
 
         expect(spy).toHaveBeenCalled();
@@ -376,6 +382,7 @@ describe('SliderEditor', () => {
 
         editor = new SliderEditor(editorArguments);
         editor.loadValue(mockItemData);
+        editor.setValue(35);
         editor.save();
 
         expect(spy).toHaveBeenCalled();
@@ -400,6 +407,7 @@ describe('SliderEditor', () => {
 
         editor = new SliderEditor(editorArguments);
         editor.loadValue(mockItemData);
+        editor.setValue(35);
         const spySave = jest.spyOn(editor, 'save');
         const editorElm = editor.editorDomElement;
 

--- a/src/aurelia-slickgrid/editors/dateEditor.ts
+++ b/src/aurelia-slickgrid/editors/dateEditor.ts
@@ -30,6 +30,7 @@ export class DateEditor implements Editor {
 
   flatInstance: any;
   defaultDate: string;
+  originalDate: string;
 
   /** SlickGrid Grid object */
   grid: any;
@@ -174,7 +175,12 @@ export class DateEditor implements Editor {
   }
 
   isValueChanged(): boolean {
-    return (!(this._$input.val() === '' && this.defaultDate == null)) && (this._$input.val() !== this.defaultDate);
+    const elmValue = this._$input.val();
+    const outputFormat = mapMomentDateFormatWithFieldType(this.columnDef.type || FieldType.dateIso);
+    const elmDateStr = elmValue ? moment(elmValue).format(outputFormat) : '';
+    const orgDateStr = this.originalDate ? moment(this.originalDate).format(outputFormat) : '';
+
+    return (!(elmDateStr === '' && orgDateStr === '')) && (elmDateStr !== orgDateStr);
   }
 
   loadValue(item: any) {
@@ -185,7 +191,7 @@ export class DateEditor implements Editor {
 
     if (item && this.columnDef && (item.hasOwnProperty(fieldName) || isComplexObject)) {
       const value = (isComplexObject) ? getDescendantProperty(item, fieldName) : item[fieldName];
-      this.defaultDate = value;
+      this.originalDate = value;
       this.flatInstance.setDate(value);
       this.show();
       this.focus();

--- a/src/aurelia-slickgrid/editors/sliderEditor.ts
+++ b/src/aurelia-slickgrid/editors/sliderEditor.ts
@@ -18,6 +18,7 @@ export class SliderEditor implements Editor {
   private _$editorElm: any;
   private _$input: any;
   $sliderNumber: any;
+  defaultValue: any;
   originalValue: any;
 
   /** SlickGrid Grid object */
@@ -132,9 +133,9 @@ export class SliderEditor implements Editor {
     }
   }
 
-  isValueChanged() {
+  isValueChanged(): boolean {
     const elmValue = this._$input.val();
-    return (!(elmValue === '' && this.originalValue === null)) && (+elmValue !== this.originalValue);
+    return (!(elmValue === '' && this.originalValue === undefined)) && (+elmValue !== this.originalValue);
   }
 
   loadValue(item: any) {
@@ -146,8 +147,9 @@ export class SliderEditor implements Editor {
     if (item && this.columnDef && (item.hasOwnProperty(fieldName) || isComplexObject)) {
       let value = (isComplexObject) ? getDescendantProperty(item, fieldName) : item[fieldName];
       if (value === '' || value === null || value === undefined) {
-        value = this.originalValue; // load default value when item doesn't have any value
+        value = this.defaultValue; // load default value when item doesn't have any value
       }
+      this.originalValue = +value;
       this._$input.val(value);
       this.$sliderNumber.html(value);
     }
@@ -218,7 +220,7 @@ export class SliderEditor implements Editor {
     const maxValue = this.columnEditor.hasOwnProperty('maxValue') ? this.columnEditor.maxValue : DEFAULT_MAX_VALUE;
     const defaultValue = this.editorParams.hasOwnProperty('sliderStartValue') ? this.editorParams.sliderStartValue : minValue;
     const step = this.columnEditor.hasOwnProperty('valueStep') ? this.columnEditor.valueStep : DEFAULT_STEP;
-    this.originalValue = defaultValue;
+    this.defaultValue = defaultValue;
 
     if (this.editorParams.hideSliderNumber) {
       return `


### PR DESCRIPTION
- certain Editors were triggering a save when clicking/opening the Editor when autocommit was enabled even though the value if the field was the same since we just opened the editor.