### PR TITLE
fix(pagination): never display page 0, minimum should be page 1

### DIFF
--- a/src/aurelia-slickgrid/filters/compoundInputFilter.ts
+++ b/src/aurelia-slickgrid/filters/compoundInputFilter.ts
@@ -139,7 +139,7 @@ export class CompoundInputFilter implements Filter {
     if (this.columnFilter && this.columnFilter.placeholder) {
       placeholder = this.columnFilter.placeholder;
     }
-    return `<input type="${this._inputType || 'text'}" class="form-control" role="presentation" autocomplete="off" placeholder="${placeholder}" /><span></span>`;
+    return `<input type="${this._inputType || 'text'}" class="form-control compound-input" role="presentation" autocomplete="off" placeholder="${placeholder}" /><span></span>`;
   }
 
   private buildSelectOperatorHtmlString() {
@@ -205,7 +205,7 @@ export class CompoundInputFilter implements Filter {
         <div class="input-group-addon input-group-prepend operator">
           <select class="form-control"></select>
         </div>
-        <input class="form-control" type="text" />
+        <input class="form-control compound-input" type="text" />
       </div>
     */
     $operatorInputGroupAddon.append(this.$selectOperatorElm);

--- a/src/aurelia-slickgrid/formatters/checkmarkFormatter.ts
+++ b/src/aurelia-slickgrid/formatters/checkmarkFormatter.ts
@@ -3,4 +3,4 @@ import { parseBoolean } from '../services/utilities';
 
 export const checkmarkFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any) => {
   return parseBoolean(value) ? `<i class="fa fa-check checkmark-icon" aria-hidden="true"></i>` : '';
-}
+};

--- a/src/aurelia-slickgrid/services/__tests__/pagination.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/pagination.service.spec.ts
@@ -71,7 +71,7 @@ describe('PaginationService', () => {
   const ea = new EventAggregator();
 
   beforeEach(() => {
-    service = new PaginationService(ea, filterServiceStub, gridServiceStub);
+    service = new PaginationService(ea);
   });
 
   afterEach(() => {
@@ -133,12 +133,12 @@ describe('PaginationService', () => {
   });
 
   describe('changeItemPerPage method', () => {
-    it('should be on page 0 when total items is 0', () => {
+    it('should be on page 1 when total items is 0', () => {
       mockGridOption.pagination.totalItems = 0;
       service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.changeItemPerPage(30);
 
-      expect(service.getCurrentPageNumber()).toBe(0);
+      expect(service.getCurrentPageNumber()).toBe(1);
       expect(service.getCurrentItemPerPageCount()).toBe(30);
     });
 
@@ -374,7 +374,7 @@ describe('PaginationService', () => {
   });
 
   describe('recalculateFromToIndexes method', () => {
-    it('should recalculate the From/To as 0 when total items is 0', () => {
+    it('should recalculate the From/To as 1 when total items is 0', () => {
       mockGridOption.pagination.pageSize = 25;
       mockGridOption.pagination.pageNumber = 2;
       mockGridOption.pagination.totalItems = 0;
@@ -382,8 +382,8 @@ describe('PaginationService', () => {
       service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
       service.recalculateFromToIndexes();
 
-      expect(service.pager.from).toBe(0);
-      expect(service.pager.to).toBe(0);
+      expect(service.pager.from).toBe(1);
+      expect(service.pager.to).toBe(1);
     });
 
     it('should recalculate the From/To within range', () => {

--- a/src/aurelia-slickgrid/services/pagination.service.ts
+++ b/src/aurelia-slickgrid/services/pagination.service.ts
@@ -35,7 +35,7 @@ export class PaginationService {
   private _dataFrom = 1;
   private _dataTo = 1;
   private _itemsPerPage: number;
-  private _pageCount = 0;
+  private _pageCount = 1;
   private _pageNumber = 1;
   private _totalItems = 0;
   private _availablePageSizes: number[];
@@ -52,10 +52,10 @@ export class PaginationService {
   get pager(): Pager {
     return {
       from: this._dataFrom,
-      to: this._dataTo,
+      to: this._dataTo || 1,
       itemsPerPage: this._itemsPerPage,
-      pageCount: this._pageCount,
-      pageNumber: this._pageNumber,
+      pageCount: this._pageCount || 1,
+      pageNumber: this._pageNumber || 1,
       availablePageSizes: this._availablePageSizes,
       totalItems: this._totalItems,
     };
@@ -108,8 +108,8 @@ export class PaginationService {
   }
 
   changeItemPerPage(itemsPerPage: number, event?: any): Promise<any> {
+    this._pageNumber = 1;
     this._pageCount = Math.ceil(this._totalItems / itemsPerPage);
-    this._pageNumber = (this._totalItems > 0) ? 1 : 0;
     this._itemsPerPage = itemsPerPage;
     return this.processOnPageChanged(this._pageNumber, event);
   }
@@ -239,9 +239,9 @@ export class PaginationService {
 
   recalculateFromToIndexes() {
     if (this._totalItems === 0) {
-      this._dataFrom = 0;
-      this._dataTo = 0;
-      this._pageNumber = 0;
+      this._dataFrom = 1;
+      this._dataTo = 1;
+      this._pageNumber = 1;
     } else {
       this._dataFrom = this._pageNumber > 1 ? ((this._pageNumber * this._itemsPerPage) - this._itemsPerPage + 1) : 1;
       this._dataTo = (this._totalItems < this._itemsPerPage) ? this._totalItems : (this._pageNumber * this._itemsPerPage);

--- a/src/aurelia-slickgrid/slick-pagination-without-i18n.spec.ts
+++ b/src/aurelia-slickgrid/slick-pagination-without-i18n.spec.ts
@@ -6,6 +6,10 @@ import { PLATFORM } from 'aurelia-pal';
 import { Column, GridOption, Pager, Locale } from './models';
 import { PaginationService } from './services';
 
+function removeExtraSpaces(textS: string) {
+  return `${textS}`.replace(/\s{2,}/g, '');
+}
+
 const dataviewStub = {
   onRowCountChanged: jest.fn(),
   onRowsChanged: jest.fn(),
@@ -163,8 +167,11 @@ describe('Slick-Pagination Component without I18N', () => {
       ea.publish(`paginationService:on-pagination-changed`, mockPager);
       ea.publish(`paginationService:on-pagination-refreshed`, true);
 
-      const elm = await component.waitForElement('.slick-pagination-count');
-      expect(elm.innerHTML).toContain('<span>5-10 of 100 items</span>');
+      const pageInfoFromTo = await component.waitForElement('.page-info-from-to');
+      const pageInfoTotalItems = await component.waitForElement('.page-info-total-items');
+      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span data-test="item-from">5</span>-<span data-test="item-to">10</span>of');
+      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span data-test="total-items">100</span> items');
+
       component.dispose();
     });
   });

--- a/src/aurelia-slickgrid/slick-pagination.html
+++ b/src/aurelia-slickgrid/slick-pagination.html
@@ -19,10 +19,11 @@
 
         <div class="slick-page-number">
           <span>${textPage}</span>
-          <input type="text" class="form-control" value.bind="pager.pageNumber | asgNumber" size="1"
-            readonly.bind="pager.totalItems === 0" change.delegate="changeToCurrentPage($event)">
+          <input type="text" class="form-control" data-test="page-number-input"
+            value.bind="pager.pageNumber | asgNumber" size="1" readonly.bind="pager.totalItems === 0"
+            change.delegate="changeToCurrentPage($event)">
           <span>${textOf}</span>
-          <span> ${pager.pageCount}</span>
+          <span data-test="page-count"> ${pager.pageCount}</span>
         </div>
 
         <nav aria-label="Page navigation">
@@ -50,7 +51,15 @@
         </select>
         <span>${textItemsPerPage}</span>,
         <span class="slick-pagination-count">
-          <span>${pager.from}-${pager.to} ${textOf} ${pager.totalItems} ${textItems}</span>
+          <span if.bind="pager.totalItems">
+            <span class="page-info-from-to">
+              <span data-test="item-from">${pager.from}</span>-<span data-test="item-to">${pager.to}</span>
+              ${textOf}
+            </span>
+          </span>
+          <span class="page-info-total-items">
+            <span data-test="total-items">${pager.totalItems}</span> ${textItems}
+          </span>
         </span>
       </span>
     </div>

--- a/src/aurelia-slickgrid/slick-pagination.spec.ts
+++ b/src/aurelia-slickgrid/slick-pagination.spec.ts
@@ -9,6 +9,10 @@ import { SlickPaginationCustomElement } from './slick-pagination';
 import { Column, GridOption, Pager } from './models';
 import { PaginationService } from './services';
 
+function removeExtraSpaces(textS: string) {
+  return `${textS}`.replace(/\s{2,}/g, '');
+}
+
 const dataviewStub = {
   onRowCountChanged: jest.fn(),
   onRowsChanged: jest.fn(),
@@ -169,16 +173,23 @@ describe('Slick-Pagination Component', () => {
     });
 
     it('should create a the Slick-Pagination component in the DOM', async () => {
-      const elm = await component.waitForElement('.slick-pagination-count');
-      expect(elm.innerHTML).toContain('<span>5-10 de 100 éléments</span>');
+      const pageInfoFromTo = await component.waitForElement('.page-info-from-to');
+      const pageInfoTotalItems = await component.waitForElement('.page-info-total-items');
+
+      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe('<span data-test="item-from">5</span>-<span data-test="item-to">10</span>de');
+      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span data-test="total-items">100</span> éléments');
     });
 
     it('should create a the Slick-Pagination component in the DOM', async () => {
       i18n.setLocale('en');
       ea.publish('i18n:locale:changed', 'en');
       expect(i18n.getLocale()).toBe('en');
-      const elm = await component.waitForElement('.slick-pagination-count');
-      expect(elm.innerHTML).toContain('<span>5-10 of 100 items</span>');
+
+      const pageInfoFromTo = await component.waitForElement('.page-info-from-to');
+      const pageInfoTotalItems = await component.waitForElement('.page-info-total-items');
+
+      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe(`<span data-test="item-from">5</span>-<span data-test="item-to">10</span>of`;
+      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span data-test="total-items">100</span> items');
     });
 
     it('should call changeToFirstPage() from the View and expect the pagination service to be called with correct method', async () => {

--- a/src/aurelia-slickgrid/slick-pagination.spec.ts
+++ b/src/aurelia-slickgrid/slick-pagination.spec.ts
@@ -180,7 +180,7 @@ describe('Slick-Pagination Component', () => {
       expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span data-test="total-items">100</span> éléments');
     });
 
-    it('should create a the Slick-Pagination component in the DOM', async () => {
+    it('should create a the Slick-Pagination component in the DOM and expect different locale when changed', async () => {
       i18n.setLocale('en');
       ea.publish('i18n:locale:changed', 'en');
       expect(i18n.getLocale()).toBe('en');
@@ -188,8 +188,8 @@ describe('Slick-Pagination Component', () => {
       const pageInfoFromTo = await component.waitForElement('.page-info-from-to');
       const pageInfoTotalItems = await component.waitForElement('.page-info-total-items');
 
-      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe(`<span data-test="item-from">5</span>-<span data-test="item-to">10</span>of`;
-      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe('<span data-test="total-items">100</span> items');
+      expect(removeExtraSpaces(pageInfoFromTo.innerHTML)).toBe(`<span data-test="item-from">5</span>-<span data-test="item-to">10</span>of`);
+      expect(removeExtraSpaces(pageInfoTotalItems.innerHTML)).toBe(`<span data-test="total-items">100</span> items`);
     });
 
     it('should call changeToFirstPage() from the View and expect the pagination service to be called with correct method', async () => {

--- a/src/aurelia-slickgrid/styles/_variables.scss
+++ b/src/aurelia-slickgrid/styles/_variables.scss
@@ -351,7 +351,7 @@ $pagination-page-input-padding:           2px !default;
 $pagination-page-select-border-radius:    3px !default;
 $pagination-page-select-padding:          0 0 2px 2px !default;
 $pagination-page-select-height:           32px !default;
-$pagination-page-select-width:            54px !default;
+$pagination-page-select-width:            58px !default;
 $pagination-page-select-font-size:        ($font-size-base - 2px) !default;
 $pagination-text-color:                   #808080 !default;
 

--- a/src/aurelia-slickgrid/styles/slick-plugins.scss
+++ b/src/aurelia-slickgrid/styles/slick-plugins.scss
@@ -376,6 +376,9 @@ input.search-filter {
 .search-filter {
     input {
         font-family: $filter-placeholder-font-family;
+        &.compound-input {
+          border-radius: $compound-filter-border-radius !important;
+        }
     }
 }
 

--- a/test/cypress/integration/example15.spec.js
+++ b/test/cypress/integration/example15.spec.js
@@ -172,7 +172,7 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
     cy.reload();
   });
 
-  xit('should expect the same Grid State to persist after the page got reloaded', () => {
+  it('should expect the same Grid State to persist after the page got reloaded', () => {
     const expectedTitles = ['', 'Description', 'Duration', 'Title', '% Complete', 'Completed'];
 
     cy.get('#grid15')
@@ -186,7 +186,7 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
       .each(($child, index) => expect($child.find('.slick-column-name').text()).to.eq(expectedTitles[index]));
   });
 
-  xit('should have French titles in Column Picker after switching to Language', () => {
+  it('should have French titles in Column Picker after switching to Language', () => {
     const expectedTitles = ['', 'Description', 'Durée', 'Titre', '% Achevée', 'Début', 'Terminé'];
 
     cy.get('[data-test=language-button]')
@@ -221,7 +221,7 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
       .click();
   });
 
-  xit('should have French titles in Grid Menu after switching to Language', () => {
+  it('should have French titles in Grid Menu after switching to Language', () => {
     const expectedTitles = ['', 'Description', 'Durée', 'Titre', '% Achevée', 'Début', 'Terminé'];
 
     cy.get('#grid15')
@@ -248,7 +248,7 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
       .click();
   });
 
-  xit('should hover over the "Terminé" column and click on "Cacher la colonne" remove the column from grid', () => {
+  it('should hover over the "Terminé" column and click on "Cacher la colonne" remove the column from grid', () => {
     const expectedTitles = ['', 'Description', 'Durée', 'Titre', '% Achevée'];
 
     cy.get('.slick-header-columns')
@@ -274,7 +274,7 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
     cy.reload();
   });
 
-  xit('should expect the same Grid State to persist after the page got reloaded, however we always load in English', () => {
+  it('should expect the same Grid State to persist after the page got reloaded, however we always load in English', () => {
     const expectedTitles = ['', 'Description', 'Duration', 'Title', '% Complete'];
 
     cy.get('#grid15')

--- a/test/cypress/integration/example15.spec.js
+++ b/test/cypress/integration/example15.spec.js
@@ -172,7 +172,7 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
     cy.reload();
   });
 
-  it('should expect the same Grid State to persist after the page got reloaded', () => {
+  xit('should expect the same Grid State to persist after the page got reloaded', () => {
     const expectedTitles = ['', 'Description', 'Duration', 'Title', '% Complete', 'Completed'];
 
     cy.get('#grid15')
@@ -186,7 +186,7 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
       .each(($child, index) => expect($child.find('.slick-column-name').text()).to.eq(expectedTitles[index]));
   });
 
-  it('should have French titles in Column Picker after switching to Language', () => {
+  xit('should have French titles in Column Picker after switching to Language', () => {
     const expectedTitles = ['', 'Description', 'Durée', 'Titre', '% Achevée', 'Début', 'Terminé'];
 
     cy.get('[data-test=language-button]')
@@ -221,7 +221,7 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
       .click();
   });
 
-  it('should have French titles in Grid Menu after switching to Language', () => {
+  xit('should have French titles in Grid Menu after switching to Language', () => {
     const expectedTitles = ['', 'Description', 'Durée', 'Titre', '% Achevée', 'Début', 'Terminé'];
 
     cy.get('#grid15')
@@ -248,7 +248,7 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
       .click();
   });
 
-  it('should hover over the "Terminé" column and click on "Cacher la colonne" remove the column from grid', () => {
+  xit('should hover over the "Terminé" column and click on "Cacher la colonne" remove the column from grid', () => {
     const expectedTitles = ['', 'Description', 'Durée', 'Titre', '% Achevée'];
 
     cy.get('.slick-header-columns')
@@ -274,7 +274,7 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
     cy.reload();
   });
 
-  it('should expect the same Grid State to persist after the page got reloaded, however we always load in English', () => {
+  xit('should expect the same Grid State to persist after the page got reloaded, however we always load in English', () => {
     const expectedTitles = ['', 'Description', 'Duration', 'Title', '% Complete'];
 
     cy.get('#grid15')

--- a/test/cypress/integration/example5.spec.js
+++ b/test/cypress/integration/example5.spec.js
@@ -49,7 +49,8 @@ describe('Example 5 - OData Grid', () => {
     it('should change Pagination to first page with 10 items', () => {
       cy.get('#items-per-page-label').select('10');
 
-      // wait for the query to finish
+      // wait for the query to start and finish
+      cy.get('[data-test=status]').should('contain', 'processing...');
       cy.get('[data-test=status]').should('contain', 'done');
 
       cy.get('[data-test=page-number-input]')

--- a/test/cypress/integration/example5.spec.js
+++ b/test/cypress/integration/example5.spec.js
@@ -24,6 +24,22 @@ describe('Example 5 - OData Grid', () => {
       // wait for the query to finish
       cy.get('[data-test=status]').should('contain', 'done');
 
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('3'));
+
+      cy.get('[data-test=page-count]')
+        .contains('3');
+
+      cy.get('[data-test=item-from]')
+        .contains('41');
+
+      cy.get('[data-test=item-to]')
+        .contains('50');
+
+      cy.get('[data-test=total-items]')
+        .contains('50');
+
       cy.get('[data-test=odata-query-result]')
         .should(($span) => {
           expect($span.text()).to.eq(`$inlinecount=allpages&$top=20&$skip=40&$orderby=Name asc&$filter=(Gender eq 'male')`);
@@ -36,6 +52,22 @@ describe('Example 5 - OData Grid', () => {
       // wait for the query to finish
       cy.get('[data-test=status]').should('contain', 'done');
 
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+
+      cy.get('[data-test=page-count]')
+        .contains('5');
+
+      cy.get('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('[data-test=item-to]')
+        .contains('10');
+
+      cy.get('[data-test=total-items]')
+        .contains('50');
+
       cy.get('[data-test=odata-query-result]')
         .should(($span) => {
           expect($span.text()).to.eq(`$inlinecount=allpages&$top=10&$orderby=Name asc&$filter=(Gender eq 'male')`);
@@ -47,6 +79,22 @@ describe('Example 5 - OData Grid', () => {
 
       // wait for the query to finish
       cy.get('[data-test=status]').should('contain', 'done');
+
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('5'));
+
+      cy.get('[data-test=page-count]')
+        .contains('5');
+
+      cy.get('[data-test=item-from]')
+        .contains('41');
+
+      cy.get('[data-test=item-to]')
+        .contains('50');
+
+      cy.get('[data-test=total-items]')
+        .contains('50');
 
       cy.get('[data-test=odata-query-result]')
         .should(($span) => {
@@ -61,6 +109,22 @@ describe('Example 5 - OData Grid', () => {
       // wait for the query to finish
       cy.get('[data-test=status]').should('contain', 'done');
 
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+
+      cy.get('[data-test=page-count]')
+        .contains('5');
+
+      cy.get('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('[data-test=item-to]')
+        .contains('10');
+
+      cy.get('[data-test=total-items]')
+        .contains('50');
+
       cy.get('[data-test=odata-query-result]')
         .should(($span) => {
           expect($span.text()).to.eq(`$inlinecount=allpages&$top=10&$orderby=Name asc&$filter=(Gender eq 'male')`);
@@ -73,6 +137,22 @@ describe('Example 5 - OData Grid', () => {
 
       // wait for the query to finish
       cy.get('[data-test=status]').should('contain', 'done');
+
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('5'));
+
+      cy.get('[data-test=page-count]')
+        .contains('5');
+
+      cy.get('[data-test=item-from]')
+        .contains('41');
+
+      cy.get('[data-test=item-to]')
+        .contains('50');
+
+      cy.get('[data-test=total-items]')
+        .contains('50');
 
       cy.get('[data-test=odata-query-result]')
         .should(($span) => {
@@ -95,6 +175,22 @@ describe('Example 5 - OData Grid', () => {
 
       // wait for the query to finish
       cy.get('[data-test=status]').should('contain', 'done');
+
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+
+      cy.get('[data-test=page-count]')
+        .contains('10');
+
+      cy.get('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('[data-test=item-to]')
+        .contains('10');
+
+      cy.get('[data-test=total-items]')
+        .contains('100');
 
       cy.get('[data-test=odata-query-result]')
         .should(($span) => {
@@ -306,6 +402,36 @@ describe('Example 5 - OData Grid', () => {
       cy.get('#grid5')
         .find('.slick-row')
         .should('have.length', 1);
+    });
+  });
+
+  describe('General Pagination Behaviors', () => {
+    it('should display page 1 of 1 but hide pagination from/to numbers when filtered data returns an empty dataset', () => {
+      cy.get('.search-filter.filter-name')
+        .find('input')
+        .clear()
+        .type('xyz');
+
+      cy.get('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+
+      cy.get('[data-test=page-count]')
+        .contains('1');
+
+      cy.get('[data-test=item-from]')
+        .should('not.exist');
+
+      cy.get('[data-test=item-to]')
+        .should('not.exist');
+
+      cy.get('[data-test=total-items]')
+        .contains('0');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$filter=(contains(Name, 'xyz'))`);
+        });
     });
   });
 });

--- a/test/cypress/integration/example5.spec.js
+++ b/test/cypress/integration/example5.spec.js
@@ -302,7 +302,8 @@ describe('Example 5 - OData Grid', () => {
     it('should change Pagination to first page with 10 items', () => {
       cy.get('#items-per-page-label').select('10');
 
-      // wait for the query to finish
+      // wait for the query to start and finish
+      cy.get('[data-test=status]').should('contain', 'processing...');
       cy.get('[data-test=status]').should('contain', 'done');
 
       cy.get('[data-test=odata-query-result]')

--- a/test/cypress/package.json
+++ b/test/cypress/package.json
@@ -11,7 +11,7 @@
   "author": "Ghislain B.",
   "license": "MIT",
   "devDependencies": {
-    "cypress": "^3.5.0",
+    "cypress": "^3.6.0",
     "mocha": "^5.2.0",
     "mochawesome": "^3.1.2",
     "mochawesome-merge": "^1.0.7",


### PR DESCRIPTION
- if we filter the data and an empty dataset is returned, we should display "Page 1 of 1", not "Page 0 of 0". Also instead of "0-0 of 0 items", we should hide the "0-0" and only display "0 items". This matches roughly what UI-Grid does (in their case, they actually even hide the total count).
- this fixes some small issues that I have seen, sometime the page 0 of 0 was sticking even though we removed the filter, so it's better to use Page 1 of 1 as a minimum
- update Cypress E2E test

**BEFORE**
![image](https://user-images.githubusercontent.com/643976/68436165-3b962900-018b-11ea-9921-7ff7eb190bfd.png)

**AFTER**
![image](https://user-images.githubusercontent.com/643976/68436140-24efd200-018b-11ea-86eb-26d98c2f9b82.png)
