### PR TITLE
feat(filters): provide method to apply grid filters dynamically

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid-constructor.spec.ts
+++ b/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid-constructor.spec.ts
@@ -791,7 +791,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
         }, 5);
       });
 
-      xit('should throw an error when the process method on initialization when "executeProcessCommandOnInit" is set as a backend service options', (done) => {
+      it('should throw an error when the process method on initialization when "executeProcessCommandOnInit" is set as a backend service options', (done) => {
         const mockError = { error: '404' };
         const query = `query { users (first:20,offset:0) { totalCount, nodes { id,name,gender,company } } }`;
         const promise = new Promise((resolve, reject) => setTimeout(() => reject(mockError), 1));
@@ -804,10 +804,10 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
 
         expect(processSpy).toHaveBeenCalled();
 
-        setTimeout(() => {
-          expect(mockBackendError).toHaveBeenCalledWith(mockError, customElement.gridOptions.backendServiceApi);
+        promise.catch((e) => {
+          expect(e).toBe(mockError);
           done();
-        }, 10);
+        });
       });
     });
 

--- a/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
@@ -1,5 +1,7 @@
 import { inject, Optional, singleton } from 'aurelia-framework';
 import { I18N } from 'aurelia-i18n';
+import * as $ from 'jquery';
+
 import { Constants } from '../constants';
 import {
   CellArgs,
@@ -14,13 +16,13 @@ import {
   Locale,
   SlickEventHandler,
 } from '../models/index';
+import { ExtensionUtility } from './extensionUtility';
+import { refreshBackendDataset } from '../services/backend-utilities';
 import { ExcelExportService } from '../services/excelExport.service';
 import { ExportService } from '../services/export.service';
-import { ExtensionUtility } from './extensionUtility';
 import { FilterService } from '../services/filter.service';
-import { SortService } from '../services/sort.service';
 import { SharedService } from '../services/shared.service';
-import * as $ from 'jquery';
+import { SortService } from '../services/sort.service';
 
 // using external non-typed js libraries
 declare var Slick: any;
@@ -157,58 +159,13 @@ export class GridMenuExtension implements Extension {
 
   /** Refresh the dataset through the Backend Service */
   refreshBackendDataset(gridOptions?: GridOption) {
-    let query = '';
-
     // user can pass new set of grid options which will override current ones
     if (gridOptions) {
       this.sharedService.gridOptions = { ...this.sharedService.gridOptions, ...gridOptions };
     }
 
     const backendApi = this.sharedService.gridOptions.backendServiceApi;
-    if (!backendApi || !backendApi.service || !backendApi.process) {
-      throw new Error(`BackendServiceApi requires at least a "process" function and a "service" defined`);
-    }
-
-    if (backendApi.service) {
-      query = backendApi.service.buildQuery();
-    }
-
-    if (query && query !== '') {
-      // keep start time & end timestamps & return it after process execution
-      const startTime = new Date();
-
-      if (backendApi.preProcess) {
-        backendApi.preProcess();
-      }
-
-      // the process could be an Observable (like HttpClient) or a Promise
-      // in any case, we need to have a Promise so that we can await on it (if an Observable, convert it to Promise)
-      const processPromise = backendApi.process(query);
-
-      processPromise.then((processResult: GraphqlResult | any) => {
-        const endTime = new Date();
-
-        // from the result, call our internal post process to update the Dataset and Pagination info
-        if (processResult && backendApi && backendApi.internalPostProcess) {
-          backendApi.internalPostProcess(processResult);
-        }
-
-        // send the response process to the postProcess callback
-        if (backendApi && backendApi.postProcess) {
-          if (processResult instanceof Object) {
-            processResult.metrics = {
-              startTime,
-              endTime,
-              executionTime: endTime.valueOf() - startTime.valueOf(),
-              totalItemCount: this.sharedService.gridOptions && this.sharedService.gridOptions.pagination && this.sharedService.gridOptions.pagination.totalItems
-            };
-            // @deprecated, use metrics instead
-            processResult.statistics = processResult.metrics;
-          }
-          backendApi.postProcess(processResult);
-        }
-      });
-    }
+    refreshBackendDataset(backendApi, this.sharedService.gridOptions);
   }
 
   /** Translate the Grid Menu titles and column picker */

--- a/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
@@ -9,7 +9,6 @@ import {
   ExtensionName,
   Extension,
   FileType,
-  GraphqlResult,
   GridMenu,
   GridMenuItem,
   GridOption,
@@ -163,9 +162,7 @@ export class GridMenuExtension implements Extension {
     if (gridOptions) {
       this.sharedService.gridOptions = { ...this.sharedService.gridOptions, ...gridOptions };
     }
-
-    const backendApi = this.sharedService.gridOptions.backendServiceApi;
-    refreshBackendDataset(backendApi, this.sharedService.gridOptions);
+    refreshBackendDataset(this.sharedService.gridOptions);
   }
 
   /** Translate the Grid Menu titles and column picker */

--- a/src/aurelia-slickgrid/filters/__tests__/compoundDateFilter.spec.ts
+++ b/src/aurelia-slickgrid/filters/__tests__/compoundDateFilter.spec.ts
@@ -2,7 +2,7 @@ import { DOM } from 'aurelia-pal';
 import { EventAggregator } from 'aurelia-event-aggregator';
 import { I18N } from 'aurelia-i18n';
 import { BindingSignaler } from 'aurelia-templating-resources';
-import { Column, FilterArguments, GridOption, FieldType } from '../../models';
+import { Column, FieldType, FilterArguments, GridOption, OperatorType } from '../../models';
 import { Filters } from '..';
 import { CompoundDateFilter } from '../compoundDateFilter';
 
@@ -151,6 +151,17 @@ describe('CompoundDateFilter', () => {
     filter.init(filterArguments);
     filter.setValues([mockDate]);
     expect(filter.currentDate).toEqual(mockDate);
+  });
+
+  it('should be able to call "setValues" with a value and an extra operator and expect it to be set as new operator', () => {
+    const mockDate = '2001-01-02T16:02:02.239Z';
+    filter.init(filterArguments);
+    filter.setValues([mockDate], OperatorType.greaterThanOrEqual);
+
+    const filterOperatorElm = divContainer.querySelector<HTMLInputElement>('.input-group-prepend.operator select');
+
+    expect(filter.currentDate).toEqual(mockDate);
+    expect(filterOperatorElm.value).toBe('>=');
   });
 
   it('should trigger input change event and expect the callback to be called with the date provided in the input', () => {

--- a/src/aurelia-slickgrid/filters/__tests__/compoundInputFilter.spec.ts
+++ b/src/aurelia-slickgrid/filters/__tests__/compoundInputFilter.spec.ts
@@ -2,7 +2,7 @@ import { I18N } from 'aurelia-i18n';
 import { DOM } from 'aurelia-pal';
 import { EventAggregator } from 'aurelia-event-aggregator';
 import { BindingSignaler } from 'aurelia-templating-resources';
-import { Column, FilterArguments, FieldType, GridOption } from '../../models';
+import { Column, FieldType, FilterArguments, GridOption, OperatorType } from '../../models';
 import { Filters } from '..';
 import { CompoundInputFilter } from '../compoundInputFilter';
 
@@ -130,6 +130,20 @@ describe('CompoundInputFilter', () => {
     filterInputElm.dispatchEvent(new (window.window as any).KeyboardEvent('keyup', { keyCode: 97, bubbles: true, cancelable: true }));
 
     expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '>', searchTerms: ['9'], shouldTriggerQuery: true });
+  });
+
+  it('should be able to call "setValues" with a value and an extra operator and expect it to be set as new operator', () => {
+    mockColumn.type = FieldType.number;
+    const spyCallback = jest.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    filter.setValues(['9'], OperatorType.greaterThanOrEqual);
+
+    const filterSelectElm = divContainer.querySelector<HTMLInputElement>('.search-filter.filter-duration select');
+    filterSelectElm.dispatchEvent(DOM.createCustomEvent('change'));
+
+    expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '>=', searchTerms: ['9'], shouldTriggerQuery: true });
+    expect(filterSelectElm.value).toBe('>=');
   });
 
   it('should trigger an operator change event and expect the callback to be called with the searchTerms and operator defined', () => {

--- a/src/aurelia-slickgrid/filters/__tests__/compoundSliderFilter.spec.ts
+++ b/src/aurelia-slickgrid/filters/__tests__/compoundSliderFilter.spec.ts
@@ -1,5 +1,5 @@
 import { DOM } from 'aurelia-pal';
-import { GridOption, FilterArguments, Column } from '../../models';
+import { Column, FilterArguments, GridOption, OperatorType } from '../../models';
 import { Filters } from '..';
 import { CompoundSliderFilter } from '../compoundSliderFilter';
 
@@ -96,6 +96,18 @@ describe('CompoundSliderFilter', () => {
     filterSelectElm.dispatchEvent(DOM.createCustomEvent('change'));
 
     expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '<=', searchTerms: ['9'], shouldTriggerQuery: true });
+  });
+
+  it('should be able to call "setValues" with a value and an extra operator and expect it to be set as new operator', () => {
+    const spyCallback = jest.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    filter.setValues(['9'], OperatorType.greaterThanOrEqual);
+
+    const filterSelectElm = divContainer.querySelector<HTMLInputElement>('.search-filter.filter-duration select');
+    filterSelectElm.dispatchEvent(DOM.createCustomEvent('change'));
+
+    expect(spyCallback).toHaveBeenCalledWith(expect.anything(), { columnDef: mockColumn, operator: '>=', searchTerms: ['9'], shouldTriggerQuery: true });
   });
 
   it('should create the input filter with default search terms range when passed as a filter argument', () => {

--- a/src/aurelia-slickgrid/filters/autoCompleteFilter.ts
+++ b/src/aurelia-slickgrid/filters/autoCompleteFilter.ts
@@ -73,6 +73,11 @@ export class AutoCompleteFilter implements Filter {
     return this.columnDef && this.columnDef.filter && this.columnDef.filter.customStructure;
   }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return OperatorType.equal;
+  }
+
   /** Getter for the Grid Options pulled through the Grid Object */
   get gridOptions(): GridOption {
     return (this.grid && this.grid.getOptions) ? this.grid.getOptions() : {};
@@ -80,7 +85,14 @@ export class AutoCompleteFilter implements Filter {
 
   /** Getter of the Operator to use when doing the filter comparing */
   get operator(): OperatorType | OperatorString {
-    return this.columnDef && this.columnDef.filter && this.columnDef.filter.operator || OperatorType.equal;
+    return this.columnFilter && this.columnFilter.operator || this.defaultOperator;
+  }
+
+  /** Setter for the filter operator */
+  set operator(operator: OperatorType | OperatorString) {
+    if (this.columnFilter) {
+      this.columnFilter.operator = operator;
+    }
   }
 
   /**
@@ -144,13 +156,14 @@ export class AutoCompleteFilter implements Filter {
     }
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
-  setValues(values: SearchTerm | SearchTerm[]) {
+  /** Set value(s) on the DOM element  */
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (values) {
       this.$filterElm.val(values);
     }
+
+    // set the operator when defined
+    this.operator = operator || this.defaultOperator;
   }
 
   //

--- a/src/aurelia-slickgrid/filters/compoundDateFilter.ts
+++ b/src/aurelia-slickgrid/filters/compoundDateFilter.ts
@@ -3,7 +3,7 @@ import { I18N } from 'aurelia-i18n';
 import * as flatpickr from 'flatpickr';
 import * as $ from 'jquery';
 
-import { mapFlatpickrDateFormatWithFieldType, mapOperatorToShortDesignation } from '../services/utilities';
+import { mapFlatpickrDateFormatWithFieldType, mapOperatorToShorthandDesignation } from '../services/utilities';
 import {
   Column,
   ColumnFilter,
@@ -151,9 +151,10 @@ export class CompoundDateFilter implements Filter {
     }
 
     // set the operator, in the DOM as well, when defined
-    this.operator = mapOperatorToShortDesignation(operator || this.defaultOperator);
+    this.operator = operator || this.defaultOperator;
     if (operator && this.$selectOperatorElm) {
-      this.$selectOperatorElm.val(this.operator);
+      const operatorShorthand = mapOperatorToShorthandDesignation(this.operator);
+      this.$selectOperatorElm.val(operatorShorthand);
     }
   }
 

--- a/src/aurelia-slickgrid/filters/compoundInputFilter.ts
+++ b/src/aurelia-slickgrid/filters/compoundInputFilter.ts
@@ -16,7 +16,7 @@ import {
   OperatorType,
   SearchTerm,
 } from './../models/index';
-import { mapOperatorToShortDesignation } from '../services/utilities';
+import { mapOperatorToShorthandDesignation } from '../services/utilities';
 
 @inject(Optional.of(I18N))
 export class CompoundInputFilter implements Filter {
@@ -135,9 +135,11 @@ export class CompoundInputFilter implements Filter {
       this.$filterInputElm.val(newValue);
     }
 
-    this.operator = mapOperatorToShortDesignation(operator || this.defaultOperator);
+    // set the operator, in the DOM as well, when defined
+    this.operator = operator || this.defaultOperator;
     if (operator && this.$selectOperatorElm) {
-      this.$selectOperatorElm.val(this.operator);
+      const operatorShorthand = mapOperatorToShorthandDesignation(this.operator);
+      this.$selectOperatorElm.val(operatorShorthand);
     }
   }
 

--- a/src/aurelia-slickgrid/filters/compoundInputFilter.ts
+++ b/src/aurelia-slickgrid/filters/compoundInputFilter.ts
@@ -1,5 +1,7 @@
 import { inject, Optional } from 'aurelia-framework';
 import { I18N } from 'aurelia-i18n';
+import * as $ from 'jquery';
+
 import { Constants } from '../constants';
 import {
   Column,
@@ -14,7 +16,7 @@ import {
   OperatorType,
   SearchTerm,
 } from './../models/index';
-import * as $ from 'jquery';
+import { mapOperatorToShortDesignation } from '../services/utilities';
 
 @inject(Optional.of(I18N))
 export class CompoundInputFilter implements Filter {
@@ -43,6 +45,11 @@ export class CompoundInputFilter implements Filter {
     return this.columnDef && this.columnDef.filter || {};
   }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return OperatorType.empty;
+  }
+
   /** Getter of input type (text, number, password) */
   get inputType() {
     return this._inputType;
@@ -55,10 +62,10 @@ export class CompoundInputFilter implements Filter {
 
   /** Getter of the Operator to use when doing the filter comparing */
   get operator(): OperatorType | OperatorString {
-    return this._operator || OperatorType.empty;
+    return this._operator || this.defaultOperator;
   }
 
-  /** Getter of the Operator to use when doing the filter comparing */
+  /** Setter of the Operator to use when doing the filter comparing */
   set operator(op: OperatorType | OperatorString) {
     this._operator = op;
   }
@@ -121,12 +128,16 @@ export class CompoundInputFilter implements Filter {
     }
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
-  setValues(values: SearchTerm[]) {
-    if (values && Array.isArray(values)) {
-      this.$filterInputElm.val(values[0]);
+  /** Set value(s) on the DOM element  */
+  setValues(values: SearchTerm[], operator?: OperatorType | OperatorString) {
+    if (values) {
+      const newValue = Array.isArray(values) ? values[0] : values;
+      this.$filterInputElm.val(newValue);
+    }
+
+    this.operator = mapOperatorToShortDesignation(operator || this.defaultOperator);
+    if (operator && this.$selectOperatorElm) {
+      this.$selectOperatorElm.val(this.operator);
     }
   }
 

--- a/src/aurelia-slickgrid/filters/compoundSliderFilter.ts
+++ b/src/aurelia-slickgrid/filters/compoundSliderFilter.ts
@@ -10,7 +10,7 @@ import {
   OperatorType,
   SearchTerm
 } from './../models/index';
-import { mapOperatorToShortDesignation } from '../services/utilities';
+import { mapOperatorToShorthandDesignation } from '../services/utilities';
 
 const DEFAULT_MIN_VALUE = 0;
 const DEFAULT_MAX_VALUE = 100;
@@ -148,9 +148,10 @@ export class CompoundSliderFilter implements Filter {
     this.$containerInputGroupElm.children('div.input-group-addon.input-group-append').children().last().html(newValue);
 
     // set the operator, in the DOM as well, when defined
-    this.operator = mapOperatorToShortDesignation(operator || this.defaultOperator);
+    this.operator = operator || this.defaultOperator;
     if (operator && this.$selectOperatorElm) {
-      this.$selectOperatorElm.val(this.operator);
+      const operatorShorthand = mapOperatorToShorthandDesignation(this.operator);
+      this.$selectOperatorElm.val(operatorShorthand);
     }
   }
 

--- a/src/aurelia-slickgrid/filters/compoundSliderFilter.ts
+++ b/src/aurelia-slickgrid/filters/compoundSliderFilter.ts
@@ -1,3 +1,5 @@
+import * as $ from 'jquery';
+
 import {
   Column,
   ColumnFilter,
@@ -8,7 +10,7 @@ import {
   OperatorType,
   SearchTerm
 } from './../models/index';
-import * as $ from 'jquery';
+import { mapOperatorToShortDesignation } from '../services/utilities';
 
 const DEFAULT_MIN_VALUE = 0;
 const DEFAULT_MAX_VALUE = 100;
@@ -30,6 +32,11 @@ export class CompoundSliderFilter implements Filter {
   columnDef: Column;
   callback: FilterCallback;
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return OperatorType.empty;
+  }
+
   /** Getter for the Filter Generic Params */
   private get filterParams(): any {
     return this.columnDef && this.columnDef.filter && this.columnDef.filter.params || {};
@@ -40,12 +47,12 @@ export class CompoundSliderFilter implements Filter {
     return this.columnDef && this.columnDef.filter || {};
   }
 
-  set operator(op: OperatorType | OperatorString) {
-    this._operator = op;
+  get operator(): OperatorType | OperatorString {
+    return this._operator || this.defaultOperator;
   }
 
-  get operator(): OperatorType | OperatorString {
-    return this._operator || OperatorType.empty;
+  set operator(op: OperatorType | OperatorString) {
+    this._operator = op;
   }
 
   /**
@@ -133,18 +140,17 @@ export class CompoundSliderFilter implements Filter {
     return this._currentValue;
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
-  setValues(values: SearchTerm | SearchTerm[]) {
-    if (Array.isArray(values)) {
-      this._currentValue = +values[0];
-      this.$filterInputElm.val(values[0]);
-      this.$containerInputGroupElm.children('div.input-group-addon.input-group-append').children().last().html(values[0]);
-    } else if (values) {
-      this._currentValue = +values;
-      this.$filterInputElm.val(values);
-      this.$containerInputGroupElm.children('div.input-group-addon.input-group-append').children().last().html(values);
+  /** Set value(s) on the DOM element */
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
+    const newValue = Array.isArray(values) ? values[0] : values;
+    this._currentValue = +newValue;
+    this.$filterInputElm.val(newValue);
+    this.$containerInputGroupElm.children('div.input-group-addon.input-group-append').children().last().html(newValue);
+
+    // set the operator, in the DOM as well, when defined
+    this.operator = mapOperatorToShortDesignation(operator || this.defaultOperator);
+    if (operator && this.$selectOperatorElm) {
+      this.$selectOperatorElm.val(this.operator);
     }
   }
 

--- a/src/aurelia-slickgrid/filters/dateRangeFilter.ts
+++ b/src/aurelia-slickgrid/filters/dateRangeFilter.ts
@@ -54,6 +54,11 @@ export class DateRangeFilter implements Filter {
     return this._currentDates;
   }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return this.gridOptions.defaultFilterRangeOperator || OperatorType.rangeExclusive;
+  }
+
   /** Getter for the Flatpickr Options */
   get flatpickrOptions(): FlatpickrOption {
     return this._flatpickrOptions || {};
@@ -61,7 +66,14 @@ export class DateRangeFilter implements Filter {
 
   /** Getter of the Operator to use when doing the filter comparing */
   get operator(): OperatorType | OperatorString {
-    return this.columnFilter.operator || this.gridOptions.defaultFilterRangeOperator || OperatorType.rangeExclusive;
+    return this.columnFilter && this.columnFilter.operator || this.defaultOperator;
+  }
+
+  /** Setter for the filter operator */
+  set operator(operator: OperatorType | OperatorString) {
+    if (this.columnFilter) {
+      this.columnFilter.operator = operator;
+    }
   }
 
   /**
@@ -128,7 +140,7 @@ export class DateRangeFilter implements Filter {
    * Set value(s) on the DOM element
    * @params searchTerms
    */
-  setValues(searchTerms: SearchTerm[]) {
+  setValues(searchTerms: SearchTerm[], operator?: OperatorType | OperatorString) {
     let pickerValues: any[] = [];
 
     // get the picker values, if it's a string with the "..", we'll do the split else we'll use the array of search terms
@@ -142,6 +154,9 @@ export class DateRangeFilter implements Filter {
       this._currentDates = pickerValues;
       this.flatInstance.setDate(pickerValues);
     }
+
+    // set the operator when defined
+    this.operator = operator || this.defaultOperator;
   }
 
   //

--- a/src/aurelia-slickgrid/filters/dateRangeFilter.ts
+++ b/src/aurelia-slickgrid/filters/dateRangeFilter.ts
@@ -206,11 +206,8 @@ export class DateRangeFilter implements Filter {
 
         // when using the time picker, we can simulate a keyup event to avoid multiple backend request
         // since backend request are only executed after user start typing, changing the time should be treated the same way
-        if (pickerOptions.enableTime) {
-          this.onTriggerEvent(new CustomEvent('keyup'));
-        } else {
-          this.onTriggerEvent(undefined);
-        }
+        const newEvent = pickerOptions.enableTime ? new CustomEvent('keyup') : undefined;
+        this.onTriggerEvent(newEvent);
       }
     };
 

--- a/src/aurelia-slickgrid/filters/inputFilter.ts
+++ b/src/aurelia-slickgrid/filters/inputFilter.ts
@@ -26,6 +26,11 @@ export class InputFilter implements Filter {
     return this.columnDef && this.columnDef.filter || {};
   }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return OperatorType.equal;
+  }
+
   /** Getter of input type (text, number, password) */
   get inputType() {
     return this._inputType;
@@ -38,7 +43,14 @@ export class InputFilter implements Filter {
 
   /** Getter of the Operator to use when doing the filter comparing */
   get operator(): OperatorType | OperatorString {
-    return this.columnDef && this.columnDef.filter && this.columnDef.filter.operator || '';
+    return this.columnFilter && this.columnFilter.operator || this.defaultOperator;
+  }
+
+  /** Setter for the filter operator */
+  set operator(operator: OperatorType | OperatorString) {
+    if (this.columnFilter) {
+      this.columnFilter.operator = operator;
+    }
   }
 
   /** Getter for the Grid Options pulled through the Grid Object */
@@ -111,13 +123,14 @@ export class InputFilter implements Filter {
     }
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
-  setValues(values: SearchTerm) {
+  /** Set value(s) on the DOM element */
+  setValues(values: SearchTerm, operator?: OperatorType | OperatorString) {
     if (values) {
       this.$filterElm.val(values);
     }
+
+    // set the operator when defined
+    this.operator = operator || this.defaultOperator;
   }
 
   //

--- a/src/aurelia-slickgrid/filters/nativeSelectFilter.ts
+++ b/src/aurelia-slickgrid/filters/nativeSelectFilter.ts
@@ -31,6 +31,11 @@ export class NativeSelectFilter implements Filter {
     return this.columnDef && this.columnDef.filter || {};
   }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return OperatorType.equal;
+  }
+
   /** Getter for the Grid Options pulled through the Grid Object */
   protected get gridOptions(): GridOption {
     return (this.grid && this.grid.getOptions) ? this.grid.getOptions() : {};
@@ -38,7 +43,14 @@ export class NativeSelectFilter implements Filter {
 
   /** Getter for the current Operator */
   get operator(): OperatorType | OperatorString {
-    return (this.columnDef && this.columnDef.filter && this.columnDef.filter.operator) || OperatorType.equal;
+    return this.columnFilter && this.columnFilter.operator || this.defaultOperator;
+  }
+
+  /** Setter for the filter operator */
+  set operator(operator: OperatorType | OperatorString) {
+    if (this.columnFilter) {
+      this.columnFilter.operator = operator;
+    }
   }
 
   /**
@@ -123,10 +135,8 @@ export class NativeSelectFilter implements Filter {
     return this._currentValues;
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
-  setValues(values: SearchTerm | SearchTerm[]) {
+  /** Set value(s) on the DOM element */
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (Array.isArray(values)) {
       this.$filterElm.val(values[0]);
       this._currentValues = values;
@@ -134,6 +144,9 @@ export class NativeSelectFilter implements Filter {
       this.$filterElm.val(values);
       this._currentValues = [values];
     }
+
+    // set the operator when defined
+    this.operator = operator || this.defaultOperator;
   }
 
   //

--- a/src/aurelia-slickgrid/filters/sliderFilter.ts
+++ b/src/aurelia-slickgrid/filters/sliderFilter.ts
@@ -26,6 +26,16 @@ export class SliderFilter implements Filter {
   columnDef: Column;
   callback: FilterCallback;
 
+  /** Getter for the Column Filter */
+  get columnFilter(): ColumnFilter {
+    return this.columnDef && this.columnDef.filter || {};
+  }
+
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return OperatorType.equal;
+  }
+
   /** Getter for the Filter Generic Params */
   private get filterParams(): any {
     return this.columnDef && this.columnDef.filter && this.columnDef.filter.params || {};
@@ -36,8 +46,16 @@ export class SliderFilter implements Filter {
     return this.columnDef && this.columnDef.filter || {};
   }
 
+  /** Getter for the current Operator */
   get operator(): OperatorType | OperatorString {
-    return (this.columnDef && this.columnDef.filter && this.columnDef.filter.operator) || OperatorType.equal;
+    return this.columnFilter && this.columnFilter.operator || this.defaultOperator;
+  }
+
+  /** Setter for the filter operator */
+  set operator(operator: OperatorType | OperatorString) {
+    if (this.columnFilter) {
+      this.columnFilter.operator = operator;
+    }
   }
 
   /**
@@ -132,10 +150,8 @@ export class SliderFilter implements Filter {
     return this._currentValue;
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
-  setValues(values: SearchTerm | SearchTerm[]) {
+  /** Set value(s) on the DOM element */
+  setValues(values: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (Array.isArray(values)) {
       this.$filterElm.val(values[0]);
       this._currentValue = +values[0];
@@ -143,6 +159,9 @@ export class SliderFilter implements Filter {
       this.$filterElm.val(values);
       this._currentValue = +values;
     }
+
+    // set the operator when defined
+    this.operator = operator || this.defaultOperator;
   }
 
   //

--- a/src/aurelia-slickgrid/filters/sliderRangeFilter.ts
+++ b/src/aurelia-slickgrid/filters/sliderRangeFilter.ts
@@ -52,6 +52,11 @@ export class SliderRangeFilter implements Filter {
     return this._currentValues;
   }
 
+  /** Getter to know what would be the default operator when none is specified */
+  get defaultOperator(): OperatorType | OperatorString {
+    return this.gridOptions.defaultFilterRangeOperator || OperatorType.rangeExclusive;
+  }
+
   /** Getter for the Grid Options pulled through the Grid Object */
   get gridOptions(): GridOption {
     return (this.grid && this.grid.getOptions) ? this.grid.getOptions() : {};
@@ -62,8 +67,16 @@ export class SliderRangeFilter implements Filter {
     return this._sliderOptions || {};
   }
 
+  /** Getter of the Operator to use when doing the filter comparing */
   get operator(): OperatorType | OperatorString {
-    return (this.columnDef && this.columnDef.filter && this.columnDef.filter.operator) || this.gridOptions.defaultFilterRangeOperator || OperatorType.rangeExclusive;
+    return this.columnFilter && this.columnFilter.operator || this.defaultOperator;
+  }
+
+  /** Setter for the filter operator */
+  set operator(operator: OperatorType | OperatorString) {
+    if (this.columnFilter) {
+      this.columnFilter.operator = operator;
+    }
   }
 
   /**
@@ -115,7 +128,7 @@ export class SliderRangeFilter implements Filter {
    * Set value(s) on the DOM element
    * @params searchTerms
    */
-  setValues(searchTerms: SearchTerm | SearchTerm[]) {
+  setValues(searchTerms: SearchTerm | SearchTerm[], operator?: OperatorType | OperatorString) {
     if (searchTerms) {
       let sliderValues: number[] | string[] = [];
 
@@ -133,6 +146,9 @@ export class SliderRangeFilter implements Filter {
         }
       }
     }
+
+    // set the operator when defined
+    this.operator = operator || this.defaultOperator;
   }
 
   //

--- a/src/aurelia-slickgrid/models/backendService.interface.ts
+++ b/src/aurelia-slickgrid/models/backendService.interface.ts
@@ -43,7 +43,7 @@ export interface BackendService {
   resetPaginationOptions: () => void;
 
   /** Update the Filters options with a set of new options */
-  updateFilters?: (columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPreset: boolean) => void;
+  updateFilters?: (columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPresetOrDynamically: boolean) => void;
 
   /** Update the Pagination component with it's new page number and size */
   updatePagination?: (newPage: number, pageSize: number) => void;

--- a/src/aurelia-slickgrid/services/__tests__/backend-utilities.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/backend-utilities.spec.ts
@@ -1,19 +1,37 @@
-import { onBackendError, executeBackendProcessesCallback } from '../backend-utilities';
 import { GridOption } from '../../models';
+import main, { executeBackendProcessesCallback, onBackendError, refreshBackendDataset } from '../../services/backend-utilities';
+import { GraphqlService } from '../../services/graphql.service';
 
 jest.mock('flatpickr', () => { });
 
-const gridOptionMock = {
-  enablePagination: true,
-  backendServiceApi: {
-    service: undefined,
-    preProcess: jest.fn(),
-    process: jest.fn(),
-    postProcess: jest.fn(),
-  }
-} as GridOption;
+const graphqlServiceMock = {
+  buildQuery: jest.fn(),
+  updateFilters: jest.fn(),
+  updatePagination: jest.fn(),
+  updateSorters: jest.fn(),
+} as unknown as GraphqlService;
 
 describe('backend-utilities', () => {
+  let gridOptionMock: GridOption;
+
+  beforeEach(() => {
+    gridOptionMock = {
+      enablePagination: true,
+      backendServiceApi: {
+        service: graphqlServiceMock,
+        preProcess: jest.fn(),
+        process: jest.fn(),
+        postProcess: jest.fn(),
+      },
+      pagination: {
+        pageSize: 10,
+        pageSizes: [10, 25, 50],
+        pageNumber: 1,
+        totalItems: 0
+      }
+    } as GridOption;
+  });
+
   describe('executeBackendProcessesCallback method', () => {
     it('should execute the "internalPostProcess" when it is defined', () => {
       const now = new Date();
@@ -68,6 +86,34 @@ describe('backend-utilities', () => {
     it('should throw back the error when callback was provided', () => {
       gridOptionMock.backendServiceApi.onError = undefined;
       expect(() => onBackendError('some error', gridOptionMock.backendServiceApi)).toThrow();
+    });
+  });
+
+  describe('refreshBackendDataset method', () => {
+    let executeSpy;
+
+    beforeAll(() => {
+      executeSpy = jest.spyOn(main, 'executeBackendCallback');
+    });
+
+    it('should call "executeBackendCallback" after calling the "refreshBackendDataset" method', () => {
+      const query = `query { users (first:20,offset:0) { totalCount, nodes { id,name,gender,company } } }`;
+      const querySpy = jest.spyOn(gridOptionMock.backendServiceApi.service, 'buildQuery').mockReturnValue(query);
+
+      refreshBackendDataset(gridOptionMock);
+
+      expect(querySpy).toHaveBeenCalled();
+      expect(executeSpy).toHaveBeenCalledWith(gridOptionMock.backendServiceApi, query, null, expect.toBeDate(), gridOptionMock.pagination.totalItems);
+    });
+
+    it('should throw an error when backendServiceApi is undefined', (done) => {
+      try {
+        gridOptionMock.backendServiceApi = undefined;
+        refreshBackendDataset(undefined);
+      } catch (e) {
+        expect(e.toString()).toContain('BackendServiceApi requires at least a "process" function and a "service" defined');
+        done();
+      }
     });
   });
 });

--- a/src/aurelia-slickgrid/services/__tests__/extension.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/extension.service.spec.ts
@@ -173,6 +173,12 @@ describe('ExtensionService', () => {
     describe('bindDifferentExtensions method', () => {
       const instanceMock = { onColumnsChanged: jest.fn() };
 
+      it('should return undefined when calling "getExtensionByName" method without anything set yet', () => {
+        service.bindDifferentExtensions();
+        const output = service.getExtensionByName(ExtensionName.autoTooltip);
+        expect(output).toEqual(undefined);
+      });
+
       it('should call "translateItems" method is "enableTranslate" is set to true in the grid options, then column name property should be translated', () => {
         const gridOptionsMock = { enableTranslate: true } as GridOption;
         const columnBeforeTranslate = { id: 'field1', field: 'field1', name: 'Hello', headerKey: 'HELLO' };

--- a/src/aurelia-slickgrid/services/__tests__/filter.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/filter.service.spec.ts
@@ -45,10 +45,12 @@ const dataViewStub = {
 };
 
 const backendServiceStub = {
+  buildQuery: jest.fn(),
   clearFilters: jest.fn(),
   getCurrentFilters: jest.fn(),
   getCurrentPagination: jest.fn(),
-  processOnFilterChanged: (event: Event, args: FilterChangedArgs) => 'backend query',
+  updateFilters: jest.fn(),
+  processOnFilterChanged: () => 'backend query',
 } as unknown as BackendService;
 
 const gridStub = {
@@ -886,6 +888,82 @@ describe('FilterService', () => {
         { id: 'name', field: 'name' },
         { id: 'gender', field: 'gender', filter: { operator: '', searchTerms: ['male'] } },
       ]);
+    });
+  });
+
+  describe('updateFilters method', () => {
+    let mockColumn1: Column;
+    let mockColumn2: Column;
+    let mockArgs1;
+    let mockArgs2;
+    let mockNewFilters: CurrentFilter[];
+
+    beforeEach(() => {
+      gridOptionMock.enableFiltering = true;
+      gridOptionMock.backendServiceApi = undefined;
+      mockColumn1 = { id: 'firstName', name: 'firstName', field: 'firstName', filterable: true, filter: { model: Filters.compoundInputText } };
+      mockColumn2 = { id: 'isActive', name: 'isActive', field: 'isActive', filterable: true, filter: { model: Filters.singleSelect, collection: [{ value: true, label: 'True' }, { value: false, label: 'False' }], } };
+      mockArgs1 = { grid: gridStub, column: mockColumn1, node: document.getElementById(DOM_ELEMENT_ID) };
+      mockArgs2 = { grid: gridStub, column: mockColumn2, node: document.getElementById(DOM_ELEMENT_ID) };
+      mockNewFilters = [
+        { columnId: 'firstName', searchTerms: ['Jane'], operator: 'StartsWith' },
+        { columnId: 'isActive', searchTerms: [false] }
+      ];
+    });
+
+    it('should throw an error when there are no filters defined in the column definitions', (done) => {
+      try {
+        gridOptionMock.enableFiltering = false;
+        service.init(gridStub);
+        service.bindLocalOnFilter(gridStub, dataViewStub);
+        service.updateFilters([{ columnId: 'firstName', searchTerms: ['John'] }]);
+      } catch (e) {
+        expect(e.toString()).toContain('[Aurelia-Slickgrid] in order to use "updateFilters" method, you need to have Filters defined in your grid');
+        done();
+      }
+    });
+
+    it('should call "clearFilters" without triggering a clear event but trigger an "emitFilterChanged" local when using "bindLocalOnFilter" and also expect filters to be set in ColumnFilters', () => {
+      const clearSpy = jest.spyOn(service, 'clearFilters');
+      const emitSpy = jest.spyOn(service, 'emitFilterChanged');
+
+      service.init(gridStub);
+      service.bindLocalOnFilter(gridStub, dataViewStub);
+      gridStub.onHeaderRowCellRendered.notify(mockArgs1, new Slick.EventData(), gridStub);
+      gridStub.onHeaderRowCellRendered.notify(mockArgs2, new Slick.EventData(), gridStub);
+      service.updateFilters(mockNewFilters);
+
+      expect(emitSpy).toHaveBeenCalledWith('local');
+      expect(clearSpy).toHaveBeenCalledWith(false);
+      expect(service.getColumnFilters()).toEqual({
+        firstName: { columnId: 'firstName', columnDef: mockColumn1, searchTerms: ['Jane'], operator: 'StartsWith' },
+        isActive: { columnId: 'isActive', columnDef: mockColumn2, searchTerms: [false], operator: 'EQ' }
+      });
+    });
+
+    it('should call "clearFilters" without triggering a clear event but trigger an "emitFilterChanged" remote when using "bindLocalOnFilter" and also expect filters to be set in ColumnFilters', () => {
+      gridOptionMock.backendServiceApi = {
+        filterTypingDebounce: 0,
+        service: backendServiceStub,
+        process: () => new Promise((resolve) => resolve(jest.fn())),
+      };
+      const clearSpy = jest.spyOn(service, 'clearFilters');
+      const emitSpy = jest.spyOn(service, 'emitFilterChanged');
+      const backendUpdateSpy = jest.spyOn(backendServiceStub, 'updateFilters');
+
+      service.init(gridStub);
+      service.bindLocalOnFilter(gridStub, dataViewStub);
+      gridStub.onHeaderRowCellRendered.notify(mockArgs1, new Slick.EventData(), gridStub);
+      gridStub.onHeaderRowCellRendered.notify(mockArgs2, new Slick.EventData(), gridStub);
+      service.updateFilters(mockNewFilters);
+
+      expect(emitSpy).toHaveBeenCalledWith('remote');
+      expect(clearSpy).toHaveBeenCalledWith(false);
+      expect(backendUpdateSpy).toHaveBeenCalledWith(mockNewFilters, true);
+      expect(service.getColumnFilters()).toEqual({
+        firstName: { columnId: 'firstName', columnDef: mockColumn1, searchTerms: ['Jane'], operator: 'StartsWith' },
+        isActive: { columnId: 'isActive', columnDef: mockColumn2, searchTerms: [false], operator: 'EQ' }
+      });
     });
   });
 });

--- a/src/aurelia-slickgrid/services/__tests__/grid-odata.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/grid-odata.service.spec.ts
@@ -1292,6 +1292,22 @@ describe('GridOdataService', () => {
       expect(currentSorters).toEqual([]);
     });
 
+    it('should return a query with the multiple new sorting when "updateSorters" with currentSorter defined as preset on 2nd argument', () => {
+      const expectation = `$top=10&$orderby=Gender asc,FirstName desc`;
+      const mockCurrentSorter = [
+        { columnId: 'gender', direction: 'asc' },
+        { columnId: 'firstName', direction: 'DESC' }
+      ] as CurrentSorter[];
+
+      service.init(serviceOptions, paginationOptions, gridStub);
+      service.updateSorters(null, mockCurrentSorter);
+      const query = service.buildQuery();
+      const currentSorters = service.getCurrentSorters();
+
+      expect(query).toBe(expectation);
+      expect(currentSorters).toEqual([{ columnId: 'gender', direction: 'asc' }, { columnId: 'firstName', direction: 'desc' }]);
+    });
+
     describe('set "enablePagination" to False', () => {
       beforeEach(() => {
         gridOptionMock.enablePagination = false;

--- a/src/aurelia-slickgrid/services/__tests__/grid.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/grid.service.spec.ts
@@ -863,11 +863,12 @@ describe('Grid Service', () => {
 
       setTimeout(() => {
         expect(getItemSpy).toHaveBeenCalledWith(2);
+        expect(updateSpy).toHaveBeenCalledTimes(3);
         expect(updateSpy).toHaveBeenCalledWith(mockColumn.id, mockColumn);
         expect(renderSpy).toHaveBeenCalled();
         expect(getIndexSpy).toHaveBeenCalled();
         done();
-      }, 2);
+      }, 5);
     });
   });
 

--- a/src/aurelia-slickgrid/services/__tests__/pagination.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/pagination.service.spec.ts
@@ -3,7 +3,7 @@ import { EventAggregator } from 'aurelia-event-aggregator';
 
 import { PaginationService } from './../pagination.service';
 import { FilterService, GridService } from '../index';
-import { Column, GridOption, CurrentFilter } from '../../models';
+import { Column, GridOption } from '../../models';
 import * as utilities from '../backend-utilities';
 
 const DEFAULT_AURELIA_EVENT_PREFIX = 'asg';
@@ -587,6 +587,22 @@ describe('PaginationService', () => {
         });
         expect(service.pager.from).toBe(26);
         expect(service.pager.to).toBe(50);
+        done();
+      });
+    });
+
+    it('should call "processOnItemAddedOrRemoved" and expect the (To) to equal the total items when it is lower than the total itemsPerPage count', (done) => {
+      mockGridOption.pagination.pageNumber = 4;
+      mockGridOption.pagination.totalItems = 100;
+      const mockItems = { name: 'John' };
+
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
+      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-added`, mockItems);
+      service.changeItemPerPage(200);
+
+      setTimeout(() => {
+        expect(service.pager.from).toBe(1);
+        expect(service.pager.to).toBe(101);
         done();
       });
     });

--- a/src/aurelia-slickgrid/services/__tests__/resizer.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/resizer.service.spec.ts
@@ -84,6 +84,19 @@ describe('Resizer Service', () => {
     beforeEach(() => {
       // @ts-ignore
       navigator.__defineGetter__('userAgent', () => 'Netscape');
+      gridOptionMock.gridId = 'grid1';
+    });
+
+    it('should return null when calling "bindAutoResizeDataGrid" method with a gridId that is not found in the DOM', () => {
+      gridOptionMock.gridId = 'unknown';
+      const output = service.bindAutoResizeDataGrid();
+      expect(output).toBe(null);
+    });
+
+    it('should return null when calling "calculateGridNewDimensions" method with a gridId that is not found in the DOM', () => {
+      gridOptionMock.gridId = 'unknown';
+      const output = service.calculateGridNewDimensions(gridOptionMock);
+      expect(output).toBe(null);
     });
 
     it('should trigger a grid resize when a window resize event occurs', () => {

--- a/src/aurelia-slickgrid/services/__tests__/utilities.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/utilities.spec.ts
@@ -15,8 +15,9 @@ import {
   htmlEntityEncode,
   mapMomentDateFormatWithFieldType,
   mapFlatpickrDateFormatWithFieldType,
-  mapOperatorType,
   mapOperatorByFieldType,
+  mapOperatorToShorthandDesignation,
+  mapOperatorType,
   parseBoolean,
   parseUtcDate,
   sanitizeHtmlToText,
@@ -439,6 +440,12 @@ describe('Service/Utilies', () => {
       obj = { id: 1, user: { firstName: 'John', lastName: 'Doe', address: { number: 123, street: 'Broadway' } } };
     });
 
+    it('should return original object when no path is provided', () => {
+      // @ts-ignore
+      const output = getDescendantProperty(obj);
+      expect(output).toBe(obj);
+    });
+
     it('should return undefined when search argument is not part of the input object', () => {
       const output = getDescendantProperty(obj, 'users');
       expect(output).toBe(undefined);
@@ -689,115 +696,227 @@ describe('Service/Utilies', () => {
 
   describe('mapOperatorType method', () => {
     it('should return OperatoryType associated to "<"', () => {
-      const output = mapOperatorType('<');
-      expect(output).toBe(OperatorType.lessThan);
+      const expectation = OperatorType.lessThan;
+
+      const output1 = mapOperatorType('<');
+      const output2 = mapOperatorType('LT');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "<="', () => {
-      const output = mapOperatorType('<=');
-      expect(output).toBe(OperatorType.lessThanOrEqual);
+      const expectation = OperatorType.lessThanOrEqual;
+
+      const output1 = mapOperatorType('<=');
+      const output2 = mapOperatorType('LE');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return OperatoryType associated to ">"', () => {
-      const output = mapOperatorType('>');
-      expect(output).toBe(OperatorType.greaterThan);
+      const expectation = OperatorType.greaterThan;
+
+      const output1 = mapOperatorType('>');
+      const output2 = mapOperatorType('GT');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return OperatoryType associated to ">="', () => {
-      const output = mapOperatorType('>=');
-      expect(output).toBe(OperatorType.greaterThanOrEqual);
+      const expectation = OperatorType.greaterThanOrEqual;
+
+      const output1 = mapOperatorType('>=');
+      const output2 = mapOperatorType('GE');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "<>", "!=", "neq" or "NEQ"', () => {
+      const expectation = OperatorType.notEqual;
+
       const output1 = mapOperatorType('<>');
       const output2 = mapOperatorType('!=');
-      const output3 = mapOperatorType('neq');
-      const output4 = mapOperatorType('NEQ');
+      const output3 = mapOperatorType('NE');
 
-      expect(output1).toBe(OperatorType.notEqual);
-      expect(output2).toBe(OperatorType.notEqual);
-      expect(output3).toBe(OperatorType.notEqual);
-      expect(output4).toBe(OperatorType.notEqual);
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "*", "a*", ".*", "startsWith"', () => {
-      const output1 = mapOperatorType('*');
-      const output2 = mapOperatorType('.*');
-      const output3 = mapOperatorType('a*');
-      const output4 = mapOperatorType('startsWith');
-      const output5 = mapOperatorType('StartsWith');
+      const expectation = OperatorType.startsWith;
 
-      expect(output1).toBe(OperatorType.startsWith);
-      expect(output2).toBe(OperatorType.startsWith);
-      expect(output3).toBe(OperatorType.startsWith);
-      expect(output4).toBe(OperatorType.startsWith);
-      expect(output5).toBe(OperatorType.startsWith);
+      const output1 = mapOperatorType('*');
+      const output2 = mapOperatorType('a*');
+      const output3 = mapOperatorType('StartsWith');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "*.", "*z", "endsWith"', () => {
-      const output1 = mapOperatorType('*.');
-      const output2 = mapOperatorType('*z');
-      const output3 = mapOperatorType('endsWith');
-      const output4 = mapOperatorType('EndsWith');
+      const expectation = OperatorType.endsWith;
 
-      expect(output1).toBe(OperatorType.endsWith);
-      expect(output2).toBe(OperatorType.endsWith);
-      expect(output3).toBe(OperatorType.endsWith);
-      expect(output4).toBe(OperatorType.endsWith);
+      const output1 = mapOperatorType('*z');
+      const output2 = mapOperatorType('EndsWith');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "=", "==", "eq" or "EQ"', () => {
+      const expectation = OperatorType.equal;
+
       const output1 = mapOperatorType('=');
       const output2 = mapOperatorType('==');
-      const output3 = mapOperatorType('eq');
-      const output4 = mapOperatorType('EQ');
+      const output3 = mapOperatorType('EQ');
 
-      expect(output1).toBe(OperatorType.equal);
-      expect(output2).toBe(OperatorType.equal);
-      expect(output3).toBe(OperatorType.equal);
-      expect(output4).toBe(OperatorType.equal);
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "in", "IN"', () => {
-      const output1 = mapOperatorType('in');
-      const output2 = mapOperatorType('IN');
+      const expectation = OperatorType.in;
 
-      expect(output1).toBe(OperatorType.in);
-      expect(output2).toBe(OperatorType.in);
+      const output1 = mapOperatorType('IN');
+
+      expect(output1).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "notIn", "NIN", "NOT_IN"', () => {
-      const output1 = mapOperatorType('notIn');
-      const output2 = mapOperatorType('NIN');
-      const output3 = mapOperatorType('NOT_IN');
+      const expectation = OperatorType.notIn;
 
-      expect(output1).toBe(OperatorType.notIn);
-      expect(output2).toBe(OperatorType.notIn);
-      expect(output3).toBe(OperatorType.notIn);
+      const output1 = mapOperatorType('NIN');
+      const output2 = mapOperatorType('NOT_IN');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return OperatoryType associated to "not_contains", "Not_Contains", "notContains"', () => {
-      const output1 = mapOperatorType('not_contains');
-      const output2 = mapOperatorType('Not_Contains');
-      const output3 = mapOperatorType('notContains');
-      const output4 = mapOperatorType('NotContains');
-      const output5 = mapOperatorType('NOT_CONTAINS');
+      const expectation = OperatorType.notContains;
 
-      expect(output1).toBe(OperatorType.notContains);
-      expect(output2).toBe(OperatorType.notContains);
-      expect(output3).toBe(OperatorType.notContains);
-      expect(output4).toBe(OperatorType.notContains);
-      expect(output5).toBe(OperatorType.notContains);
+      const output1 = mapOperatorType('Not_Contains');
+      const output2 = mapOperatorType('NOT_CONTAINS');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
     });
 
     it('should return default OperatoryType associated to contains', () => {
+      const expectation = OperatorType.contains;
+
       const output1 = mapOperatorType('');
       const output2 = mapOperatorType('Contains');
       const output3 = mapOperatorType('CONTAINS');
 
-      expect(output1).toBe(OperatorType.contains);
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
+    });
+  });
+
+  describe('mapOperatorToShorthandDesignation method', () => {
+    it('should return Operator shorthand of ">"', () => {
+      const expectation = '>';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.greaterThan);
+      const output2 = mapOperatorToShorthandDesignation('>');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of ">="', () => {
+      const expectation = '>=';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.greaterThanOrEqual);
+      const output2 = mapOperatorToShorthandDesignation('>=');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of "<"', () => {
+      const expectation = '<';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.lessThan);
+      const output2 = mapOperatorToShorthandDesignation('<');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of "<="', () => {
+      const expectation = '<=';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.lessThanOrEqual);
+      const output2 = mapOperatorToShorthandDesignation('<=');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of "<>"', () => {
+      const expectation = '<>';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.notEqual);
+      const output2 = mapOperatorToShorthandDesignation('<>');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of "="', () => {
+      const expectation = '=';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.equal);
+      const output2 = mapOperatorToShorthandDesignation('=');
+      const output3 = mapOperatorToShorthandDesignation('==');
+      const output4 = mapOperatorToShorthandDesignation('EQ');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
+      expect(output4).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of "a*" to represent starts with', () => {
+      const expectation = 'a*';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.startsWith);
+      const output2 = mapOperatorToShorthandDesignation('a*');
+      const output3 = mapOperatorToShorthandDesignation('*');
+      const output4 = mapOperatorToShorthandDesignation('StartsWith');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
+      expect(output4).toBe(expectation);
+    });
+
+    it('should return Operator shorthand of "*z" to represent ends with', () => {
+      const expectation = '*z';
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.endsWith);
+      const output2 = mapOperatorToShorthandDesignation('*z');
+      const output3 = mapOperatorToShorthandDesignation('EndsWith');
+
+      expect(output1).toBe(expectation);
+      expect(output2).toBe(expectation);
+      expect(output3).toBe(expectation);
+    });
+
+    it('should return same input Operator when no shorthand is found', () => {
+      const output1 = mapOperatorToShorthandDesignation(OperatorType.in);
+      const output2 = mapOperatorToShorthandDesignation(OperatorType.contains);
+      const output3 = mapOperatorToShorthandDesignation(OperatorType.notContains);
+      const output4 = mapOperatorToShorthandDesignation(OperatorType.rangeExclusive);
+      const output5 = mapOperatorToShorthandDesignation(OperatorType.rangeInclusive);
+
+      expect(output1).toBe(OperatorType.in);
       expect(output2).toBe(OperatorType.contains);
-      expect(output3).toBe(OperatorType.contains);
+      expect(output3).toBe(OperatorType.notContains);
+      expect(output4).toBe(OperatorType.rangeExclusive);
+      expect(output5).toBe(OperatorType.rangeInclusive);
     });
   });
 

--- a/src/aurelia-slickgrid/services/__tests__/utilities.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/utilities.spec.ts
@@ -9,7 +9,6 @@ import {
   findOrDefault,
   formatNumber,
   getDescendantProperty,
-  htmlDecode,
   htmlEncode,
   htmlEntityDecode,
   htmlEntityEncode,
@@ -66,25 +65,6 @@ describe('Service/Utilies', () => {
 
     it('should return the a simple string with x spaces only where x is the number of spaces provided as argument', () => {
       expect(addWhiteSpaces(5)).toBe('     ');
-    });
-  });
-
-  // skip it for now since there is no DOMParser in node, this might work later when using Jest with JSDOM instead of node type
-  xdescribe('htmlDecode method', () => {
-    it('should return a decoded HTML string', () => {
-      const result = htmlDecode(`&lt;div class=&quot;color: blue&quot;&gt;Something&lt;/div&gt;`);
-      expect(result).toBe(`<div class="color: blue">Something</div>`);
-    });
-
-    it('should return a decoded HTML string with single quotes encoded as well', () => {
-      const result = htmlDecode(`&lt;div class=&#39;color: blue&#39;&gt;Something&lt;/div&gt;`);
-      expect(result).toBe(`<div class='color: blue'>Something</div>`);
-    });
-
-    it('should use jQuery and return a decoded HTML string with single quotes encoded as well when DOMParser is not available in older browser', () => {
-      DOMParser = undefined;
-      const result = htmlDecode(`&lt;div class=&#39;color: blue&#39;&gt;Something&lt;/div&gt;`);
-      expect(result).toBe(`<div class='color: blue'>Something</div>`);
     });
   });
 

--- a/src/aurelia-slickgrid/services/backend-utilities.ts
+++ b/src/aurelia-slickgrid/services/backend-utilities.ts
@@ -1,27 +1,10 @@
 import { BackendServiceApi, EmitterType, GraphqlResult, GridOption } from '../models/index';
 
-/**
- * Execute the backend callback, which are mainly the "process" & "postProcess" methods.
- * Also note that "preProcess" was executed prior to this callback
- */
-export async function executeBackendCallback(backendServiceApi: BackendServiceApi, query: string, args: any, startTime: Date, totalItems: number, emitActionChangedCallback: (type: EmitterType) => void) {
-  if (backendServiceApi) {
-    // emit an onFilterChanged event when it's not called by a clear filter
-    if (args && !args.clearFilterTriggered) {
-      emitActionChangedCallback(EmitterType.remote);
-    }
-
-    // the processes can be Observables (like HttpClient) or Promises
-    const process = backendServiceApi.process(query);
-    if (process instanceof Promise && process.then) {
-      process.then((processResult: GraphqlResult | any) => executeBackendProcessesCallback(startTime, processResult, backendServiceApi, totalItems))
-        .catch((error: any) => onBackendError(error, backendServiceApi));
-    }
-  }
-}
+// construct a main object that will be exported and used by unit tests
+const main: any = {};
 
 /** Execute the Backend Processes Callback, that could come from an Observable or a Promise callback */
-export function executeBackendProcessesCallback(startTime: Date, processResult: GraphqlResult | any, backendApi: BackendServiceApi, totalItems: number): GraphqlResult | any {
+main.executeBackendProcessesCallback = function exeBackendProcessesCallback(startTime: Date, processResult: GraphqlResult | any, backendApi: BackendServiceApi, totalItems: number): GraphqlResult | any {
   const endTime = new Date();
 
   // define what our internal Post Process callback, only available for GraphQL Service for now
@@ -48,7 +31,7 @@ export function executeBackendProcessesCallback(startTime: Date, processResult: 
 }
 
 /** On a backend service api error, we will run the "onError" if there is 1 provided or just throw back the error when nothing is provided */
-export function onBackendError(e: any, backendApi: BackendServiceApi) {
+main.onBackendError = function backendError(e: any, backendApi: BackendServiceApi) {
   if (backendApi && backendApi.onError) {
     backendApi.onError(e);
   } else {
@@ -56,9 +39,30 @@ export function onBackendError(e: any, backendApi: BackendServiceApi) {
   }
 }
 
+/**
+ * Execute the backend callback, which are mainly the "process" & "postProcess" methods.
+ * Also note that "preProcess" was executed prior to this callback
+ */
+main.executeBackendCallback = function exeBackendCallback(backendServiceApi: BackendServiceApi, query: string, args: any, startTime: Date, totalItems: number, emitActionChangedCallback: (type: EmitterType) => void) {
+  if (backendServiceApi) {
+    // emit an onFilterChanged event when it's not called by a clear filter
+    if (args && !args.clearFilterTriggered) {
+      emitActionChangedCallback(EmitterType.remote);
+    }
+
+    // the processes can be Observables (like HttpClient) or Promises
+    const process = backendServiceApi.process(query);
+    if (process instanceof Promise && process.then) {
+      process.then((processResult: GraphqlResult | any) => main.executeBackendProcessesCallback(startTime, processResult, backendServiceApi, totalItems))
+        .catch((error: any) => main.onBackendError(error, backendServiceApi));
+    }
+  }
+}
+
 /** Refresh the dataset through the Backend Service */
-export function refreshBackendDataset(backendApi: BackendServiceApi, gridOptions: GridOption) {
+main.refreshBackendDataset = function refreshBackend(gridOptions: GridOption) {
   let query = '';
+  const backendApi = gridOptions && gridOptions.backendServiceApi;
 
   if (!backendApi || !backendApi.service || !backendApi.process) {
     throw new Error(`BackendServiceApi requires at least a "process" function and a "service" defined`);
@@ -76,12 +80,16 @@ export function refreshBackendDataset(backendApi: BackendServiceApi, gridOptions
       backendApi.preProcess();
     }
 
-    // the process could be an Observable (like HttpClient) or a Promise
-    // in any case, we need to have a Promise so that we can await on it (if an Observable, convert it to Promise)
-    const processPromise = backendApi.process(query);
-    if (processPromise instanceof Promise && processPromise.then) {
-      processPromise.then((processResult: GraphqlResult | any) => executeBackendProcessesCallback(startTime, processResult, backendApi, gridOptions.pagination.totalItems))
-        .catch((error: any) => onBackendError(error, backendApi));
-    }
+    const totalItems = gridOptions && gridOptions.pagination && gridOptions.pagination.totalItems;
+    main.executeBackendCallback(backendApi, query, null, startTime, totalItems);
   }
-}
+};
+
+// export all methods & the main so that it works in all modules but also in Jest unit test
+// export every method as independent constant so that it still works whenever this is used in other modules
+export const executeBackendProcessesCallback = main.executeBackendProcessesCallback;
+export const onBackendError = main.onBackendError;
+export const executeBackendCallback = main.executeBackendCallback;
+export const refreshBackendDataset = main.refreshBackendDataset;
+
+export default main;

--- a/src/aurelia-slickgrid/services/extension.service.ts
+++ b/src/aurelia-slickgrid/services/extension.service.ts
@@ -99,10 +99,10 @@ export class ExtensionService {
    *  @param name
    */
   getExtensionByName(name: ExtensionName): ExtensionModel | undefined {
-    if (Array.isArray(this._extensionList)) {
-      return this._extensionList.find((p) => p.name === name);
+    if (!Array.isArray(this._extensionList) || this._extensionList.length === 0) {
+      return undefined;
     }
-    return undefined;
+    return this._extensionList.find((p) => p.name === name);
   }
 
   /**
@@ -407,10 +407,10 @@ export class ExtensionService {
    *  @param name
    */
   private getCreatedExtensionByName(name: ExtensionName): ExtensionModel | undefined {
-    if (Array.isArray(this._extensionCreatedList)) {
-      return this._extensionCreatedList.find((p) => p.name === name);
+    if (!Array.isArray(this._extensionCreatedList) || this._extensionCreatedList.length === 0) {
+      return undefined;
     }
-    return undefined;
+    return this._extensionCreatedList.find((p) => p.name === name);
   }
 
   /** Translate an array of items from an input key and assign translated value to the output key */

--- a/src/aurelia-slickgrid/services/filter.service.ts
+++ b/src/aurelia-slickgrid/services/filter.service.ts
@@ -21,7 +21,7 @@ import {
   SlickEvent,
   SlickEventHandler,
 } from './../models/index';
-import { executeBackendCallback } from './backend-utilities';
+import { executeBackendCallback, refreshBackendDataset } from './backend-utilities';
 import { getDescendantProperty } from './utilities';
 import { SharedService } from './shared.service';
 import * as $ from 'jquery';
@@ -203,10 +203,11 @@ export class FilterService {
   }
 
   /** Clear the search filters (below the column titles) */
-  clearFilters() {
+  clearFilters(triggerChange = true) {
     this._filtersMetadata.forEach((filter: Filter) => {
       if (filter && filter.clear) {
-        // clear element and trigger a change
+        // clear element but don't trigger individual clear change,
+        // we'll do 1 trigger for all filters at once afterward
         filter.clear(false);
       }
     });
@@ -236,7 +237,9 @@ export class FilterService {
     }
 
     // emit an event when filters are all cleared
-    this.ea.publish('filterService:filterCleared', true);
+    if (triggerChange) {
+      this.ea.publish('filterService:filterCleared', true);
+    }
   }
 
   /** Local Grid Filter search */
@@ -454,7 +457,7 @@ export class FilterService {
    * At the end of the day, when creating the Filter (DOM Element), it will use these searchTerm(s) so we can take advantage of that without recoding each Filter type (DOM element)
    * @param grid
    */
-  populateColumnFilterSearchTermPresets(filters: ColumnFilter[]) {
+  populateColumnFilterSearchTermPresets(filters: CurrentFilter[]) {
     if (Array.isArray(filters) && filters.length > 0) {
       this._columnDefinitions.forEach((columnDef: Column) => {
         // clear any columnDef searchTerms before applying Presets
@@ -474,6 +477,37 @@ export class FilterService {
       });
     }
     return this._columnDefinitions;
+  }
+
+  /** Update any filter(s) dynamically */
+  updateFilters(filters: CurrentFilter[]) {
+    if (Array.isArray(filters)) {
+      // start by clearing all filters, without trigger an event, before applying any new ones
+      this.clearFilters(false);
+
+      // pre-fill (value + operator) and render all filters in the DOM
+      filters.forEach((newFilter) => {
+        const uiFilter = this._filtersMetadata.find((filter) => newFilter.columnId === filter.columnDef.id);
+        this.updateColumnFilters(newFilter.searchTerms, uiFilter.columnDef, newFilter.operator || uiFilter.defaultOperator);
+        uiFilter.setValues(newFilter.searchTerms, newFilter.operator || uiFilter.defaultOperator, false);
+      });
+
+      const backendApi = this._gridOptions && this._gridOptions.backendServiceApi;
+
+      // refresh the DataView and trigger an event after all filters were updated and rendered
+      this._dataView.refresh();
+
+      if (backendApi) {
+        const backendApiService = backendApi && backendApi.service;
+        if (backendApiService) {
+          backendApiService.updateFilters(filters, true);
+          refreshBackendDataset(backendApi, this._gridOptions);
+          this.emitFilterChanged(EmitterType.remote);
+        }
+      } else {
+        this.emitFilterChanged(EmitterType.local);
+      }
+    }
   }
 
   // --

--- a/src/aurelia-slickgrid/services/filter.service.ts
+++ b/src/aurelia-slickgrid/services/filter.service.ts
@@ -481,15 +481,24 @@ export class FilterService {
 
   /** Update any filter(s) dynamically */
   updateFilters(filters: CurrentFilter[]) {
+    if (!this._filtersMetadata || this._filtersMetadata.length === 0 || !this._gridOptions || !this._gridOptions.enableFiltering) {
+      throw new Error('[Aurelia-Slickgrid] in order to use "updateFilters" method, you need to have Filters defined in your grid and "enableFiltering" set in your Grid Options');
+    }
+
     if (Array.isArray(filters)) {
       // start by clearing all filters, without trigger an event, before applying any new ones
       this.clearFilters(false);
 
       // pre-fill (value + operator) and render all filters in the DOM
+      // loop through each Filters provided (which has a columnId property)
+      // then find their associated Filter instances that were originally created in the grid
       filters.forEach((newFilter) => {
         const uiFilter = this._filtersMetadata.find((filter) => newFilter.columnId === filter.columnDef.id);
-        this.updateColumnFilters(newFilter.searchTerms, uiFilter.columnDef, newFilter.operator || uiFilter.defaultOperator);
-        uiFilter.setValues(newFilter.searchTerms, newFilter.operator || uiFilter.defaultOperator, false);
+        if (newFilter && uiFilter) {
+          const newOperator = newFilter.operator || uiFilter.defaultOperator;
+          this.updateColumnFilters(newFilter.searchTerms, uiFilter.columnDef, newOperator);
+          uiFilter.setValues(newFilter.searchTerms, newOperator);
+        }
       });
 
       const backendApi = this._gridOptions && this._gridOptions.backendServiceApi;
@@ -501,7 +510,7 @@ export class FilterService {
         const backendApiService = backendApi && backendApi.service;
         if (backendApiService) {
           backendApiService.updateFilters(filters, true);
-          refreshBackendDataset(backendApi, this._gridOptions);
+          refreshBackendDataset(this._gridOptions);
           this.emitFilterChanged(EmitterType.remote);
         }
       } else {

--- a/src/aurelia-slickgrid/services/grid-odata.service.ts
+++ b/src/aurelia-slickgrid/services/grid-odata.service.ts
@@ -229,13 +229,13 @@ export class GridOdataService implements BackendService {
    * loop through all columns to inspect filters & update backend service filters
    * @param columnFilters
    */
-  updateFilters(columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPreset?: boolean) {
+  updateFilters(columnFilters: ColumnFilters | CurrentFilter[], isUpdatedByPresetOrDynamically?: boolean) {
     let searchBy = '';
     const searchByArray: string[] = [];
     const odataVersion = this._odataService && this._odataService.options && this._odataService.options.version || 2;
 
     // on filter preset load, we need to keep current filters
-    if (isUpdatedByPreset) {
+    if (isUpdatedByPresetOrDynamically) {
       this._currentFilters = this.castFilterToColumnFilters(columnFilters);
     }
 
@@ -246,7 +246,7 @@ export class GridOdataService implements BackendService {
 
         // if user defined some "presets", then we need to find the filters from the column definitions instead
         let columnDef: Column | undefined;
-        if (isUpdatedByPreset && Array.isArray(this._columnDefinitions)) {
+        if (isUpdatedByPresetOrDynamically && Array.isArray(this._columnDefinitions)) {
           columnDef = this._columnDefinitions.find((column: Column) => {
             return column.id === columnFilter.columnId;
           });

--- a/src/aurelia-slickgrid/services/resizer.service.ts
+++ b/src/aurelia-slickgrid/services/resizer.service.ts
@@ -81,7 +81,7 @@ export class ResizerService {
     const gridDomElm = $(`#${gridOptions.gridId}`);
     const autoResizeOptions = gridOptions && gridOptions.autoResize || {};
     const containerElm = (autoResizeOptions && autoResizeOptions.containerId) ? $(`#${autoResizeOptions.containerId}`) : $(`#${gridOptions.gridContainerId}`);
-    if (!window || containerElm === undefined || gridDomElm === undefined) {
+    if (!window || containerElm === undefined || gridDomElm === undefined || gridDomElm.offset() === undefined) {
       return null;
     }
 

--- a/src/aurelia-slickgrid/services/utilities.ts
+++ b/src/aurelia-slickgrid/services/utilities.ts
@@ -47,15 +47,9 @@ export function htmlEncode(inputValue: string): string {
     '<': '&lt;',
     '>': '&gt;',
     '"': '&quot;',
-    '\'': '&#39;',
-    // '/': '&#x2F;',
-    // '`': '&#x60;',
-    // '=': '&#x3D;'
+    '\'': '&#39;'
   };
-  // all symbols::  /[&<>"'`=\/]/g
-  return inputValue.replace(/[&<>"']/g, (s) => {
-    return entityMap[s];
-  });
+  return inputValue.replace(/[&<>"']/g, (s) => entityMap[s]);
 }
 
 /**

--- a/src/aurelia-slickgrid/services/utilities.ts
+++ b/src/aurelia-slickgrid/services/utilities.ts
@@ -37,26 +37,6 @@ export function addWhiteSpaces(nbSpaces: number): string {
 }
 
 /**
- * HTML decode using jQuery with a <div>
- * Create a in-memory div, set it's inner text(which jQuery automatically encodes)
- * then grab the encoded contents back out.  The div never exists on the page.
- */
-export function htmlDecode(encodedStr: string): string {
-  // tslint:disable-next-line new-parens
-  const parser = DOMParser && new DOMParser();
-
-  if (parser && parser.parseFromString) {
-    const dom = parser.parseFromString(
-      '<!doctype html><body>' + encodedStr,
-      'text/html');
-    return dom && dom.body && dom.body.textContent || '';
-  } else {
-    // for some browsers that might not support DOMParser, use jQuery instead
-    return $('<div/>').html(encodedStr).text();
-  }
-}
-
-/**
  * HTML encode using jQuery with a <div>
  * Create a in-memory div, set it's inner text(which jQuery automatically encodes)
  * then grab the encoded contents back out.  The div never exists on the page.

--- a/src/aurelia-slickgrid/services/utilities.ts
+++ b/src/aurelia-slickgrid/services/utilities.ts
@@ -1,7 +1,8 @@
 import { Subscription } from 'aurelia-event-aggregator';
-import { FieldType, OperatorType } from '../models/index';
 import * as moment from 'moment-mini';
 import * as $ from 'jquery';
+
+import { FieldType, OperatorString, OperatorType } from '../models/index';
 
 /**
  * Add an item to an array only when the item does not exists, when the item is an object we will be using their "id" to compare
@@ -447,6 +448,58 @@ export function mapOperatorType(operator: string): OperatorType {
   }
 
   return map;
+}
+
+/**
+ * Find equivalent short designation of an Operator Type or Operator String.
+ * When using a Compound Filter, we use the short designation and so we need the mapped value.
+ * For example OperatorType.startsWith short designation is "a*", while OperatorType.greaterThanOrEqual is ">="
+ */
+export function mapOperatorToShortDesignation(operator: OperatorType | OperatorString): OperatorString {
+  let shortOperator: OperatorString = '';
+
+  switch (operator) {
+    case OperatorType.startsWith:
+    case 'a*':
+      shortOperator = 'a*';
+      break;
+    case OperatorType.endsWith:
+    case '*z':
+      shortOperator = '*z';
+      break;
+    case OperatorType.greaterThan:
+    case '>':
+      shortOperator = '>';
+      break;
+    case OperatorType.greaterThanOrEqual:
+    case '>=':
+      shortOperator = '>=';
+      break;
+    case OperatorType.lessThan:
+    case '<':
+      shortOperator = '<';
+      break;
+    case OperatorType.lessThanOrEqual:
+    case '<=':
+      shortOperator = '<=';
+      break;
+    case OperatorType.notEqual:
+    case '<>':
+      shortOperator = '<>';
+      break;
+    case OperatorType.equal:
+    case '=':
+    case '==':
+    case 'EQ':
+      shortOperator = '=';
+      break;
+    default:
+      // any other operator will be considered as already a short expression, so we can return same input operator
+      shortOperator = operator;
+      break;
+  }
+
+  return shortOperator;
 }
 
 /**

--- a/src/aurelia-slickgrid/services/utilities.ts
+++ b/src/aurelia-slickgrid/services/utilities.ts
@@ -186,10 +186,10 @@ export function disposeAllSubscriptions(subscriptions: Subscription[]) {
 
 /** From a dot (.) notation path, find and return a property within an object given a path */
 export function getDescendantProperty(obj: any, path: string | undefined): any {
-  if (obj && path) {
-    return path.split('.').reduce((acc, part) => acc && acc[part], obj);
+  if (!obj || !path) {
+    return obj;
   }
-  return obj;
+  return path.split('.').reduce((acc, part) => acc && acc[part], obj);
 }
 
 /**
@@ -383,60 +383,53 @@ export function mapFlatpickrDateFormatWithFieldType(fieldType: FieldType): strin
  * @param string operator
  * @returns string map
  */
-export function mapOperatorType(operator: string): OperatorType {
+export function mapOperatorType(operator: OperatorType | OperatorString): OperatorType {
   let map: OperatorType;
 
   switch (operator) {
     case '<':
+    case 'LT':
       map = OperatorType.lessThan;
       break;
     case '<=':
+    case 'LE':
       map = OperatorType.lessThanOrEqual;
       break;
     case '>':
+    case 'GT':
       map = OperatorType.greaterThan;
       break;
     case '>=':
+    case 'GE':
       map = OperatorType.greaterThanOrEqual;
       break;
     case '<>':
     case '!=':
-    case 'neq':
-    case 'NEQ':
+    case 'NE':
       map = OperatorType.notEqual;
       break;
     case '*':
-    case '.*':
     case 'a*':
-    case 'startsWith':
     case 'StartsWith':
       map = OperatorType.startsWith;
       break;
-    case '*.':
     case '*z':
-    case 'endsWith':
     case 'EndsWith':
       map = OperatorType.endsWith;
       break;
     case '=':
     case '==':
-    case 'eq':
     case 'EQ':
       map = OperatorType.equal;
       break;
-    case 'in':
     case 'IN':
       map = OperatorType.in;
       break;
-    case 'notIn':
     case 'NIN':
     case 'NOT_IN':
       map = OperatorType.notIn;
       break;
-    case 'not_contains':
     case 'Not_Contains':
-    case 'notContains':
-    case 'NotContains':
     case 'NOT_CONTAINS':
       map = OperatorType.notContains;
       break;
@@ -455,18 +448,10 @@ export function mapOperatorType(operator: string): OperatorType {
  * When using a Compound Filter, we use the short designation and so we need the mapped value.
  * For example OperatorType.startsWith short designation is "a*", while OperatorType.greaterThanOrEqual is ">="
  */
-export function mapOperatorToShortDesignation(operator: OperatorType | OperatorString): OperatorString {
+export function mapOperatorToShorthandDesignation(operator: OperatorType | OperatorString): OperatorString {
   let shortOperator: OperatorString = '';
 
   switch (operator) {
-    case OperatorType.startsWith:
-    case 'a*':
-      shortOperator = 'a*';
-      break;
-    case OperatorType.endsWith:
-    case '*z':
-      shortOperator = '*z';
-      break;
     case OperatorType.greaterThan:
     case '>':
       shortOperator = '>';
@@ -492,6 +477,15 @@ export function mapOperatorToShortDesignation(operator: OperatorType | OperatorS
     case '==':
     case 'EQ':
       shortOperator = '=';
+      break;
+    case OperatorType.startsWith:
+    case 'a*':
+    case '*':
+      shortOperator = 'a*';
+      break;
+    case OperatorType.endsWith:
+    case '*z':
+      shortOperator = '*z';
       break;
     default:
       // any other operator will be considered as already a short expression, so we can return same input operator

--- a/src/examples/slickgrid/custom-inputFilter.ts
+++ b/src/examples/slickgrid/custom-inputFilter.ts
@@ -92,9 +92,7 @@ export class CustomInputFilter implements Filter {
     }
   }
 
-  /**
-   * Set value(s) on the DOM element
-   */
+  /** Set value(s) on the DOM element */
   setValues(values) {
     if (values) {
       this.$filterElm.val(values);

--- a/src/examples/slickgrid/example18.html
+++ b/src/examples/slickgrid/example18.html
@@ -25,9 +25,6 @@
       <button class="btn btn-default btn-xs" click.delegate="exportToExcel()">
         <i class="fa fa-file-excel-o text-success"></i> Export to Excel
       </button>
-      <button class="btn btn-default btn-xs" click.delegate="setFiltersDynamically()">
-        Set Filters Dynamically
-      </button>
     </div>
 
     <div class="row col-sm-12">
@@ -39,6 +36,9 @@
       </button>
       <button class="btn btn-default btn-xs" click.delegate="groupByDurationEffortDriven()">
         Group by Duration then Effort-Driven
+      </button>
+      <button class="btn btn-default btn-xs" data-test="set-dynamic-filter" click.delegate="setFiltersDynamically()">
+        Set Filters Dynamically
       </button>
     </div>
 

--- a/src/examples/slickgrid/example18.html
+++ b/src/examples/slickgrid/example18.html
@@ -25,6 +25,9 @@
       <button class="btn btn-default btn-xs" click.delegate="exportToExcel()">
         <i class="fa fa-file-excel-o text-success"></i> Export to Excel
       </button>
+      <button class="btn btn-default btn-xs" click.delegate="setFiltersDynamically()">
+        Set Filters Dynamically
+      </button>
     </div>
 
     <div class="row col-sm-12">

--- a/src/examples/slickgrid/example18.ts
+++ b/src/examples/slickgrid/example18.ts
@@ -355,7 +355,8 @@ export class Example18 {
   setFiltersDynamically() {
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.aureliaGrid.filterService.updateFilters([
-      { columnId: 'percentComplete', operator: '>=', searchTerms: ['75'] },
+      { columnId: 'percentComplete', operator: '>=', searchTerms: ['55'] },
+      { columnId: 'cost', operator: '<', searchTerms: ['80'] },
     ]);
   }
 

--- a/src/examples/slickgrid/example18.ts
+++ b/src/examples/slickgrid/example18.ts
@@ -352,6 +352,13 @@ export class Example18 {
     this.gridObj.setPreHeaderPanelVisibility(true);
   }
 
+  setFiltersDynamically() {
+    // we can Set Filters Dynamically (or different filters) afterward through the FilterService
+    this.aureliaGrid.filterService.updateFilters([
+      { columnId: 'percentComplete', operator: '>=', searchTerms: ['75'] },
+    ]);
+  }
+
   toggleDraggableGroupingRow() {
     this.clearGroupsAndSelects();
     this.gridObj.setPreHeaderPanelVisibility(!this.gridObj.getOptions().showPreHeaderPanel);

--- a/src/examples/slickgrid/example23.html
+++ b/src/examples/slickgrid/example23.html
@@ -12,24 +12,19 @@
     <i class="fa fa-language"></i>
     Switch Language
   </button>
-  <b>Locale:</b> <span style="font-style: italic"
-        data-test="selected-locale">${selectedLanguage + '.json'}</span>
+  <b>Locale:</b> <span style="font-style: italic" data-test="selected-locale">${selectedLanguage + '.json'}</span>
 
-  <button class="btn btn-default btn-sm"
-          click.delegate="aureliaGrid.filterService.clearFilters()"
-          data-test="clear-filter-button">Clear Filters
+  <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.filterService.clearFilters()"
+    data-test="clear-filter-button">Clear Filters
   </button>
-  <button class="btn btn-default btn-sm"
-          click.delegate="aureliaGrid.sortService.clearSorting()">Clear Sorting</button>
-  <button class="btn btn-default btn-sm"
-          click.delegate="setFiltersDynamically()">Set Filters Dynamically</button>
+  <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.sortService.clearSorting()">Clear Sorting</button>
+  <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" click.delegate="setFiltersDynamically()">
+    Set Filters Dynamically
+  </button>
 
-  <aurelia-slickgrid grid-id="grid23"
-                     column-definitions.bind="columnDefinitions"
-                     grid-options.bind="gridOptions"
-                     dataset.bind="dataset"
-                     asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
-                     asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)"
-                     sg-on-row-count-changed.delegate="refreshMetrics($event.detail.eventData, $event.detail.args)">
+  <aurelia-slickgrid grid-id="grid23" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
+    dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
+    asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)"
+    sg-on-row-count-changed.delegate="refreshMetrics($event.detail.eventData, $event.detail.args)">
   </aurelia-slickgrid>
 </template>

--- a/src/examples/slickgrid/example23.html
+++ b/src/examples/slickgrid/example23.html
@@ -3,25 +3,33 @@
   <div class="subtitle" innerhtml.bind="subTitle"></div>
 
   <br />
+
   <span if.bind="metrics">
-    <b>Metrics:</b> ${metrics.endTime | dateFormat: 'DD MMM, h:mm:ss a'} | ${metrics.itemCount} of
-    ${metrics.totalItemCount}
-    items
+    <b>Metrics:</b>
+    ${metrics.endTime | dateFormat: 'DD MMM, h:mm:ss a'} | ${metrics.itemCount} of ${metrics.totalItemCount} items
   </span>
   <button class="btn btn-default btn-sm" data-test="language" click.delegate="switchLanguage()">
     <i class="fa fa-language"></i>
     Switch Language
   </button>
-  <b>Locale:</b> <span style="font-style: italic" data-test="selected-locale">${selectedLanguage + '.json'}</span>
+  <b>Locale:</b> <span style="font-style: italic"
+        data-test="selected-locale">${selectedLanguage + '.json'}</span>
 
-  <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.filterService.clearFilters()"
-    data-test="clear-filter-button">Clear
-    Filters</button>
-  <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.sortService.clearSorting()">Clear Sorting</button>
+  <button class="btn btn-default btn-sm"
+          click.delegate="aureliaGrid.filterService.clearFilters()"
+          data-test="clear-filter-button">Clear Filters
+  </button>
+  <button class="btn btn-default btn-sm"
+          click.delegate="aureliaGrid.sortService.clearSorting()">Clear Sorting</button>
+  <button class="btn btn-default btn-sm"
+          click.delegate="setFiltersDynamically()">Set Filters Dynamically</button>
 
-  <aurelia-slickgrid grid-id="grid23" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
-    dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
-    asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)"
-    sg-on-row-count-changed.delegate="refreshMetrics($event.detail.eventData, $event.detail.args)">
+  <aurelia-slickgrid grid-id="grid23"
+                     column-definitions.bind="columnDefinitions"
+                     grid-options.bind="gridOptions"
+                     dataset.bind="dataset"
+                     asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
+                     asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)"
+                     sg-on-row-count-changed.delegate="refreshMetrics($event.detail.eventData, $event.detail.args)">
   </aurelia-slickgrid>
 </template>

--- a/src/examples/slickgrid/example23.ts
+++ b/src/examples/slickgrid/example23.ts
@@ -232,14 +232,13 @@ export class Example23 {
   }
 
   setFiltersDynamically() {
-    const presetLowestDay = moment().add(-2, 'days').format('YYYY-MM-DD');
-    const presetHighestDay = moment().add(20, 'days').format('YYYY-MM-DD');
+    const presetLowestDay = moment().add(-5, 'days').format('YYYY-MM-DD');
+    const presetHighestDay = moment().add(25, 'days').format('YYYY-MM-DD');
 
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.aureliaGrid.filterService.updateFilters([
-      { columnId: 'duration', searchTerms: ['14..78'] },
-      { columnId: 'complete', searchTerms: ['13..73'] }, // without operator will default to 'RangeExclusive'
-      { columnId: 'complete', operator: 'RangeInclusive', searchTerms: [12, 82] }, // same result with searchTerms: ['5..80']
+      { columnId: 'duration', searchTerms: ['14..78'], operator: 'RangeInclusive' },
+      { columnId: 'complete', operator: 'RangeExclusive', searchTerms: [12, 82] },
       { columnId: 'finish', operator: 'RangeInclusive', searchTerms: [presetLowestDay, presetHighestDay] },
     ]);
   }

--- a/src/examples/slickgrid/example23.ts
+++ b/src/examples/slickgrid/example23.ts
@@ -220,12 +220,12 @@ export class Example23 {
   }
 
   refreshMetrics(e, args) {
-    if (args && args.current > 0) {
+    if (args && args.current >= 0) {
       setTimeout(() => {
         this.metrics = {
           startTime: new Date(),
-          itemCount: args && args.current,
-          totalItemCount: this.dataset.length
+          itemCount: args && args.current || 0,
+          totalItemCount: this.dataset.length || 0
         };
       });
     }

--- a/src/examples/slickgrid/example23.ts
+++ b/src/examples/slickgrid/example23.ts
@@ -231,6 +231,19 @@ export class Example23 {
     }
   }
 
+  setFiltersDynamically() {
+    const presetLowestDay = moment().add(-2, 'days').format('YYYY-MM-DD');
+    const presetHighestDay = moment().add(20, 'days').format('YYYY-MM-DD');
+
+    // we can Set Filters Dynamically (or different filters) afterward through the FilterService
+    this.aureliaGrid.filterService.updateFilters([
+      { columnId: 'duration', searchTerms: ['14..78'] },
+      { columnId: 'complete', searchTerms: ['13..73'] }, // without operator will default to 'RangeExclusive'
+      { columnId: 'complete', operator: 'RangeInclusive', searchTerms: [12, 82] }, // same result with searchTerms: ['5..80']
+      { columnId: 'finish', operator: 'RangeInclusive', searchTerms: [presetLowestDay, presetHighestDay] },
+    ]);
+  }
+
   switchLanguage() {
     const nextLocale = (this.selectedLanguage === 'en') ? 'fr' : 'en';
     this.i18n.setLocale(nextLocale).then(() => this.selectedLanguage = nextLocale);

--- a/src/examples/slickgrid/example4.html
+++ b/src/examples/slickgrid/example4.html
@@ -12,9 +12,11 @@
   <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.filterService.clearFilters()">Clear
     Filters</button>
   <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.sortService.clearSorting()">Clear Sorting</button>
-  <button class="btn btn-default btn-sm" click.delegate="setFiltersDynamically()">Set Filters Dynamically</button>
+  <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" click.delegate="setFiltersDynamically()">
+    Set Filters Dynamically
+  </button>
 
-  <aurelia-slickgrid grid-id="grid1" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
+  <aurelia-slickgrid grid-id="grid4" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
     dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
     asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)"
     sg-on-row-count-changed.delegate="refreshMetrics($event.detail.eventData, $event.detail.args)">

--- a/src/examples/slickgrid/example4.html
+++ b/src/examples/slickgrid/example4.html
@@ -12,6 +12,7 @@
   <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.filterService.clearFilters()">Clear
     Filters</button>
   <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.sortService.clearSorting()">Clear Sorting</button>
+  <button class="btn btn-default btn-sm" click.delegate="setFiltersDynamically()">Set Filters Dynamically</button>
 
   <aurelia-slickgrid grid-id="grid1" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
     dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"

--- a/src/examples/slickgrid/example4.ts
+++ b/src/examples/slickgrid/example4.ts
@@ -18,7 +18,7 @@ import {
 function randomBetween(min, max) {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
-const NB_ITEMS = 500;
+const NB_ITEMS = 1000;
 const URL_SAMPLE_COLLECTION_DATA = 'assets/data/collection_500_numbers.json';
 
 @autoinject()
@@ -228,8 +228,8 @@ export class Example4 {
     const tempDataset = [];
     for (let i = startingIndex; i < (startingIndex + itemCount); i++) {
       const randomDuration = Math.round(Math.random() * 100);
-      const randomYear = randomBetween(2000, 2025);
-      const randomYearShort = randomBetween(10, 25);
+      const randomYear = randomBetween(2000, 2035);
+      const randomYearShort = randomBetween(10, 35);
       const randomMonth = randomBetween(1, 12);
       const randomMonthStr = (randomMonth < 10) ? `0${randomMonth}` : randomMonth;
       const randomDay = randomBetween(10, 28);
@@ -267,6 +267,14 @@ export class Example4 {
   /** Save current Filters, Sorters in LocaleStorage or DB */
   saveCurrentGridState() {
     console.log('Client sample, current Grid State:: ', this.aureliaGrid.gridStateService.getCurrentGridState());
+  }
+
+  setFiltersDynamically() {
+    // we can Set Filters Dynamically (or different filters) afterward through the FilterService
+    this.aureliaGrid.filterService.updateFilters([
+      { columnId: 'duration', searchTerms: [10, 220] },
+      { columnId: 'usDateShort', operator: '<', searchTerms: ['4/20/25'] },
+    ]);
   }
 
   refreshMetrics(e, args) {

--- a/src/examples/slickgrid/example4.ts
+++ b/src/examples/slickgrid/example4.ts
@@ -18,7 +18,7 @@ import {
 function randomBetween(min, max) {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
-const NB_ITEMS = 1000;
+const NB_ITEMS = 1500;
 const URL_SAMPLE_COLLECTION_DATA = 'assets/data/collection_500_numbers.json';
 
 @autoinject()
@@ -272,8 +272,10 @@ export class Example4 {
   setFiltersDynamically() {
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.aureliaGrid.filterService.updateFilters([
-      { columnId: 'duration', searchTerms: [10, 220] },
-      { columnId: 'usDateShort', operator: '<', searchTerms: ['4/20/25'] },
+      { columnId: 'duration', searchTerms: [2, 25, 48, 50] },
+      { columnId: 'complete', searchTerms: [95], operator: '<' },
+      { columnId: 'effort-driven', searchTerms: [true] },
+      { columnId: 'start', operator: '>=', searchTerms: ['2001-02-28'] },
     ]);
   }
 

--- a/src/examples/slickgrid/example4.ts
+++ b/src/examples/slickgrid/example4.ts
@@ -10,9 +10,9 @@ import {
   FlatpickrOption,
   Formatters,
   GridOption,
+  Metrics,
   MultipleSelectOption,
   OperatorType,
-  Metrics,
 } from '../../aurelia-slickgrid';
 
 function randomBetween(min, max) {
@@ -278,12 +278,12 @@ export class Example4 {
   }
 
   refreshMetrics(e, args) {
-    if (args && args.current > 0) {
+    if (args && args.current >= 0) {
       setTimeout(() => {
         this.metrics = {
           startTime: new Date(),
-          itemCount: args && args.current,
-          totalItemCount: this.dataset.length
+          itemCount: args && args.current || 0,
+          totalItemCount: this.dataset.length || 0
         };
       });
     }

--- a/src/examples/slickgrid/example5.html
+++ b/src/examples/slickgrid/example5.html
@@ -15,7 +15,9 @@
         ${metrics.totalItemCount}
         items
       </span>
-      <button class="btn btn-default btn-sm" click.delegate="setFiltersDynamically()">Set Filters Dynamically</button>
+      <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" click.delegate="setFiltersDynamically()">
+        Set Filters Dynamically
+      </button>
     </div>
     <div class="col-sm-8">
       <div class="alert alert-info" data-test="alert-odata-query">

--- a/src/examples/slickgrid/example5.html
+++ b/src/examples/slickgrid/example5.html
@@ -15,6 +15,7 @@
         ${metrics.totalItemCount}
         items
       </span>
+      <button class="btn btn-default btn-sm" click.delegate="setFiltersDynamically()">Set Filters Dynamically</button>
     </div>
     <div class="col-sm-8">
       <div class="alert alert-info" data-test="alert-odata-query">

--- a/src/examples/slickgrid/example5.ts
+++ b/src/examples/slickgrid/example5.ts
@@ -131,14 +131,6 @@ export class Example5 {
       : { text: 'done', class: 'alert alert-success' };
   }
 
-  setFiltersDynamically() {
-    // we can Set Filters Dynamically (or different filters) afterward through the FilterService
-    this.aureliaGrid.filterService.updateFilters([
-      // { columnId: 'gender', searchTerms: ['male'], operator: OperatorType.equal },
-      { columnId: 'name', searchTerms: ['A'], operator: 'a*' },
-    ]);
-  }
-
   getCustomerCallback(data) {
     // totalItems property needs to be filled for pagination to work correctly
     // however we need to force Aurelia to do a dirty check, doing a clone object will do just that
@@ -293,6 +285,14 @@ export class Example5 {
 
   goToLastPage() {
     this.aureliaGrid.paginationService.goToLastPage();
+  }
+
+  setFiltersDynamically() {
+    // we can Set Filters Dynamically (or different filters) afterward through the FilterService
+    this.aureliaGrid.filterService.updateFilters([
+      // { columnId: 'gender', searchTerms: ['male'], operator: OperatorType.equal },
+      { columnId: 'name', searchTerms: ['A'], operator: 'a*' },
+    ]);
   }
 
   /** Dispatched event of a Grid State Changed event */

--- a/src/examples/slickgrid/example5.ts
+++ b/src/examples/slickgrid/example5.ts
@@ -59,7 +59,8 @@ export class Example5 {
   defineGrid() {
     this.columnDefinitions = [
       {
-        id: 'name', name: 'Name', field: 'name', sortable: true, type: FieldType.string,
+        id: 'name', name: 'Name', field: 'name', sortable: true,
+        type: FieldType.string,
         filterable: true,
         filter: {
           model: Filters.compoundInput
@@ -128,6 +129,14 @@ export class Example5 {
     this.status = (isProcessing)
       ? { text: 'processing...', class: 'alert alert-danger' }
       : { text: 'done', class: 'alert alert-success' };
+  }
+
+  setFiltersDynamically() {
+    // we can Set Filters Dynamically (or different filters) afterward through the FilterService
+    this.aureliaGrid.filterService.updateFilters([
+      // { columnId: 'gender', searchTerms: ['male'], operator: OperatorType.equal },
+      { columnId: 'name', searchTerms: ['A'], operator: 'a*' },
+    ]);
   }
 
   getCustomerCallback(data) {

--- a/src/examples/slickgrid/example6.html
+++ b/src/examples/slickgrid/example6.html
@@ -14,6 +14,9 @@
         <i class="fa fa-filter text-danger"></i>
         Clear all Filter & Sorts
       </button>
+      <button class="btn btn-default btn-sm" click.delegate="setFiltersDynamically()">
+        Set Filters Dynamically
+      </button>
       <button class="btn btn-default btn-sm" click.delegate="switchLanguage()">
         <i class="fa fa-language"></i>
         Switch Language

--- a/src/examples/slickgrid/example6.html
+++ b/src/examples/slickgrid/example6.html
@@ -14,7 +14,7 @@
         <i class="fa fa-filter text-danger"></i>
         Clear all Filter & Sorts
       </button>
-      <button class="btn btn-default btn-sm" click.delegate="setFiltersDynamically()">
+      <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" click.delegate="setFiltersDynamically()">
         Set Filters Dynamically
       </button>
       <button class="btn btn-default btn-sm" click.delegate="switchLanguage()">

--- a/src/examples/slickgrid/example6.ts
+++ b/src/examples/slickgrid/example6.ts
@@ -100,9 +100,9 @@ export class Example6 {
           } as MultipleSelectOption
         }
       },
-      { id: 'billing.address.street', field: 'billing.address.street', headerKey: 'BILLING.ADDRESS.STREET', width: 60, filterable: true, sortable: true },
+      { id: 'billingAddressStreet', field: 'billing.address.street', headerKey: 'BILLING.ADDRESS.STREET', width: 60, filterable: true, sortable: true },
       {
-        id: 'billing.address.zip', field: 'billing.address.zip', headerKey: 'BILLING.ADDRESS.ZIP', width: 60,
+        id: 'billingAddressZip', field: 'billing.address.zip', headerKey: 'BILLING.ADDRESS.ZIP', width: 60,
         type: FieldType.number,
         filterable: true, sortable: true,
         filter: {
@@ -141,8 +141,8 @@ export class Example6 {
           { columnId: 'name', width: 100 },
           { columnId: 'gender', width: 55 },
           { columnId: 'company' },
-          { columnId: 'billing.address.zip' }, // flip column position of Street/Zip to Zip/Street
-          { columnId: 'billing.address.street', width: 120 },
+          { columnId: 'billingAddressZip' }, // flip column position of Street/Zip to Zip/Street
+          { columnId: 'billingAddressStreet', width: 120 },
           { columnId: 'finish', width: 130 },
         ],
         filters: [
@@ -265,7 +265,7 @@ export class Example6 {
       { columnId: 'gender', searchTerms: ['female'], operator: OperatorType.equal },
       { columnId: 'name', searchTerms: ['Jane'], operator: OperatorType.startsWith },
       { columnId: 'company', searchTerms: ['acme'], operator: 'IN' },
-      { columnId: 'billing.address.zip', searchTerms: ['11'], operator: OperatorType.greaterThanOrEqual },
+      { columnId: 'billingAddressZip', searchTerms: ['11'], operator: OperatorType.greaterThanOrEqual },
       { columnId: 'finish', searchTerms: [presetLowestDay, presetHighestDay], operator: OperatorType.rangeInclusive },
     ]);
   }

--- a/src/examples/slickgrid/example6.ts
+++ b/src/examples/slickgrid/example6.ts
@@ -72,7 +72,15 @@ export class Example6 {
 
   defineGrid() {
     this.columnDefinitions = [
-      { id: 'name', field: 'name', headerKey: 'NAME', filterable: true, sortable: true, type: FieldType.string, width: 60 },
+      {
+        id: 'name', field: 'name', headerKey: 'NAME', width: 60,
+        type: FieldType.string,
+        sortable: true,
+        filterable: true,
+        filter: {
+          model: Filters.compoundInput
+        }
+      },
       {
         id: 'gender', field: 'gender', headerKey: 'GENDER', filterable: true, sortable: true, width: 60,
         filter: {
@@ -246,6 +254,20 @@ export class Example6 {
 
   saveCurrentGridState() {
     console.log('GraphQL current grid state', this.aureliaGrid.gridStateService.getCurrentGridState());
+  }
+
+  setFiltersDynamically() {
+    const presetLowestDay = moment().add(-2, 'days').format('YYYY-MM-DD');
+    const presetHighestDay = moment().add(20, 'days').format('YYYY-MM-DD');
+
+    // we can Set Filters Dynamically (or different filters) afterward through the FilterService
+    this.aureliaGrid.filterService.updateFilters([
+      { columnId: 'gender', searchTerms: ['female'], operator: OperatorType.equal },
+      { columnId: 'name', searchTerms: ['Jane'], operator: OperatorType.startsWith },
+      { columnId: 'company', searchTerms: ['acme'], operator: 'IN' },
+      { columnId: 'billing.address.zip', searchTerms: ['11'], operator: OperatorType.greaterThanOrEqual },
+      { columnId: 'finish', searchTerms: [presetLowestDay, presetHighestDay], operator: OperatorType.rangeInclusive },
+    ]);
   }
 
   switchLanguage() {

--- a/test/cypress/integration/example23.spec.js
+++ b/test/cypress/integration/example23.spec.js
@@ -1,9 +1,10 @@
 /// <reference types="cypress" />
-
 import moment from 'moment-mini';
 
 const presetMinComplete = 5;
-const presetMaxComplete = 88;
+const presetMaxComplete = 80;
+const presetMinDuration = 4;
+const presetMaxDuration = 88;
 const presetLowestDay = moment().add(-2, 'days').format('YYYY-MM-DD');
 const presetHighestDay = moment().add(20, 'days').format('YYYY-MM-DD');
 
@@ -51,9 +52,8 @@ describe('Example 23 - Range Filters', () => {
           .each(($cell) => {
             const value = parseInt($cell.text().trim(), 10);
             if (!isNaN(value)) {
-              console.log('duration', value, presetMinComplete, presetMaxComplete, value > presetMinComplete, value < presetMaxComplete)
-              expect(value > presetMinComplete).to.eq(true);
-              expect(value < presetMaxComplete).to.eq(true);
+              expect(value > presetMinDuration).to.eq(true);
+              expect(value < presetMaxDuration).to.eq(true);
             }
           });
       });
@@ -117,7 +117,6 @@ describe('Example 23 - Range Filters', () => {
       });
   });
 
-
   xit('should change the "Finish" date in the picker and expect all rows to be within new dates range', () => {
     cy.contains('Clear Filters')
       .click({ force: true });
@@ -146,5 +145,69 @@ describe('Example 23 - Range Filters', () => {
             expect(isDateBetween).to.eq(true);
           });
       });
+  });
+
+  describe('Set Dymamic Filters', () => {
+    const dynamicMinComplete = 12;
+    const dynamicMaxComplete = 82;
+    const dynamicMinDuration = 14;
+    const dynamicMaxDuration = 78;
+    const dynamicLowestDay = moment().add(-5, 'days').format('YYYY-MM-DD');
+    const dynamicHighestDay = moment().add(25, 'days').format('YYYY-MM-DD');
+
+    it('should click on Set Dynamic Filters', () => {
+      cy.get('[data-test=set-dynamic-filter]')
+        .click();
+    });
+
+    it('should have "% Complete" fields within the exclusive range of the filters presets', () => {
+      cy.get('#grid23')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(2)')
+            .each(($cell) => {
+              const value = parseInt($cell.text().trim(), 10);
+              if (!isNaN(value)) {
+                expect(value > dynamicMinComplete).to.eq(true);
+                expect(value < dynamicMaxComplete).to.eq(true);
+              }
+            });
+        });
+    });
+
+    it('should have "Duration" fields within the inclusive range of the dynamic filters', () => {
+      cy.get('#grid23')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(5)')
+            .each(($cell) => {
+              const value = parseInt($cell.text().trim(), 10);
+              if (!isNaN(value)) {
+                expect(value >= dynamicMinDuration).to.eq(true);
+                expect(value <= dynamicMaxDuration).to.eq(true);
+              }
+            });
+        });
+    });
+
+    it('should have Finish Dates within the range (inclusive) of the dynamic filters', () => {
+      cy.get('.search-filter.filter-finish')
+        .find('input')
+        .invoke('val')
+        .then(text => expect(text).to.eq(`${dynamicLowestDay} to ${dynamicHighestDay}`));
+
+      cy.get('#grid23')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(4)')
+            .each(($cell) => {
+              const isDateBetween = moment($cell.text()).isBetween(dynamicLowestDay, dynamicHighestDay, null, '[]'); // [] is inclusive, () is exclusive
+              expect(isDateBetween).to.eq(true);
+            });
+        });
+    });
   });
 });

--- a/test/cypress/integration/example4.spec.js
+++ b/test/cypress/integration/example4.spec.js
@@ -1,0 +1,108 @@
+/// <reference types="cypress" />
+import moment from 'moment-mini';
+
+describe('Example 4 - Client Side Sort/Filter Grid', () => {
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example4`);
+    cy.get('h2').should('contain', 'Example 4: Client Side Sort/Filter');
+  });
+
+  describe('Load Grid with Presets', () => {
+    const presetDurationValues = [220, 10];
+    const presetUsDateShort = '04/20/25';
+
+    it('should have "Duration" fields within the inclusive range of the preset filters', () => {
+      cy.get('#grid4')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(2)')
+            .each(($cell) => {
+              const value = parseInt($cell.text().trim(), 10);
+              if (!isNaN(value)) {
+                const foundItems = presetDurationValues.filter(acceptedValue => acceptedValue === value);
+                expect(foundItems).to.have.length(1);
+              }
+            });
+        });
+    });
+
+    it('should have US Date Short within the range of the preset filters', () => {
+      cy.get('.search-filter.filter-usDateShort')
+        .find('input')
+        .invoke('val')
+        .then(text => expect(text).to.eq(presetUsDateShort));
+
+      cy.get('#grid4')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(5)')
+            .each(($cell) => {
+              const isDateValid = moment($cell.text(), 'M/D/YY').isBefore(presetUsDateShort);
+              expect(isDateValid).to.eq(true);
+            });
+        });
+    });
+  });
+
+  describe('Set Dymamic Filters', () => {
+    const dynamicDurationValues = [2, 25, 48, 50];
+    const dynamicMaxComplete = 95;
+    const dynamicStartDate = '2001-02-28';
+
+    it('should click on Set Dynamic Filters', () => {
+      cy.get('[data-test=set-dynamic-filter]')
+        .click();
+    });
+
+    it('should have "% Complete" fields within the exclusive range of the filters presets', () => {
+      cy.get('#grid4')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(3)')
+            .each(($cell) => {
+              const value = parseInt($cell.text().trim(), 10);
+              if (!isNaN(value)) {
+                expect(value < dynamicMaxComplete).to.eq(true);
+              }
+            });
+        });
+    });
+
+    it('should have "Duration" fields within the inclusive range of the dynamic filters', () => {
+      cy.get('#grid4')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(2)')
+            .each(($cell) => {
+              const value = parseInt($cell.text().trim(), 10);
+              if (!isNaN(value)) {
+                const foundItems = dynamicDurationValues.filter(acceptedValue => acceptedValue === value);
+                expect(foundItems).to.have.length(1);
+              }
+            });
+        });
+    });
+
+    it('should have Start Date within the range of the dynamic filters', () => {
+      cy.get('.search-filter.filter-start')
+        .find('input')
+        .invoke('val')
+        .then(text => expect(text).to.eq(dynamicStartDate));
+
+      cy.get('#grid4')
+        .find('.slick-row')
+        .each(($row) => {
+          cy.wrap($row)
+            .children('.slick-cell:nth(4)')
+            .each(($cell) => {
+              const isDateValid = moment($cell.text()).isSameOrAfter(dynamicStartDate);
+              expect(isDateValid).to.eq(true);
+            });
+        });
+    });
+  });
+});

--- a/test/cypress/integration/example5.spec.js
+++ b/test/cypress/integration/example5.spec.js
@@ -258,6 +258,31 @@ describe('Example 5 - OData Grid', () => {
         .find('.slick-row')
         .should('have.length', 1);
     });
+
+    it('should click on Set Dynamic Filter and expect query and filters to be changed', () => {
+      cy.get('[data-test=set-dynamic-filter]')
+        .click();
+
+      cy.get('.search-filter.filter-name select')
+        .should('have.value', 'a*')
+
+      cy.get('.search-filter.filter-name')
+        .find('input')
+        .invoke('val')
+        .then(text => expect(text).to.eq('A'));
+
+      // wait for the query to finish
+      cy.get('[data-test=status]').should('contain', 'done');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$count=true&$top=10&$filter=(startswith(Name, 'A'))`);
+        });
+
+      cy.get('#grid5')
+        .find('.slick-row')
+        .should('have.length', 5);
+    });
   });
 
   describe('when "enableCount" is unchecked (not set)', () => {
@@ -362,6 +387,31 @@ describe('Example 5 - OData Grid', () => {
         .should(($span) => {
           expect($span.text()).to.eq(`$top=10&$skip=90`);
         });
+    });
+
+    it('should click on Set Dynamic Filter and expect query and filters to be changed', () => {
+      cy.get('[data-test=set-dynamic-filter]')
+        .click();
+
+      cy.get('.search-filter.filter-name select')
+        .should('have.value', 'a*')
+
+      cy.get('.search-filter.filter-name')
+        .find('input')
+        .invoke('val')
+        .then(text => expect(text).to.eq('A'));
+
+      // wait for the query to finish
+      cy.get('[data-test=status]').should('contain', 'done');
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$filter=(startswith(Name, 'A'))`);
+        });
+
+      cy.get('#grid5')
+        .find('.slick-row')
+        .should('have.length', 5);
     });
 
     it('should use "substringof" when OData version is set to 2', () => {

--- a/test/cypress/package.json
+++ b/test/cypress/package.json
@@ -11,7 +11,7 @@
   "author": "Ghislain B.",
   "license": "MIT",
   "devDependencies": {
-    "cypress": "^3.6.0",
+    "cypress": "^3.6.1",
     "mocha": "^5.2.0",
     "mochawesome": "^3.1.2",
     "mochawesome-merge": "^1.0.7",


### PR DESCRIPTION
- prior to this change, we could update filters only through "presets" but that was only on first page load. Now with this new change we will be able to update filters on the fly at any time

- [x] POC (Proof of Concept)
- [x] Should work with Regular Grid (JSON dataset)
- [x] Should work with Backend Services (OData & GraphQL)
- [x] Add Unit Tests
- [x] Update demos
- [x] Add Cypress E2E tests
- [ ] Update [filter](https://github.com/ghiscoding/aurelia-slickgrid/wiki/Input-Filter) Wiki