### PR TITLE
feat(formatterOptions): add decimal,thousand separator to all Formatters

### DIFF
--- a/src/aurelia-slickgrid/formatters/__tests__/dateEuroFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dateEuroFormatter.spec.ts
@@ -1,8 +1,6 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
 
-jest.mock('flatpickr', () => { });
-
 describe('the DateEuro Formatter', () => {
   it('should return null when no value is provided', () => {
     const value = null;

--- a/src/aurelia-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dateIsoFormatter.spec.ts
@@ -1,8 +1,6 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
 
-jest.mock('flatpickr', () => { });
-
 describe('the Date ISO Formatter', () => {
   it('should return null when no value is provided', () => {
     const value = null;

--- a/src/aurelia-slickgrid/formatters/__tests__/dateTimeEuroAmPmFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dateTimeEuroAmPmFormatter.spec.ts
@@ -1,8 +1,6 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
 
-jest.mock('flatpickr', () => { });
-
 describe('the DateTimeShortEuro Formatter', () => {
   it('should return null when no value is provided', () => {
     const value = null;

--- a/src/aurelia-slickgrid/formatters/__tests__/dateTimeEuroFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dateTimeEuroFormatter.spec.ts
@@ -1,8 +1,6 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
 
-jest.mock('flatpickr', () => { });
-
 describe('the DateTimeEuro Formatter', () => {
   it('should return null when no value is provided', () => {
     const value = null;

--- a/src/aurelia-slickgrid/formatters/__tests__/dateTimeIsoAmPmFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dateTimeIsoAmPmFormatter.spec.ts
@@ -1,8 +1,6 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
 
-jest.mock('flatpickr', () => { });
-
 describe('the DateTimeIsoAmPm Formatter', () => {
   it('should return null when no value is provided', () => {
     const value = null;

--- a/src/aurelia-slickgrid/formatters/__tests__/dateTimeIsoFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dateTimeIsoFormatter.spec.ts
@@ -1,8 +1,6 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
 
-jest.mock('flatpickr', () => { });
-
 describe('the DateTimeIso Formatter', () => {
   it('should return null when no value is provided', () => {
     const value = null;

--- a/src/aurelia-slickgrid/formatters/__tests__/dateTimeShortEuroFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dateTimeShortEuroFormatter.spec.ts
@@ -1,8 +1,6 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
 
-jest.mock('flatpickr', () => { });
-
 describe('the DateTimeShortEuro Formatter', () => {
   it('should return null when no value is provided', () => {
     const value = null;

--- a/src/aurelia-slickgrid/formatters/__tests__/dateTimeShortIsoFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dateTimeShortIsoFormatter.spec.ts
@@ -1,8 +1,6 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
 
-jest.mock('flatpickr', () => { });
-
 describe('the DateTimeShortIso Formatter', () => {
   it('should return null when no value is provided', () => {
     const value = null;

--- a/src/aurelia-slickgrid/formatters/__tests__/dateTimeShortUsFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dateTimeShortUsFormatter.spec.ts
@@ -1,8 +1,6 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
 
-jest.mock('flatpickr', () => { });
-
 describe('the DateTimeShortUs Formatter', () => {
   it('should return null when no value is provided', () => {
     const value = null;

--- a/src/aurelia-slickgrid/formatters/__tests__/dateTimeUsAmPmFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dateTimeUsAmPmFormatter.spec.ts
@@ -1,8 +1,6 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
 
-jest.mock('flatpickr', () => { });
-
 describe('the DateTimeShortUs Formatter', () => {
   it('should return null when no value is provided', () => {
     const value = null;

--- a/src/aurelia-slickgrid/formatters/__tests__/dateTimeUsFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dateTimeUsFormatter.spec.ts
@@ -1,8 +1,6 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
 
-jest.mock('flatpickr', () => { });
-
 describe('the DateTimeUs Formatter', () => {
   it('should return null when no value is provided', () => {
     const value = null;

--- a/src/aurelia-slickgrid/formatters/__tests__/dateUsFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dateUsFormatter.spec.ts
@@ -1,8 +1,6 @@
 import { Column } from '../../models';
 import { Formatters } from '../index';
 
-jest.mock('flatpickr', () => { });
-
 describe('the DateUs Formatter', () => {
   it('should return null when no value is provided', () => {
     const value = null;

--- a/src/aurelia-slickgrid/formatters/__tests__/decimalFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/decimalFormatter.spec.ts
@@ -47,11 +47,17 @@ describe('the Decimal Formatter', () => {
   });
 
   it('should display a number with dollar sign and use "minDecimalPlaces" (or the deprecated "decimalPlaces") params', () => {
-    const input = 99.1;
+    const input = 12345678.1;
+
     const output1 = decimalFormatter(1, 1, input, { params: { minDecimalPlaces: 2 } } as Column, {});
     const output2 = decimalFormatter(1, 1, input, { params: { decimalPlaces: 2 } } as Column, {});
-    expect(output1).toBe('99.10');
-    expect(output2).toBe('99.10');
+    const output3 = decimalFormatter(1, 1, input, { params: { decimalPlaces: 2, thousandSeparator: ',' } } as Column, {});
+    const output4 = decimalFormatter(1, 1, input, { params: { decimalPlaces: 2, decimalSeparator: ',', thousandSeparator: ' ' } } as Column, {});
+
+    expect(output1).toBe('12345678.10');
+    expect(output2).toBe('12345678.10');
+    expect(output3).toBe('12,345,678.10');
+    expect(output4).toBe('12 345 678,10');
   });
 
   it('should display a number with dollar sign and use "maxDecimal" params', () => {
@@ -72,10 +78,23 @@ describe('the Decimal Formatter', () => {
     expect(output).toBe(`(2.40)`);
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled and thousand separator in the "params"', () => {
+    const input = -12345678.4;
+    const output = decimalFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`(12,345,678.40)`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2 } } as GridOption);
     const input = -2.4;
     const output = decimalFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`(2.40)`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled and thousand separator in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: ' ' } } as GridOption);
+    const input = -12345678.4;
+    const output = decimalFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`(12 345 678,40)`);
   });
 });

--- a/src/aurelia-slickgrid/formatters/__tests__/dollarColoredBoldFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dollarColoredBoldFormatter.spec.ts
@@ -28,6 +28,12 @@ describe('the DollarColoredBold Formatter', () => {
     expect(output).toBe(`<span style="color:red; font-weight:bold;">-$15.00</span>`);
   });
 
+  it('should display a red number with dollar symbol and thousand separator when value is a negative number', () => {
+    const input = -12345678;
+    const output = dollarColoredBoldFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`<span style="color:red; font-weight:bold;">-$12,345,678.00</span>`);
+  });
+
   it('should display a green number with dollar symbol when value greater or equal to 70 and is a type string', () => {
     const input = '70';
     const output = dollarColoredBoldFormatter(1, 1, input, {} as Column, {});
@@ -58,10 +64,23 @@ describe('the DollarColoredBold Formatter', () => {
     expect(output).toBe(`<span style="color:red; font-weight:bold;">($2.40)</span>`);
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled and thousand separator in the "params"', () => {
+    const input = -12345678.4;
+    const output = dollarColoredBoldFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`<span style="color:red; font-weight:bold;">($12,345,678.40)</span>`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const input = -2.4;
     const output = dollarColoredBoldFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`<span style="color:red; font-weight:bold;">($2.40)</span>`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled and thousand separator in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: ' ' } } as GridOption);
+    const input = -12345678.4;
+    const output = dollarColoredBoldFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`<span style="color:red; font-weight:bold;">($12 345 678,40)</span>`);
   });
 });

--- a/src/aurelia-slickgrid/formatters/__tests__/dollarColoredFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dollarColoredFormatter.spec.ts
@@ -28,6 +28,12 @@ describe('the DollarColored Formatter', () => {
     expect(output).toBe(`<span style="color:red">-$15.00</span>`);
   });
 
+  it('should display a red number with dollar symbol and thousand separator when value is a negative number', () => {
+    const input = -12345678;
+    const output = dollarColoredFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`<span style="color:red">-$12,345,678.00</span>`);
+  });
+
   it('should display a green number with dollar symbol when value greater or equal to 70 and is a type string', () => {
     const input = '70';
     const output = dollarColoredFormatter(1, 1, input, {} as Column, {});
@@ -58,10 +64,22 @@ describe('the DollarColored Formatter', () => {
     expect(output).toBe(`<span style="color:red">($2.40)</span>`);
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled and thousand separator in the "params"', () => {
+    const input = -12345678.4;
+    const output = dollarColoredFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`<span style="color:red">($12,345,678.40)</span>`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const input = -2.4;
     const output = dollarColoredFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`<span style="color:red">($2.40)</span>`);
+  });
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled and thousand separator in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: ' ' } } as GridOption);
+    const input = -12345678.4;
+    const output = dollarColoredFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`<span style="color:red">($12 345 678,40)</span>`);
   });
 });

--- a/src/aurelia-slickgrid/formatters/__tests__/dollarFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/dollarFormatter.spec.ts
@@ -28,6 +28,12 @@ describe('the Dollar Formatter', () => {
     expect(output).toBe(`-$15.00`);
   });
 
+  it('should display a number with negative dollar sign when a negative number and thousand separator is provided', () => {
+    const input = -12345678;
+    const output = dollarFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`-$12,345,678.00`);
+  });
+
   it('should display a number with dollar sign when a number is provided', () => {
     const input = 99;
     const output = dollarFormatter(1, 1, input, {} as Column, {});
@@ -58,10 +64,23 @@ describe('the Dollar Formatter', () => {
     expect(output).toBe(`($2.40)`);
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled and thousand separator in the "params"', () => {
+    const input = -12345678.4;
+    const output = dollarFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`($12,345,678.40)`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const input = -2.4;
     const output = dollarFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`($2.40)`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled and thousand separator in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: ' ' } } as GridOption);
+    const input = -12345678.4;
+    const output = dollarFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`($12 345 678,40)`);
   });
 });

--- a/src/aurelia-slickgrid/formatters/__tests__/formatterUtilities.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/formatterUtilities.spec.ts
@@ -1,0 +1,65 @@
+import { getAssociatedDateFormatter, getValueFromParamsOrFormatterOptions } from '../formatterUtilities';
+import { FieldType, Column, GridOption } from '../../models';
+
+describe('formatterUtilities', () => {
+  const gridStub = {
+    getOptions: jest.fn()
+  };
+
+  describe('getValueFromParamsOrGridOptions method', () => {
+    it('should return options found in the Grid Option when not found in Column Definition "params" property', () => {
+      const gridOptions = { formatterOptions: { minDecimal: 2 } } as GridOption;
+      const gridSpy = gridStub.getOptions.mockReturnValue(gridOptions);
+
+      const output = getValueFromParamsOrFormatterOptions('minDecimal', {} as Column, gridStub, -1);
+
+      expect(gridSpy).toHaveBeenCalled();
+      expect(output).toBe(2);
+    });
+
+    it('should return options found in the Column Definition "params" even if exist in the Grid Option as well', () => {
+      const gridOptions = { formatterOptions: { minDecimal: 2 } } as GridOption;
+      const gridSpy = gridStub.getOptions.mockReturnValue(gridOptions);
+
+      const output = getValueFromParamsOrFormatterOptions('minDecimal', { params: { minDecimal: 3 } } as Column, gridStub, -1);
+
+      expect(gridSpy).toHaveBeenCalled();
+      expect(output).toBe(3);
+    });
+
+    it('should return default value when not found in "params" (columnDef) neither the "formatterOptions" (gridOption)', () => {
+      const defaultValue = 5;
+      const output = getValueFromParamsOrFormatterOptions('minDecimal', { field: 'column1' } as Column, {}, defaultValue);
+      expect(output).toBe(defaultValue);
+    });
+  });
+
+  describe('getAssociatedDateFormatter method', () => {
+    it('should return a Formatter function', () => {
+      const formatterFn = getAssociatedDateFormatter(FieldType.dateIso, '-');
+      const isFunction = typeof formatterFn === 'function';
+      expect(isFunction).toBe(true);
+    });
+
+    it('should return a formatted Date when calling the Formatter function', () => {
+      const formatterFn = getAssociatedDateFormatter(FieldType.dateIso, '-');
+      const gridSpy = jest.spyOn(gridStub, 'getOptions');
+
+      const output = formatterFn(1, 1, '2002-01-01T00:01:01', { type: FieldType.dateIso } as Column, {}, gridStub);
+
+      expect(gridSpy).toHaveBeenCalled();
+      expect(output).toBe('2002-01-01');
+    });
+
+    it('should return a formatted Date with a different separator when changing setting the "dateSeparator" in "formatterOptions"', () => {
+      const formatterFn = getAssociatedDateFormatter(FieldType.dateIso, '-');
+      const gridOptions = { formatterOptions: { dateSeparator: '.' } } as GridOption;
+      const gridSpy = gridStub.getOptions.mockReturnValue(gridOptions);
+
+      const output = formatterFn(1, 1, '2002-01-01T00:01:01', { type: FieldType.dateIso } as Column, {}, gridStub);
+
+      expect(gridSpy).toHaveBeenCalled();
+      expect(output).toBe('2002.01.01');
+    });
+  });
+});

--- a/src/aurelia-slickgrid/formatters/__tests__/percentCompleteFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/percentCompleteFormatter.spec.ts
@@ -52,10 +52,23 @@ describe('the Percent Complete Formatter', () => {
     expect(output).toBe(`<span style='color:red'>(2.4%)</span>`);
   });
 
-  it('should display a negative percentage with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with thousand separator and parentheses when "displayNegativeNumberWithParentheses" is enabled in the "params"', () => {
+    const input = -345678.024;
+    const output = percentCompleteFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`<span style='color:red'>(345,678.024%)</span>`);
+  });
+
+  it('should display a negative percentage with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2 } } as GridOption);
     const input = -2.4;
     const output = percentCompleteFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`<span style='color:red'>(2.40%)</span>`);
+  });
+
+  it('should display a negative average with thousand separator and parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as GridOption);
+    const input = -345678.024;
+    const output = percentCompleteFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`<span style='color:red'>(345_678,02%)</span>`);
   });
 });

--- a/src/aurelia-slickgrid/formatters/__tests__/percentFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/percentFormatter.spec.ts
@@ -40,16 +40,35 @@ describe('the Percent Symbol Formatter', () => {
     expect(output).toBe('88%');
   });
 
+  it('should display thousand separated percentage when the thousand separator is provided', () => {
+    const input = '345678';
+    const output = percentFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe('34,567,800%');
+  });
+
   it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled in the "params"', () => {
     const input = -0.024;
     const output = percentFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true } } as Column, {});
     expect(output).toBe(`(2.4%)`);
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with thousand separator and parentheses when "displayNegativeNumberWithParentheses" is enabled in the "params"', () => {
+    const input = -345678.024;
+    const output = percentFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`(34,567,802.4%)`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2 } } as GridOption);
     const input = -0.024;
     const output = percentFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`(2.40%)`);
+  });
+
+  it('should display a negative average with thousand separator and parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as GridOption);
+    const input = -345678.024;
+    const output = percentFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`(34_567_802,40%)`);
   });
 });

--- a/src/aurelia-slickgrid/formatters/__tests__/percentSymbolFormatter.spec.ts
+++ b/src/aurelia-slickgrid/formatters/__tests__/percentSymbolFormatter.spec.ts
@@ -28,10 +28,22 @@ describe('the Percent Symbol Formatter', () => {
     expect(output).toBe(`-15%`);
   });
 
+  it('should display a number with thousand separator and negative percentage sign when a negative number is provided', () => {
+    const input = -15;
+    const output = percentSymbolFormatter(1, 1, input, {} as Column, {});
+    expect(output).toBe(`-15%`);
+  });
+
   it('should display a number with percentage sign when a number is provided', () => {
     const input = 99;
     const output = percentSymbolFormatter(1, 1, input, {} as Column, {});
     expect(output).toBe(`99%`);
+  });
+
+  it('should display a number with thousand separator and  percentage sign when a number is provided', () => {
+    const input = 2345678;
+    const output = percentSymbolFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`2,345,678%`);
   });
 
   it('should display a number with percentage sign when a string number is provided', () => {
@@ -40,16 +52,35 @@ describe('the Percent Symbol Formatter', () => {
     expect(output).toBe(`99%`);
   });
 
+  it('should display a number with thousand separator and  percentage sign when a string number is provided', () => {
+    const input = '2345678';
+    const output = percentSymbolFormatter(1, 1, input, { params: { thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`2,345,678%`);
+  });
+
   it('should display a negative number with parentheses when "displayNegativeNumberWithParentheses" is enabled in the "params"', () => {
     const input = -2.4;
     const output = percentSymbolFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true } } as Column, {});
     expect(output).toBe(`(2.4%)`);
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative number with thousand separator and parentheses when "displayNegativeNumberWithParentheses" is enabled in the "params"', () => {
+    const input = -2345678.4;
+    const output = percentSymbolFormatter(1, 1, input, { params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    expect(output).toBe(`(2,345,678.4%)`);
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2 } } as GridOption);
     const input = -2.4;
     const output = percentSymbolFormatter(1, 1, input, {} as Column, {}, gridStub);
     expect(output).toBe(`(2.40%)`);
+  });
+
+  it('should display a negative average with thousand separator and parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, minDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as GridOption);
+    const input = -2345678.4;
+    const output = percentSymbolFormatter(1, 1, input, {} as Column, {}, gridStub);
+    expect(output).toBe(`(2_345_678,40%)`);
   });
 });

--- a/src/aurelia-slickgrid/formatters/decimalFormatter.ts
+++ b/src/aurelia-slickgrid/formatters/decimalFormatter.ts
@@ -1,13 +1,15 @@
 import { Column, Formatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const decimalFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any) => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
   const params = columnDef.params || {};
-  let minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  let maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 2);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  let minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  let maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 2);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   // @deprecated: decimalPlaces, minDecimalPlaces, maxDecimalPlaces
   // add these extra checks to support previous way of passing the decimal count
@@ -19,7 +21,7 @@ export const decimalFormatter: Formatter = (row: number, cell: number, value: an
   }
 
   if (isNumber) {
-    return formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses);
+    return formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '', decimalSeparator, thousandSeparator);
   }
   return value;
 };

--- a/src/aurelia-slickgrid/formatters/dollarColoredBoldFormatter.ts
+++ b/src/aurelia-slickgrid/formatters/dollarColoredBoldFormatter.ts
@@ -1,16 +1,18 @@
 import { Column, Formatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const dollarColoredBoldFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any) => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (isNumber) {
     const colorStyle = (value >= 0) ? 'green' : 'red';
-    const formattedNumber = formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `<span style="color:${colorStyle}; font-weight:bold;">${formattedNumber}</span>`;
   }
   return value;

--- a/src/aurelia-slickgrid/formatters/dollarColoredFormatter.ts
+++ b/src/aurelia-slickgrid/formatters/dollarColoredFormatter.ts
@@ -1,16 +1,18 @@
 import { Column, Formatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const dollarColoredFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any) => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (isNumber) {
     const colorStyle = (value >= 0) ? 'green' : 'red';
-    const formattedNumber = formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `<span style="color:${colorStyle}">${formattedNumber}</span>`;
   }
   return value;

--- a/src/aurelia-slickgrid/formatters/dollarFormatter.ts
+++ b/src/aurelia-slickgrid/formatters/dollarFormatter.ts
@@ -1,15 +1,17 @@
 import { Column, Formatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const dollarFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any) => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (isNumber) {
-    return formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    return formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
   }
   return value;
 };

--- a/src/aurelia-slickgrid/formatters/formatterUtilities.ts
+++ b/src/aurelia-slickgrid/formatters/formatterUtilities.ts
@@ -8,7 +8,7 @@ import * as moment from 'moment-mini';
  * 2- Grid Options "formatterOptions"
  * 3- nothing found, return default value provided
  */
-export function getValueFromParamsOrGridOptions(optionName: string, columnDef: Column, grid: any, defaultValue?: any) {
+export function getValueFromParamsOrFormatterOptions(optionName: string, columnDef: Column, grid: any, defaultValue?: any) {
   const gridOptions = ((grid && typeof grid.getOptions === 'function') ? grid.getOptions() : {}) as GridOption;
   const params = columnDef && columnDef.params;
 
@@ -21,11 +21,23 @@ export function getValueFromParamsOrGridOptions(optionName: string, columnDef: C
 }
 
 /** From a FieldType, return the associated date Formatter */
-export function getAssociatedDateFormatter(fieldType: FieldType): Formatter {
-  const FORMAT = mapMomentDateFormatWithFieldType(fieldType);
+export function getAssociatedDateFormatter(fieldType: FieldType, defaultSeparator: string): Formatter {
+  const defaultDateFormat = mapMomentDateFormatWithFieldType(fieldType);
 
-  return (row: number, cell: number, value: any, columnDef: Column, dataContext: any) => {
-    const isDateValid = moment(value, FORMAT, false).isValid();
-    return (value && isDateValid) ? moment(value).format(FORMAT) : value;
+  return (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any) => {
+    const gridOptions = ((grid && typeof grid.getOptions === 'function') ? grid.getOptions() : {}) as GridOption;
+    const customSeparator = gridOptions && gridOptions.formatterOptions && gridOptions.formatterOptions.dateSeparator || defaultSeparator;
+
+    const isDateValid = moment(value, defaultDateFormat, false).isValid();
+    let outputDate = (value && isDateValid) ? moment(value).format(defaultDateFormat) : value;
+
+    // user can customize the separator through the "formatterOptions"
+    // if that is the case we need to replace the default "/" to the new separator
+    if (outputDate && customSeparator !== defaultSeparator) {
+      const regex = new RegExp(defaultSeparator, 'ig'); // find separator globally
+      outputDate = outputDate.replace(regex, customSeparator);
+    }
+
+    return outputDate;
   };
 }

--- a/src/aurelia-slickgrid/formatters/index.ts
+++ b/src/aurelia-slickgrid/formatters/index.ts
@@ -82,40 +82,40 @@ export const Formatters = {
   collectionEditor: collectionEditorFormatter,
 
   /** Takes a Date object and displays it as an ISO Date format (YYYY-MM-DD) */
-  dateIso: getAssociatedDateFormatter(FieldType.dateIso),
+  dateIso: getAssociatedDateFormatter(FieldType.dateIso, '-'),
 
   /** Takes a Date object and displays it as an ISO Date+Time format (YYYY-MM-DD HH:mm:ss) */
-  dateTimeIso: getAssociatedDateFormatter(FieldType.dateTimeIso),
+  dateTimeIso: getAssociatedDateFormatter(FieldType.dateTimeIso, '-'),
 
   /** Takes a Date object and displays it as an ISO Date+Time (without seconds) format (YYYY-MM-DD HH:mm) */
-  dateTimeShortIso: getAssociatedDateFormatter(FieldType.dateTimeShortIso),
+  dateTimeShortIso: getAssociatedDateFormatter(FieldType.dateTimeShortIso, '-'),
 
   /** Takes a Date object and displays it as an ISO Date+Time+(am/pm) format (YYYY-MM-DD h:mm:ss a) */
-  dateTimeIsoAmPm: getAssociatedDateFormatter(FieldType.dateTimeIsoAmPm),
+  dateTimeIsoAmPm: getAssociatedDateFormatter(FieldType.dateTimeIsoAmPm, '-'),
 
   /** Takes a Date object and displays it as an Euro Date format (DD/MM/YYYY) */
-  dateEuro: getAssociatedDateFormatter(FieldType.dateEuro),
+  dateEuro: getAssociatedDateFormatter(FieldType.dateEuro, '/'),
 
   /** Takes a Date object and displays it as an Euro Date+Time format (DD/MM/YYYY HH:mm:ss) */
-  dateTimeEuro: getAssociatedDateFormatter(FieldType.dateTimeEuro),
+  dateTimeEuro: getAssociatedDateFormatter(FieldType.dateTimeEuro, '/'),
 
   /** Takes a Date object and displays it as an Euro Date+Time (without seconds) format (DD/MM/YYYY HH:mm) */
-  dateTimeShortEuro: getAssociatedDateFormatter(FieldType.dateTimeShortEuro),
+  dateTimeShortEuro: getAssociatedDateFormatter(FieldType.dateTimeShortEuro, '/'),
 
   /** Takes a Date object and displays it as an Euro Date+Time+(am/pm) format (DD/MM/YYYY hh:mm:ss a) */
-  dateTimeEuroAmPm: getAssociatedDateFormatter(FieldType.dateTimeEuroAmPm),
+  dateTimeEuroAmPm: getAssociatedDateFormatter(FieldType.dateTimeEuroAmPm, '/'),
 
   /** Takes a Date object and displays it as an US Date format (MM/DD/YYYY) */
-  dateUs: getAssociatedDateFormatter(FieldType.dateUs),
+  dateUs: getAssociatedDateFormatter(FieldType.dateUs, '/'),
 
   /** Takes a Date object and displays it as an US Date+Time format (MM/DD/YYYY HH:mm:ss) */
-  dateTimeUs: getAssociatedDateFormatter(FieldType.dateTimeUs),
+  dateTimeUs: getAssociatedDateFormatter(FieldType.dateTimeUs, '/'),
 
   /** Takes a Date object and displays it as an US Date+Time (without seconds) format (MM/DD/YYYY HH:mm:ss) */
-  dateTimeShortUs: getAssociatedDateFormatter(FieldType.dateTimeShortUs),
+  dateTimeShortUs: getAssociatedDateFormatter(FieldType.dateTimeShortUs, '/'),
 
   /** Takes a Date object and displays it as an US Date+Time+(am/pm) format (MM/DD/YYYY hh:mm:ss a) */
-  dateTimeUsAmPm: getAssociatedDateFormatter(FieldType.dateTimeUsAmPm),
+  dateTimeUsAmPm: getAssociatedDateFormatter(FieldType.dateTimeUsAmPm, '/'),
 
   /** Displays a Font-Awesome delete icon (fa-trash) */
   deleteIcon: deleteIconFormatter,
@@ -143,8 +143,12 @@ export const Formatters = {
   /**
    * Takes an hyperlink cell value and transforms it into a real hyperlink, given that the value starts with 1 of these (http|ftp|https).
    * The structure will be "<a href="hyperlink">hyperlink</a>"
+   *
    * You can optionally change the hyperlink text displayed by using the generic params "hyperlinkText" in the column definition
    * For example: { id: 'link', field: 'link', params: { hyperlinkText: 'Company Website' } } will display "<a href="link">Company Website</a>"
+   *
+   * You can also optionally provide the hyperlink URL by using the generic params "hyperlinkUrl" in the column definition
+   * For example: { id: 'link', field: 'link', params: {  hyperlinkText: 'Company Website', hyperlinkUrl: 'http://www.somewhere.com' } } will display "<a href="http://www.somewhere.com">Company Website</a>"
    */
   hyperlink: hyperlinkFormatter,
 

--- a/src/aurelia-slickgrid/formatters/maskFormatter.ts
+++ b/src/aurelia-slickgrid/formatters/maskFormatter.ts
@@ -13,12 +13,10 @@ export const maskFormatter: Formatter = (row: number, cell: number, value: any, 
     throw new Error(`You must provide a "mask" via the generic "params" options (e.g.: { formatter: Formatters.mask, params: { mask: '000-000' }}`);
   }
 
-  if (value && mask) {
+  if (value) {
     let i = 0;
     const v = value.toString();
-    return mask.replace(/[09A]/gi, (match: string) => {
-      return v[i++] || '';
-    });
+    return mask.replace(/[09A]/gi, () => v[i++] || '');
   }
   return value;
 };

--- a/src/aurelia-slickgrid/formatters/percentCompleteFormatter.ts
+++ b/src/aurelia-slickgrid/formatters/percentCompleteFormatter.ts
@@ -1,16 +1,18 @@
 import { Column, Formatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const percentCompleteFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any): string => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (isNumber) {
     const colorStyle = (value < 50) ? 'red' : 'green';
-    const formattedNumber = formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '%');
+    const formattedNumber = formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '%', decimalSeparator, thousandSeparator);
     const outputFormattedValue = value > 100 ? '100%' : formattedNumber;
     return `<span style='color:${colorStyle}'>${outputFormattedValue}</span>`;
   }

--- a/src/aurelia-slickgrid/formatters/percentFormatter.ts
+++ b/src/aurelia-slickgrid/formatters/percentFormatter.ts
@@ -1,17 +1,19 @@
 import { Column } from './../models/column.interface';
 import { Formatter } from './../models/formatter.interface';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const percentFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any): string => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (isNumber) {
     const percentValue = value * 100;
-    return formatNumber(percentValue, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '%');
+    return formatNumber(percentValue, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '%', decimalSeparator, thousandSeparator);
   }
   return value;
 };

--- a/src/aurelia-slickgrid/formatters/percentSymbolFormatter.ts
+++ b/src/aurelia-slickgrid/formatters/percentSymbolFormatter.ts
@@ -1,16 +1,18 @@
 import { Column } from './../models/column.interface';
 import { Formatter } from './../models/formatter.interface';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from './formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from './formatterUtilities';
 
 export const percentSymbolFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any): string => {
   const isNumber = (value === null || value === undefined || value === '') ? false : !isNaN(+value);
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (isNumber) {
-    return formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '%');
+    return formatNumber(value, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '%', decimalSeparator, thousandSeparator);
   }
   return value;
 };

--- a/src/aurelia-slickgrid/grouping-formatters/__tests__/avgTotalsDollarFormatters.spec.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/__tests__/avgTotalsDollarFormatters.spec.ts
@@ -40,6 +40,20 @@ describe('avgTotalsDollarFormatter', () => {
     expect(output).toBe('-$2.45');
   });
 
+  it('should display a negative average with dollar sign and thousand separator when its input is negative', () => {
+    const columnDef = { id: 'column3', field: 'column3', params: { thousandSeparator: ',' } } as Column;
+    const totals = { avg: { column1: 123, column2: 345, column3: -12345678.45 } };
+    const output = avgTotalsDollarFormatter(totals, columnDef, {});
+    expect(output).toBe('-$12,345,678.45');
+  });
+
+  it('should display a negative average with dollar sign, comma as decimal separator and underscore as thousand separator when its input is negative', () => {
+    const columnDef = { id: 'column3', field: 'column3', params: { decimalSeparator: ',', thousandSeparator: '_' } } as Column;
+    const totals = { avg: { column1: 123, column2: 345, column3: -12345678.45 } };
+    const output = avgTotalsDollarFormatter(totals, columnDef, {});
+    expect(output).toBe('-$12_345_678,45');
+  });
+
   it('should display a negative average with parentheses instead of the negative sign with dollar sign when its input is negative', () => {
     const columnDef = { id: 'column3', field: 'column3', params: { displayNegativeNumberWithParentheses: true } } as Column;
     const totals = { avg: { column1: 123, column2: 345, column3: -2.4 } };
@@ -47,12 +61,27 @@ describe('avgTotalsDollarFormatter', () => {
     expect(output).toBe('($2.40)');
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative average with parentheses instead of the negative sign with dollar sign and thousand separator when its input is negative', () => {
+    const columnDef = { id: 'column3', field: 'column3', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column;
+    const totals = { avg: { column1: 123, column2: 345, column3: -12345678.4 } };
+    const output = avgTotalsDollarFormatter(totals, columnDef, {});
+    expect(output).toBe('($12,345,678.40)');
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { avg: { column1: 123, column2: 345, column3: -2.4 } };
     const output = avgTotalsDollarFormatter(totals, columnDef, gridStub);
     expect(output).toBe('($2.40)');
+  });
+
+  it('should display a negative average with parentheses and thousand separator when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
+    gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as GridOption);
+    const columnDef = { id: 'column3', field: 'column3' } as Column;
+    const totals = { avg: { column1: 123, column2: 345, column3: -12345678.4 } };
+    const output = avgTotalsDollarFormatter(totals, columnDef, gridStub);
+    expect(output).toBe('($12,345,678.40)');
   });
 
   it('should display an average number with at least 2 decimals but no more than 4 by default, and dollar sign when a positive number is provided', () => {
@@ -104,5 +133,21 @@ describe('avgTotalsDollarFormatter', () => {
     expect(output1).toBe('Avg: $123.46');
     expect(output2).toBe('$345.2 (avg)');
     expect(output3).toBe('Avg: ($2.450)/item');
+  });
+
+  it('should display an average number with prefix, suffix and thousand separator', () => {
+    const totals = { avg: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = avgTotalsDollarFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Avg: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = avgTotalsDollarFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (avg)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = avgTotalsDollarFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Avg: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Avg: $12_345_678,46');
+    expect(output2).toBe('$345_678,2 (avg)');
+    expect(output3).toBe('Avg: ($345_678,450)/item');
   });
 });

--- a/src/aurelia-slickgrid/grouping-formatters/__tests__/avgTotalsFormatter.spec.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/__tests__/avgTotalsFormatter.spec.ts
@@ -43,6 +43,18 @@ describe('avgTotalsFormatter', () => {
     expect(output2).toBe('-34.57');
   });
 
+  it('should display a negative average and thousand separator when its input is negative', () => {
+    const totals = { avg: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = avgTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = avgTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = avgTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('-12,345,678');
+    expect(output2).toBe('-345,678.57');
+    expect(output3).toBe('-345_678,57');
+  });
+
   it('should display a negative average with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { avg: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
@@ -53,7 +65,19 @@ describe('avgTotalsFormatter', () => {
     expect(output2).toBe('(34.57)');
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative average with and thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { avg: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = avgTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = avgTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = avgTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('(12,345,678)');
+    expect(output2).toBe('(345,678.57)');
+    expect(output3).toBe('(345_678,57)');
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { avg: { column1: 123, column2: 345, column3: -2.4 } };
@@ -112,5 +136,21 @@ describe('avgTotalsFormatter', () => {
     expect(output1).toBe('Avg: 123.46');
     expect(output2).toBe('345.2 (avg)');
     expect(output3).toBe('Avg: (2.450)/item');
+  });
+
+  it('should display an average number with prefix, suffix and thousand separator', () => {
+    const totals = { avg: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = avgTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Avg: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = avgTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (avg)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = avgTotalsFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Avg: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Avg: 12_345_678,46');
+    expect(output2).toBe('345_678,2 (avg)');
+    expect(output3).toBe('Avg: (345_678,450)/item');
   });
 });

--- a/src/aurelia-slickgrid/grouping-formatters/__tests__/avgTotalsPercentageFormatter.spec.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/__tests__/avgTotalsPercentageFormatter.spec.ts
@@ -43,6 +43,18 @@ describe('avgTotalsPercentageFormatter', () => {
     expect(output2).toBe('-34.57%');
   });
 
+  it('should display a negative percentage average and thousand separator when its input is negative', () => {
+    const totals = { avg: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = avgTotalsPercentageFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = avgTotalsPercentageFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = avgTotalsPercentageFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('-12,345,678%');
+    expect(output2).toBe('-345,678.57%');
+    expect(output3).toBe('-345_678,57%');
+  });
+
   it('should display a negative percentage average with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { avg: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
@@ -53,7 +65,19 @@ describe('avgTotalsPercentageFormatter', () => {
     expect(output2).toBe('(34.57%)');
   });
 
-  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative percentage average and thousand separator with parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { avg: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = avgTotalsPercentageFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = avgTotalsPercentageFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = avgTotalsPercentageFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('(12,345,678%)');
+    expect(output2).toBe('(345,678.57%)');
+    expect(output3).toBe('(345_678,57%)');
+  });
+
+  it('should display a negative average with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { avg: { column1: 123, column2: 345, column3: -2.4 } };
@@ -112,5 +136,21 @@ describe('avgTotalsPercentageFormatter', () => {
     expect(output1).toBe('Avg: 123.46%');
     expect(output2).toBe('345.2% (avg)');
     expect(output3).toBe('Avg: (2.450%)/item');
+  });
+
+  it('should display an average number with prefix, suffix and thousand separator', () => {
+    const totals = { avg: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = avgTotalsPercentageFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Avg: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = avgTotalsPercentageFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (avg)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = avgTotalsPercentageFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Avg: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Avg: 12_345_678,46%');
+    expect(output2).toBe('345_678,2% (avg)');
+    expect(output3).toBe('Avg: (345_678,450%)/item');
   });
 });

--- a/src/aurelia-slickgrid/grouping-formatters/__tests__/maxTotalsFormatter.spec.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/__tests__/maxTotalsFormatter.spec.ts
@@ -43,6 +43,18 @@ describe('maxTotalsFormatter', () => {
     expect(output2).toBe('-34.57');
   });
 
+  it('should display a negative maximum and thousand separator when its input is negative', () => {
+    const totals = { max: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = maxTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = maxTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = maxTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('-12,345,678');
+    expect(output2).toBe('-345,678.57');
+    expect(output3).toBe('-345_678,57');
+  });
+
   it('should display a negative maximum with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { max: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
@@ -53,7 +65,19 @@ describe('maxTotalsFormatter', () => {
     expect(output2).toBe('(34.57)');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative maximum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { max: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = maxTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = maxTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = maxTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('(12,345,678)');
+    expect(output2).toBe('(345,678.57)');
+    expect(output3).toBe('(345_678,57)');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { max: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('maxTotalsFormatter', () => {
     expect(output1).toBe('Max: 123.46');
     expect(output2).toBe('345.2 (max)');
     expect(output3).toBe('Max: (2.450)/item');
+  });
+
+  it('should display a max number with prefix, suffix and thousand separator', () => {
+    const totals = { max: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = maxTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Max: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = maxTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (max)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = maxTotalsFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Max: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Max: 12_345_678,46');
+    expect(output2).toBe('345_678,2 (max)');
+    expect(output3).toBe('Max: (345_678,450)/item');
   });
 });

--- a/src/aurelia-slickgrid/grouping-formatters/__tests__/minTotalsFormatter.spec.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/__tests__/minTotalsFormatter.spec.ts
@@ -43,7 +43,19 @@ describe('minTotalsFormatter', () => {
     expect(output2).toBe('-34.57');
   });
 
-  it('should display a negative number with parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative minimum and thousand separator when its input is negative', () => {
+    const totals = { min: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = minTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = minTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = minTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('-12,345,678');
+    expect(output2).toBe('-345,678.57');
+    expect(output3).toBe('-345_678,57');
+  });
+
+  it('should display a negative minimum with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { min: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = minTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +65,19 @@ describe('minTotalsFormatter', () => {
     expect(output2).toBe('(34.57)');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative minimum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { min: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = minTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = minTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = minTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('(12,345,678)');
+    expect(output2).toBe('(345,678.57)');
+    expect(output3).toBe('(345_678,57)');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { min: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('minTotalsFormatter', () => {
     expect(output1).toBe('min: 123.46');
     expect(output2).toBe('345.2 (max)');
     expect(output3).toBe('min: (2.450)/item');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { min: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = minTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Min: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = minTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (min)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = minTotalsFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Min: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Min: 12_345_678,46');
+    expect(output2).toBe('345_678,2 (min)');
+    expect(output3).toBe('Min: (345_678,450)/item');
   });
 });

--- a/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsBoldFormatter.spec.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsBoldFormatter.spec.ts
@@ -43,7 +43,19 @@ describe('sumTotalsBoldFormatter', () => {
     expect(output2).toBe('<b>-34.57</b>');
   });
 
-  it('should display a negative maximum with parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative sum with parentheses and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsBoldFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<b>-12,345,678</b>');
+    expect(output2).toBe('<b>-345,678.57</b>');
+    expect(output3).toBe('<b>-345_678,57</b>');
+  });
+
+  it('should display a negative sum with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = sumTotalsBoldFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +65,19 @@ describe('sumTotalsBoldFormatter', () => {
     expect(output2).toBe('<b>(34.57)</b>');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsBoldFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<b>(12,345,678)</b>');
+    expect(output2).toBe('<b>(345,678.57)</b>');
+    expect(output3).toBe('<b>(345_678,57)</b>');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -109,18 +133,34 @@ describe('sumTotalsBoldFormatter', () => {
   it('should display a sum number a prefix and suffix', () => {
     const totals = { sum: { column1: 123.45678, column2: 345.2, column3: -2.45 } };
 
-    const output1 = sumTotalsBoldFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'sum: ' } } as Column, {});
-    const output2 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (max)' } } as Column, {});
+    const output1 = sumTotalsBoldFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ' } } as Column, {});
+    const output2 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)' } } as Column, {});
     const output3 = sumTotalsBoldFormatter(
       totals, {
         id: 'column3',
         field: 'column3',
-        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'sum: ', groupFormatterSuffix: '/item' }
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item' }
       } as Column
     );
 
-    expect(output1).toBe('<b>sum: 123.46</b>');
-    expect(output2).toBe('<b>345.2 (max)</b>');
-    expect(output3).toBe('<b>sum: (2.450)/item</b>');
+    expect(output1).toBe('<b>Sum: 123.46</b>');
+    expect(output2).toBe('<b>345.2 (sum)</b>');
+    expect(output3).toBe('<b>Sum: (2.450)/item</b>');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsBoldFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsBoldFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsBoldFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('<b>Sum: 12_345_678,46</b>');
+    expect(output2).toBe('<b>345_678,2 (sum)</b>');
+    expect(output3).toBe('<b>Sum: (345_678,450)/item</b>');
   });
 });

--- a/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsColoredFormatter.spec.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsColoredFormatter.spec.ts
@@ -43,6 +43,18 @@ describe('sumTotalsColoredFormatter', () => {
     expect(output2).toBe('<span style="color:red">-34.57</span>');
   });
 
+  it('should display a negative sum in red and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsColoredFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<span style="color:red">-12,345,678</span>');
+    expect(output2).toBe('<span style="color:red">-345,678.57</span>');
+    expect(output3).toBe('<span style="color:red">-345_678,57</span>');
+  });
+
   it('should display a negative sum in red with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
@@ -53,7 +65,19 @@ describe('sumTotalsColoredFormatter', () => {
     expect(output2).toBe('<span style="color:red">(34.57)</span>');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsColoredFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<span style="color:red">(12,345,678)</span>');
+    expect(output2).toBe('<span style="color:red">(345,678.57)</span>');
+    expect(output3).toBe('<span style="color:red">(345_678,57)</span>');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('sumTotalsColoredFormatter', () => {
     expect(output1).toBe('<span style="color:green">sum: 123.46</span>');
     expect(output2).toBe('<span style="color:green">345.2 (max)</span>');
     expect(output3).toBe('<span style="color:red">sum: (2.450)/item</span>');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsColoredFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsColoredFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsColoredFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('<span style="color:green">Sum: 12_345_678,46</span>');
+    expect(output2).toBe('<span style="color:green">345_678,2 (sum)</span>');
+    expect(output3).toBe('<span style="color:red">Sum: (345_678,450)/item</span>');
   });
 });

--- a/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsDollarBoldFormatter.spec.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsDollarBoldFormatter.spec.ts
@@ -43,7 +43,19 @@ describe('sumTotalsDollarBoldFormatter', () => {
     expect(output2).toBe('<b>-$34.57</b>');
   });
 
-  it('should display a negative sum in red with at least 2 decimals in parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative sum in red with at least 2 decimals and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarBoldFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<b>-$12,345,678.00</b>');
+    expect(output2).toBe('<b>-$345,678.57</b>');
+    expect(output3).toBe('<b>-$345_678,57</b>');
+  });
+
+  it('should display a negative sum in red with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = sumTotalsDollarBoldFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +65,19 @@ describe('sumTotalsDollarBoldFormatter', () => {
     expect(output2).toBe('<b>($34.57)</b>');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum in red with at least 2 decimals and thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarBoldFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<b>($12,345,678.00)</b>');
+    expect(output2).toBe('<b>($345,678.57)</b>');
+    expect(output3).toBe('<b>($345_678,57)</b>');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('sumTotalsDollarBoldFormatter', () => {
     expect(output1).toBe('<b>sum: $123.46</b>');
     expect(output2).toBe('<b>$345.2 (max)</b>');
     expect(output3).toBe('<b>sum: ($2.450)/item</b>');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsDollarBoldFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsDollarBoldFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsDollarBoldFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('<b>Sum: $12_345_678,46</b>');
+    expect(output2).toBe('<b>$345_678,2 (sum)</b>');
+    expect(output3).toBe('<b>Sum: ($345_678,450)/item</b>');
   });
 });

--- a/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsDollarColoredBoldFormatter.spec.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsDollarColoredBoldFormatter.spec.ts
@@ -43,7 +43,19 @@ describe('sumTotalsDollarColoredBoldFormatter', () => {
     expect(output2).toBe('<span style="color:red; font-weight: bold;">-$34.57</span>');
   });
 
-  it('should display a negative sum in red with at least 2 decimals in parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative sum in red and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<span style="color:red; font-weight: bold;">-$12,345,678.00</span>');
+    expect(output2).toBe('<span style="color:red; font-weight: bold;">-$345,678.57</span>');
+    expect(output3).toBe('<span style="color:red; font-weight: bold;">-$345_678,57</span>');
+  });
+
+  it('should display a negative sum in red with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +65,19 @@ describe('sumTotalsDollarColoredBoldFormatter', () => {
     expect(output2).toBe('<span style="color:red; font-weight: bold;">($34.57)</span>');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<span style="color:red; font-weight: bold;">($12,345,678.00)</span>');
+    expect(output2).toBe('<span style="color:red; font-weight: bold;">($345,678.57)</span>');
+    expect(output3).toBe('<span style="color:red; font-weight: bold;">($345_678,57)</span>');
+  });
+
+  it('should display a negative sum in red with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('sumTotalsDollarColoredBoldFormatter', () => {
     expect(output1).toBe('<span style="color:green; font-weight: bold;">sum: $123.46</span>');
     expect(output2).toBe('<span style="color:green; font-weight: bold;">$345.2 (max)</span>');
     expect(output3).toBe('<span style="color:red; font-weight: bold;">sum: ($2.450)/item</span>');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsDollarColoredBoldFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsDollarColoredBoldFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('<span style="color:green; font-weight: bold;">Sum: $12_345_678,46</span>');
+    expect(output2).toBe('<span style="color:green; font-weight: bold;">$345_678,2 (sum)</span>');
+    expect(output3).toBe('<span style="color:red; font-weight: bold;">Sum: ($345_678,450)/item</span>');
   });
 });

--- a/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsDollarColoredFormatter.spec.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsDollarColoredFormatter.spec.ts
@@ -43,7 +43,19 @@ describe('sumTotalsDollarColoredFormatter', () => {
     expect(output2).toBe('<span style="color:red">-$34.57</span>');
   });
 
-  it('should display a negative sum in red with at least 2 decimals in parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative sum in red and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarColoredFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<span style="color:red">-$12,345,678.00</span>');
+    expect(output2).toBe('<span style="color:red">-$345,678.57</span>');
+    expect(output3).toBe('<span style="color:red">-$345_678,57</span>');
+  });
+
+  it('should display a negative sum in red with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = sumTotalsDollarColoredFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +65,19 @@ describe('sumTotalsDollarColoredFormatter', () => {
     expect(output2).toBe('<span style="color:red">($34.57)</span>');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum in red with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarColoredFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarColoredFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('<span style="color:red">($12,345,678.00)</span>');
+    expect(output2).toBe('<span style="color:red">($345,678.57)</span>');
+    expect(output3).toBe('<span style="color:red">($345_678,57)</span>');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('sumTotalsDollarColoredFormatter', () => {
     expect(output1).toBe('<span style="color:green">sum: $123.46</span>');
     expect(output2).toBe('<span style="color:green">$345.2 (max)</span>');
     expect(output3).toBe('<span style="color:red">sum: ($2.450)/item</span>');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsDollarColoredFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsDollarColoredFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsDollarColoredFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('<span style="color:green">Sum: $12_345_678,46</span>');
+    expect(output2).toBe('<span style="color:green">$345_678,2 (sum)</span>');
+    expect(output3).toBe('<span style="color:red">Sum: ($345_678,450)/item</span>');
   });
 });

--- a/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsDollarFormatter.spec.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsDollarFormatter.spec.ts
@@ -43,7 +43,19 @@ describe('sumTotalsDollarFormatter', () => {
     expect(output2).toBe('-$34.57');
   });
 
-  it('should display a negative sum in red with at least 2 decimals in parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative sum with at least 2 decimals and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('-$12,345,678.00');
+    expect(output2).toBe('-$345,678.57');
+    expect(output3).toBe('-$345_678,57');
+  });
+
+  it('should display a negative sum in red with at least 2 decimals with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = sumTotalsDollarFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +65,19 @@ describe('sumTotalsDollarFormatter', () => {
     expect(output2).toBe('($34.57)');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsDollarFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsDollarFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsDollarFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('($12,345,678.00)');
+    expect(output2).toBe('($345,678.57)');
+    expect(output3).toBe('($345_678,57)');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -122,5 +146,21 @@ describe('sumTotalsDollarFormatter', () => {
     expect(output1).toBe('sum: $123.46');
     expect(output2).toBe('$345.2 (max)');
     expect(output3).toBe('sum: ($2.450)/item');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsDollarFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsDollarFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsDollarFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Sum: $12_345_678,46');
+    expect(output2).toBe('$345_678,2 (sum)');
+    expect(output3).toBe('Sum: ($345_678,450)/item');
   });
 });

--- a/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsFormatter.spec.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/__tests__/sumTotalsFormatter.spec.ts
@@ -38,12 +38,26 @@ describe('sumTotalsFormatter', () => {
 
     const output1 = sumTotalsFormatter(totals, { id: 'column1', field: 'column1' } as Column, {});
     const output2 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2 } } as Column, {});
+    const output3 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',' } } as Column, {});
 
     expect(output1).toBe('-123');
     expect(output2).toBe('-34.57');
+    expect(output3).toBe('-34,57');
   });
 
-  it('should display a negative maximum with parentheses instead of the negative sign when its input is negative', () => {
+  it('should display a negative sum and thousand separator when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+
+    expect(output1).toBe('-12,345,678');
+    expect(output2).toBe('-345,678.57');
+    expect(output3).toBe('-345_678,57');
+  });
+
+  it('should display a negative sum with parentheses instead of the negative sign when its input is negative', () => {
     const totals = { sum: { column1: -123, column2: -34.5678, column3: -2.4 } };
 
     const output1 = sumTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true } } as Column, {});
@@ -53,7 +67,19 @@ describe('sumTotalsFormatter', () => {
     expect(output2).toBe('(34.57)');
   });
 
-  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Grid Options', () => {
+  it('should display a negative sum with thousand separator and parentheses instead of the negative sign when its input is negative', () => {
+    const totals = { sum: { column1: -12345678, column2: -345678.5678, column3: -2.4 } };
+
+    const output1 = sumTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output2 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, thousandSeparator: ',' } } as Column, {});
+    const output3 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { maxDecimal: 2, displayNegativeNumberWithParentheses: true, decimalSeparator: ',', thousandSeparator: ' ' } } as Column, {});
+
+    expect(output1).toBe('(12,345,678)');
+    expect(output2).toBe('(345,678.57)');
+    expect(output3).toBe('(345 678,57)');
+  });
+
+  it('should display a negative sum with parentheses when input is negative and "displayNegativeNumberWithParentheses" is enabled in the Formatter Options', () => {
     gridStub.getOptions.mockReturnValue({ formatterOptions: { displayNegativeNumberWithParentheses: true } } as GridOption);
     const columnDef = { id: 'column3', field: 'column3' } as Column;
     const totals = { sum: { column1: 123, column2: 345, column3: -2.4 } };
@@ -112,5 +138,21 @@ describe('sumTotalsFormatter', () => {
     expect(output1).toBe('sum: 123.46');
     expect(output2).toBe('345.2 (max)');
     expect(output3).toBe('sum: (2.450)/item');
+  });
+
+  it('should display a sum number with prefix, suffix and thousand separator', () => {
+    const totals = { sum: { column1: 12345678.45678, column2: 345678.2, column3: -345678.45 } };
+
+    const output1 = sumTotalsFormatter(totals, { id: 'column1', field: 'column1', params: { maxDecimal: 2, groupFormatterPrefix: 'Sum: ', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output2 = sumTotalsFormatter(totals, { id: 'column2', field: 'column2', params: { minDecimal: 0, groupFormatterSuffix: ' (sum)', decimalSeparator: ',', thousandSeparator: '_' } } as Column, {});
+    const output3 = sumTotalsFormatter(
+      totals, {
+        id: 'column3', field: 'column3',
+        params: { minDecimal: 3, displayNegativeNumberWithParentheses: true, groupFormatterPrefix: 'Sum: ', groupFormatterSuffix: '/item', decimalSeparator: ',', thousandSeparator: '_' }
+      } as Column);
+
+    expect(output1).toBe('Sum: 12_345_678,46');
+    expect(output2).toBe('345_678,2 (sum)');
+    expect(output3).toBe('Sum: (345_678,450)/item');
   });
 });

--- a/src/aurelia-slickgrid/grouping-formatters/avgTotalsDollarFormatter.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/avgTotalsDollarFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const avgTotalsDollarFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const avgTotalsDollarFormatter: GroupTotalsFormatter = (totals: any, colu
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `${prefix}${formattedNumber}${suffix}`;
   }
   return '';

--- a/src/aurelia-slickgrid/grouping-formatters/avgTotalsFormatter.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/avgTotalsFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
-import { decimalFormatted } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { decimalFormatted, thousandSeparatorFormatted } from '../services/utilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const avgTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,9 +8,11 @@ export const avgTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef:
   const params = columnDef && columnDef.params;
   let prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
     if (val < 0) {
@@ -19,16 +21,18 @@ export const avgTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef:
         prefix += '-';
       } else {
         if (isNaN(minDecimal) && isNaN(maxDecimal)) {
-          return `${prefix}(${Math.round(val)})${suffix}`;
+          const outputVal = thousandSeparatorFormatted(Math.round(val), thousandSeparator);
+          return `${prefix}(${outputVal})${suffix}`;
         }
-        return `${prefix}(${decimalFormatted(val, minDecimal, maxDecimal)})${suffix}`;
+        return `${prefix}(${decimalFormatted(val, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)})${suffix}`;
       }
     }
 
     if (isNaN(minDecimal) && isNaN(maxDecimal)) {
-      return `${prefix}${Math.round(val)}${suffix}`;
+      const outputVal = thousandSeparatorFormatted(Math.round(val), thousandSeparator);
+      return `${prefix}${outputVal}${suffix}`;
     }
-    return `${prefix}${decimalFormatted(val, minDecimal, maxDecimal)}${suffix}`;
+    return `${prefix}${decimalFormatted(val, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)}${suffix}`;
   }
   return '';
 };

--- a/src/aurelia-slickgrid/grouping-formatters/avgTotalsPercentageFormatter.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/avgTotalsPercentageFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
-import { decimalFormatted } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { decimalFormatted, thousandSeparatorFormatted } from '../services/utilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const avgTotalsPercentageFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,9 +8,11 @@ export const avgTotalsPercentageFormatter: GroupTotalsFormatter = (totals: any, 
   const params = columnDef && columnDef.params;
   let prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
     if (val < 0) {
@@ -19,16 +21,18 @@ export const avgTotalsPercentageFormatter: GroupTotalsFormatter = (totals: any, 
         prefix += '-';
       } else {
         if (isNaN(minDecimal) && isNaN(maxDecimal)) {
-          return `${prefix}(${Math.round(val)}%)${suffix}`;
+          const outputVal = thousandSeparatorFormatted(Math.round(val), thousandSeparator);
+          return `${prefix}(${outputVal}%)${suffix}`;
         }
-        return `${prefix}(${decimalFormatted(val, minDecimal, maxDecimal)}%)${suffix}`;
+        return `${prefix}(${decimalFormatted(val, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)}%)${suffix}`;
       }
     }
 
     if (isNaN(minDecimal) && isNaN(maxDecimal)) {
-      return `${prefix}${Math.round(val)}%${suffix}`;
+      const outputVal = thousandSeparatorFormatted(Math.round(val), thousandSeparator);
+      return `${prefix}${outputVal}%${suffix}`;
     }
-    return `${prefix}${decimalFormatted(val, minDecimal, maxDecimal)}%${suffix}`;
+    return `${prefix}${decimalFormatted(val, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)}%${suffix}`;
   }
   return '';
 };

--- a/src/aurelia-slickgrid/grouping-formatters/maxTotalsFormatter.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/maxTotalsFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const maxTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const maxTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef:
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses);
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '', decimalSeparator, thousandSeparator);
     return `${prefix}${formattedNumber}${suffix}`;
   }
   return '';

--- a/src/aurelia-slickgrid/grouping-formatters/minTotalsFormatter.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/minTotalsFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const minTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const minTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef:
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses);
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '', decimalSeparator, thousandSeparator);
     return `${prefix}${formattedNumber}${suffix}`;
   }
   return '';

--- a/src/aurelia-slickgrid/grouping-formatters/sumTotalsBoldFormatter.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/sumTotalsBoldFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsBoldFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const sumTotalsBoldFormatter: GroupTotalsFormatter = (totals: any, column
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses);
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '', decimalSeparator, thousandSeparator);
     return `<b>${prefix}${formattedNumber}${suffix}</b>`;
   }
   return '';

--- a/src/aurelia-slickgrid/grouping-formatters/sumTotalsColoredFormatter.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/sumTotalsColoredFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsColoredFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,13 +8,15 @@ export const sumTotalsColoredFormatter: GroupTotalsFormatter = (totals: any, col
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
     const colorStyle = (val >= 0) ? 'green' : 'red';
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses);
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '', decimalSeparator, thousandSeparator);
     return `<span style="color:${colorStyle}">${prefix}${formattedNumber}${suffix}</span>`;
   }
   return '';

--- a/src/aurelia-slickgrid/grouping-formatters/sumTotalsDollarBoldFormatter.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/sumTotalsDollarBoldFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsDollarBoldFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const sumTotalsDollarBoldFormatter: GroupTotalsFormatter = (totals: any, 
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `<b>${prefix}${formattedNumber}${suffix}</b>`;
   }
   return '';

--- a/src/aurelia-slickgrid/grouping-formatters/sumTotalsDollarColoredBoldFormatter.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/sumTotalsDollarColoredBoldFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsDollarColoredBoldFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,13 +8,15 @@ export const sumTotalsDollarColoredBoldFormatter: GroupTotalsFormatter = (totals
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
     const colorStyle = (val >= 0) ? 'green' : 'red';
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `<span style="color:${colorStyle}; font-weight: bold;">${prefix}${formattedNumber}${suffix}</span>`;
   }
   return '';

--- a/src/aurelia-slickgrid/grouping-formatters/sumTotalsDollarColoredFormatter.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/sumTotalsDollarColoredFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsDollarColoredFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,13 +8,15 @@ export const sumTotalsDollarColoredFormatter: GroupTotalsFormatter = (totals: an
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
     const colorStyle = (val >= 0) ? 'green' : 'red';
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `<span style="color:${colorStyle}">${prefix}${formattedNumber}${suffix}</span>`;
   }
   return '';

--- a/src/aurelia-slickgrid/grouping-formatters/sumTotalsDollarFormatter.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/sumTotalsDollarFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from './../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsDollarFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const sumTotalsDollarFormatter: GroupTotalsFormatter = (totals: any, colu
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid, 2);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid, 4);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 4);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$');
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '$', '', decimalSeparator, thousandSeparator);
     return `${prefix}${formattedNumber}${suffix}`;
   }
   return '';

--- a/src/aurelia-slickgrid/grouping-formatters/sumTotalsFormatter.ts
+++ b/src/aurelia-slickgrid/grouping-formatters/sumTotalsFormatter.ts
@@ -1,6 +1,6 @@
 import { Column, GroupTotalsFormatter } from './../models/index';
 import { formatNumber } from '../services/utilities';
-import { getValueFromParamsOrGridOptions } from '../formatters/formatterUtilities';
+import { getValueFromParamsOrFormatterOptions } from '../formatters/formatterUtilities';
 
 export const sumTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column, grid?: any) => {
   const field = columnDef.field || '';
@@ -8,12 +8,14 @@ export const sumTotalsFormatter: GroupTotalsFormatter = (totals: any, columnDef:
   const params = columnDef && columnDef.params;
   const prefix = params && params.groupFormatterPrefix || '';
   const suffix = params && params.groupFormatterSuffix || '';
-  const minDecimal = getValueFromParamsOrGridOptions('minDecimal', columnDef, grid);
-  const maxDecimal = getValueFromParamsOrGridOptions('maxDecimal', columnDef, grid);
-  const displayNegativeNumberWithParentheses = getValueFromParamsOrGridOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
 
   if (val != null && !isNaN(+val)) {
-    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses);
+    const formattedNumber = formatNumber(val, minDecimal, maxDecimal, displayNegativeNumberWithParentheses, '', '', decimalSeparator, thousandSeparator);
     return `${prefix}${formattedNumber}${suffix}`;
   }
   return '';

--- a/src/aurelia-slickgrid/models/formatterOption.interface.ts
+++ b/src/aurelia-slickgrid/models/formatterOption.interface.ts
@@ -1,10 +1,19 @@
 export interface FormatterOption {
-  /** defaults to false, option to display negative numbers in parentheses, example: -$12.50 becomes ($12.50) */
+  /** What separator to use to display a Date, for example using "." it could be "2002.01.01" */
+  dateSeparator?: '/' | '-' | '.' | ' ' | '';
+
+  /** Defaults to dot ".", separator to use as the decimal separator, example $123.55 or $123,55 */
+  decimalSeparator?: '.' | ',';
+
+  /** Defaults to false, option to display negative numbers wrapped in parentheses, example: -$12.50 becomes ($12.50) */
   displayNegativeNumberWithParentheses?: boolean;
 
-  /** defaults to undefined, minimum number of decimals */
+  /** Defaults to undefined, minimum number of decimals */
   minDecimal?: number;
 
-  /** defaults to undefined, maximum number of decimals */
+  /** Defaults to undefined, maximum number of decimals */
   maxDecimal?: number;
+
+  /** Defaults to empty string, thousand separator on a number. Example: 12345678 becomes 12,345,678 */
+  thousandSeparator?: ',' | '_' | '.' | ' ' | '';
 }

--- a/src/aurelia-slickgrid/services/__tests__/utilities.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/utilities.spec.ts
@@ -21,6 +21,7 @@ import {
   parseUtcDate,
   sanitizeHtmlToText,
   setDeepValue,
+  thousandSeparatorFormatted,
   titleCase,
   toCamelCase,
   toKebabCase,
@@ -265,6 +266,24 @@ describe('Service/Utilies', () => {
       const output = decimalFormatted(input, 2, 4);
       expect(output).toBe('-456.40');
     });
+
+    it('should return a string with comma as decimal separator when separator is set and maxDecimal is set and will round the decimal', () => {
+      const input = 1234567890.44566;
+      const output = decimalFormatted(input, 2, 4, ',');
+      expect(output).toBe('1234567890,4457');
+    });
+
+    it('should return a string with dot as decimal separator when separator is set and maxDecimal is set and will round the decimal', () => {
+      const input = '1234567890.44566';
+      const output = decimalFormatted(input, 2, 4, ',');
+      expect(output).toBe('1234567890,4457');
+    });
+
+    it('should return a string with thousand separator when separator is set and maxDecimal is set and will round the decimal', () => {
+      const input = 1234567890.44566;
+      const output = decimalFormatted(input, 2, 4, '.', ',');
+      expect(output).toBe('1,234,567,890.4457');
+    });
   });
 
   describe('formatNumber method', () => {
@@ -274,27 +293,62 @@ describe('Service/Utilies', () => {
       expect(output).toBe(input);
     });
 
+    it('should return original value when input provided is not a number even if thousand separator is set', () => {
+      const input = 'abc';
+      const decimalSeparator = ',';
+      const thousandSeparator = '_';
+      const output = formatNumber(input, undefined, undefined, false, '', '', decimalSeparator, thousandSeparator);
+      expect(output).toBe(input);
+    });
+
     it('should return a string with a number formatted to 2 decimals when minDecimal is set to 2', () => {
-      const input = 123;
+      const input = 12345678;
       const output = formatNumber(input, 2);
-      expect(output).toBe('123.00');
+      expect(output).toBe('12345678.00');
+    });
+
+    it('should return a string with thousand separator and a number formatted to 2 decimals when minDecimal is set to 2', () => {
+      const input = 12345678;
+      const decimalSeparator = '.';
+      const thousandSeparator = ',';
+      const output = formatNumber(input, 2, undefined, false, '', '', decimalSeparator, thousandSeparator);
+      expect(output).toBe('12,345,678.00');
     });
 
     it('should return a string with a number formatted and rounded to 4 decimals when maxDecimal is set to 4 and the number provided has extra decimals', () => {
-      const input = 456.4567899;
+      const input = 12345678.4567899;
       const output = formatNumber(input, 0, 4);
-      expect(output).toBe('456.4568');
+      expect(output).toBe('12345678.4568');
+    });
+
+    it('should return a string with thousand separator and a number formatted and rounded to 4 decimals when maxDecimal is set to 4 and the number provided has extra decimals', () => {
+      const input = 12345678.4567899;
+      const decimalSeparator = ',';
+      const thousandSeparator = ' ';
+      const output = formatNumber(input, 0, 4, false, '', '', decimalSeparator, thousandSeparator);
+      expect(output).toBe('12 345 678,4568');
     });
 
     it('should return a string without decimals when these arguments are null or undefined and the input provided is an integer', () => {
-      const input = 456;
+      const input = 12345678;
       const output1 = formatNumber(input);
       const output2 = formatNumber(input, null, null);
       const output3 = formatNumber(input, undefined, undefined);
 
-      expect(output1).toBe('456');
-      expect(output2).toBe('456');
-      expect(output3).toBe('456');
+      expect(output1).toBe('12345678');
+      expect(output2).toBe('12345678');
+      expect(output3).toBe('12345678');
+    });
+
+    it('should return a string without decimals and thousand separator when these arguments are null or undefined and the input provided is an integer', () => {
+      const input = 12345678;
+      const decimalSeparator = '.';
+      const thousandSeparator = ',';
+      const output1 = formatNumber(input, null, null, false, '', '', decimalSeparator, thousandSeparator);
+      const output2 = formatNumber(input, undefined, undefined, false, '', '', decimalSeparator, thousandSeparator);
+
+      expect(output1).toBe('12,345,678');
+      expect(output2).toBe('12,345,678');
     });
 
     it('should return a formatted string wrapped in parentheses when the input number is negative and the displayNegativeNumberWithParentheses argument is enabled', () => {
@@ -302,6 +356,22 @@ describe('Service/Utilies', () => {
       const displayNegativeNumberWithParentheses = true;
       const output = formatNumber(input, 2, 2, displayNegativeNumberWithParentheses);
       expect(output).toBe('(123.00)');
+    });
+
+    it('should return a formatted string wrapped in parentheses when the input number is negative and the displayNegativeNumberWithParentheses argument is enabled', () => {
+      const input = -123;
+      const displayNegativeNumberWithParentheses = true;
+      const output = formatNumber(input, 2, 2, displayNegativeNumberWithParentheses);
+      expect(output).toBe('(123.00)');
+    });
+
+    it('should return a formatted string and thousand separator wrapped in parentheses when the input number is negative and the displayNegativeNumberWithParentheses argument is enabled', () => {
+      const input = -12345678;
+      const displayNegativeNumberWithParentheses = true;
+      const decimalSeparator = ',';
+      const thousandSeparator = '_';
+      const output = formatNumber(input, 2, 2, displayNegativeNumberWithParentheses, '', '', decimalSeparator, thousandSeparator);
+      expect(output).toBe('(12_345_678,00)');
     });
 
     it('should return a formatted currency string when the input number is negative and symbol prefix is provided', () => {
@@ -312,22 +382,54 @@ describe('Service/Utilies', () => {
       expect(output).toBe('-$123.00');
     });
 
+    it('should return a formatted currency string and thousand separator when the input number is negative and symbol prefix is provided', () => {
+      const input = -12345678;
+      const displayNegativeNumberWithParentheses = false;
+      const currencyPrefix = '$';
+      const decimalSeparator = '.';
+      const thousandSeparator = ',';
+      const output = formatNumber(input, 2, 2, displayNegativeNumberWithParentheses, currencyPrefix, '', decimalSeparator, thousandSeparator);
+      expect(output).toBe('-$12,345,678.00');
+    });
+
     it('should return a formatted currency string with symbol prefix/suffix wrapped in parentheses when the input number is negative, when all necessary arguments are filled', () => {
-      const input = -123;
+      const input = -1234;
       const displayNegativeNumberWithParentheses = true;
       const currencyPrefix = '$';
       const currencySuffix = ' CAD';
       const output = formatNumber(input, 2, 2, displayNegativeNumberWithParentheses, currencyPrefix, currencySuffix);
-      expect(output).toBe('($123.00 CAD)');
+      expect(output).toBe('($1234.00 CAD)');
+    });
+
+    it('should return a formatted currency string with symbol prefix/suffix and thousand separator wrapped in parentheses when the input number is negative, when all necessary arguments are filled', () => {
+      const input = -12345678;
+      const displayNegativeNumberWithParentheses = true;
+      const currencyPrefix = '$';
+      const currencySuffix = ' CAD';
+      const decimalSeparator = ',';
+      const thousandSeparator = ' ';
+      const output = formatNumber(input, 2, 2, displayNegativeNumberWithParentheses, currencyPrefix, currencySuffix, decimalSeparator, thousandSeparator);
+      expect(output).toBe('($12 345 678,00 CAD)');
     });
 
     it('should return a formatted currency string with symbol prefix/suffix but without decimals when these arguments are not provided, then wrapped in parentheses when the input number is negative, when all necessary arguments are filled', () => {
-      const input = -123;
+      const input = -1234;
       const displayNegativeNumberWithParentheses = true;
       const currencyPrefix = '$';
       const currencySuffix = ' CAD';
       const output = formatNumber(input, null, null, displayNegativeNumberWithParentheses, currencyPrefix, currencySuffix);
-      expect(output).toBe('($123 CAD)');
+      expect(output).toBe('($1234 CAD)');
+    });
+
+    it('should return a formatted currency string with symbol prefix/suffix and thousand separator but without decimals when these arguments are not provided, then wrapped in parentheses when the input number is negative, when all necessary arguments are filled', () => {
+      const input = -12345678;
+      const displayNegativeNumberWithParentheses = true;
+      const currencyPrefix = '$';
+      const currencySuffix = ' CAD';
+      const decimalSeparator = ',';
+      const thousandSeparator = '_';
+      const output = formatNumber(input, null, null, displayNegativeNumberWithParentheses, currencyPrefix, currencySuffix, decimalSeparator, thousandSeparator);
+      expect(output).toBe('($12_345_678 CAD)');
     });
   });
 
@@ -868,6 +970,44 @@ describe('Service/Utilies', () => {
     it('should be able to update a property that is not a complex object', () => {
       setDeepValue(obj, 'id', 76);
       expect(obj['id']).toBe(76);
+    });
+  });
+
+  describe('thousandSeparatorFormatted method', () => {
+    it('should return original value when input provided is null', () => {
+      const input = null;
+      const output = thousandSeparatorFormatted(input, ',');
+      expect(output).toBe(input);
+    });
+
+    it('should return original value when input provided is undefined', () => {
+      const input = undefined;
+      const output = thousandSeparatorFormatted(input, ',');
+      expect(output).toBe(input);
+    });
+
+    it('should return original value when input provided is not a number', () => {
+      const input = 'abc';
+      const output = thousandSeparatorFormatted(input, ',');
+      expect(output).toBe(input);
+    });
+
+    it('should return a string with a number formatted with every thousand separated with a comma when separator is not defined', () => {
+      const input = 12345678;
+      const output = thousandSeparatorFormatted(input);
+      expect(output).toBe('12,345,678');
+    });
+
+    it('should return a string with a number formatted with every thousand separated with a custom space defined as separator', () => {
+      const input = 12345678;
+      const output = thousandSeparatorFormatted(input, ' ');
+      expect(output).toBe('12 345 678');
+    });
+
+    it('should return a string with a number formatted with every thousand separated with a custom underscore defined as separator', () => {
+      const input = 12345678;
+      const output = thousandSeparatorFormatted(input, '_');
+      expect(output).toBe('12_345_678');
     });
   });
 

--- a/src/aurelia-slickgrid/services/utilities.ts
+++ b/src/aurelia-slickgrid/services/utilities.ts
@@ -106,8 +106,10 @@ export function htmlEntityEncode(input: any): string {
  * @param input
  * @param minDecimal
  * @param maxDecimal
+ * @param decimalSeparator
+ * @param thousandSeparator
  */
-export function decimalFormatted(input: number | string, minDecimal?: number, maxDecimal?: number): string {
+export function decimalFormatted(input: number | string, minDecimal?: number, maxDecimal?: number, decimalSeparator: '.' | ',' = '.', thousandSeparator: ',' | '_' | '.' | ' ' | '' = ''): string {
   if (isNaN(+input)) {
     return input as string;
   }
@@ -122,10 +124,21 @@ export function decimalFormatted(input: number | string, minDecimal?: number, ma
   while ((amount.length - amount.indexOf('.')) <= minDec) {
     amount += '0';
   }
+
+  // do we want to display our number with a custom separator in each thousand position
+  if (thousandSeparator) {
+    amount = thousandSeparatorFormatted(amount, thousandSeparator);
+  }
+
+  // when using a separator that is not a dot, replace it with the new separator
+  if (decimalSeparator !== '.') {
+    amount = amount.replace('.', decimalSeparator);
+  }
+
   return amount;
 }
 
-export function formatNumber(input: number | string, minDecimal?: number, maxDecimal?: number, displayNegativeNumberWithParentheses?: boolean, symbolPrefix = '', symbolSuffix = ''): string {
+export function formatNumber(input: number | string, minDecimal?: number, maxDecimal?: number, displayNegativeNumberWithParentheses?: boolean, symbolPrefix = '', symbolSuffix = '', decimalSeparator: '.' | ',' = '.', thousandSeparator: ',' | '_' | '.' | ' ' | '' = ''): string {
   if (isNaN(+input)) {
     return input as string;
   }
@@ -135,21 +148,24 @@ export function formatNumber(input: number | string, minDecimal?: number, maxDec
   if (calculatedValue < 0) {
     const absValue = Math.abs(calculatedValue);
     if (displayNegativeNumberWithParentheses) {
-      if (!isNaN(minDecimal as number) || !isNaN(maxDecimal as number)) {
-        return `(${symbolPrefix}${decimalFormatted(absValue, minDecimal, maxDecimal)}${symbolSuffix})`;
+      if (!isNaN(minDecimal) || !isNaN(maxDecimal)) {
+        return `(${symbolPrefix}${decimalFormatted(absValue, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)}${symbolSuffix})`;
       }
-      return `(${symbolPrefix}${absValue}${symbolSuffix})`;
+      const formattedValue = thousandSeparatorFormatted(`${absValue}`, thousandSeparator);
+      return `(${symbolPrefix}${formattedValue}${symbolSuffix})`;
     } else {
-      if (!isNaN(minDecimal as number) || !isNaN(maxDecimal as number)) {
-        return `-${symbolPrefix}${decimalFormatted(absValue, minDecimal, maxDecimal)}${symbolSuffix}`;
+      if (!isNaN(minDecimal) || !isNaN(maxDecimal)) {
+        return `-${symbolPrefix}${decimalFormatted(absValue, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)}${symbolSuffix}`;
       }
-      return `-${symbolPrefix}${absValue}${symbolSuffix}`;
+      const formattedValue = thousandSeparatorFormatted(`${absValue}`, thousandSeparator);
+      return `-${symbolPrefix}${formattedValue}${symbolSuffix}`;
     }
   } else {
-    if (!isNaN(minDecimal as number) || !isNaN(maxDecimal as number)) {
-      return `${symbolPrefix}${decimalFormatted(input, minDecimal, maxDecimal)}${symbolSuffix}`;
+    if (!isNaN(minDecimal) || !isNaN(maxDecimal)) {
+      return `${symbolPrefix}${decimalFormatted(input, minDecimal, maxDecimal, decimalSeparator, thousandSeparator)}${symbolSuffix}`;
     }
-    return `${symbolPrefix}${input}${symbolSuffix}`;
+    const formattedValue = thousandSeparatorFormatted(`${input}`, thousandSeparator);
+    return `${symbolPrefix}${formattedValue}${symbolSuffix}`;
   }
 }
 
@@ -534,6 +550,21 @@ export function setDeepValue(obj: any, path: string | string[], value: any) {
   } else if (obj && path[0] && obj.hasOwnProperty(path[0])) {
     obj[path[0]] = value;
   }
+}
+
+/**
+ * Format a number or a string into a string that is separated every thousand,
+ * the default separator is a comma but user can optionally pass a different one
+ * @param inputValue
+ * @param separator default to comma ","
+ * @returns string
+ */
+export function thousandSeparatorFormatted(inputValue: string | number | null, separator: ',' | '_' | '.' | ' ' | '' = ','): string | null {
+  if (inputValue !== null && inputValue !== undefined) {
+    const stringValue = `${inputValue}`;
+    return stringValue.replace(/(?<!\.\d+)\B(?=(\d{3})+\b)/g, separator);
+  }
+  return inputValue as null;
 }
 
 /**

--- a/src/examples/slickgrid/example2.ts
+++ b/src/examples/slickgrid/example2.ts
@@ -84,10 +84,16 @@ export class Example2 {
       },
       enableCellNavigation: true,
 
-      // you customize the date separator through "formatterOptions"
+      // you customize all formatter at once certain options through "formatterOptions" in the Grid Options
+      // or independently through the column definition "params", the option names are the same
       /*
       formatterOptions: {
-        dateSeparator: '.'
+        dateSeparator: '.',
+        decimalSeparator: ',',
+        displayNegativeNumberWithParentheses: true,
+        minDecimal: 0,
+        maxDecimal: 2,
+        thousandSeparator: '_'
       },
       */
 


### PR DESCRIPTION
- add possibility to use a custom decimal and/or thousand separator(s) to all Formatters and Grouping Formatters that can use it

For example 
```ts
loadGrid() {
  this.columnDefinitions = [ 
    // through the column definition "params"
    { id: 'price', field: 'price', params: { thousandSeparator: ',' } },
  ];

  this.gridOptions = {
    // you customize the date separator through "formatterOptions"
    formatterOptions: {
      // Defaults to dot ".", separator to use as the decimal separator, example $123.55 or $123,55
      decimalSeparator: ',', // can be any of '.' | ','

      // Defaults to empty string, thousand separator on a number. Example: 12345678 becomes 12,345,678
      thousandSeparator: ',', // can be any of ',' | '_' | ' ' | ''
    },
  }
}
```