### PR TITLE
feat(sorting): provide method to apply grid sorting dynamically

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid-constructor.spec.ts
+++ b/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid-constructor.spec.ts
@@ -137,7 +137,7 @@ const sortServiceStub = {
   bindBackendOnSort: jest.fn(),
   bindLocalOnSort: jest.fn(),
   dispose: jest.fn(),
-  loadLocalGridPresets: jest.fn(),
+  loadGridSorters: jest.fn(),
 } as unknown as SortService;
 
 const mockGroupItemMetaProvider = {
@@ -543,9 +543,9 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
         expect(spy).toHaveBeenNthCalledWith(2, 'onDataviewCreated', expect.any(Object));
       });
 
-      it('should call the "executeAfterDataviewCreated" and "loadLocalGridPresets" methods and Sorter Presets are provided in the Grid Options', () => {
+      it('should call the "executeAfterDataviewCreated" and "loadGridSorters" methods and Sorter Presets are provided in the Grid Options', () => {
         const eaSpy = jest.spyOn(ea, 'publish');
-        const sortSpy = jest.spyOn(sortServiceStub, 'loadLocalGridPresets');
+        const sortSpy = jest.spyOn(sortServiceStub, 'loadGridSorters');
 
         customElement.gridOptions = { presets: { sorters: [{ columnId: 'field1', direction: 'DESC' }] } } as GridOption;
         customElement.bind();

--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -617,7 +617,7 @@ export class AureliaSlickgridCustomElement {
     // if user entered some Sort "presets", we need to reflect them all in the DOM
     if (gridOptions.enableSorting) {
       if (gridOptions.presets && Array.isArray(gridOptions.presets.sorters) && gridOptions.presets.sorters.length > 0) {
-        this.sortService.loadLocalGridPresets(grid, dataView);
+        this.sortService.loadGridSorters(gridOptions.presets.sorters);
       }
     }
   }

--- a/src/aurelia-slickgrid/services/__tests__/filter.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/filter.service.spec.ts
@@ -918,7 +918,7 @@ describe('FilterService', () => {
         service.bindLocalOnFilter(gridStub, dataViewStub);
         service.updateFilters([{ columnId: 'firstName', searchTerms: ['John'] }]);
       } catch (e) {
-        expect(e.toString()).toContain('[Aurelia-Slickgrid] in order to use "updateFilters" method, you need to have Filters defined in your grid');
+        expect(e.toString()).toContain('[Aurelia-Slickgrid] in order to use "updateFilters" method, you need to have Filterable Columns defined in your grid');
         done();
       }
     });

--- a/src/aurelia-slickgrid/services/__tests__/filter.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/filter.service.spec.ts
@@ -1,9 +1,9 @@
 // import 3rd party lib multiple-select for the tests
 import '../../../assets/lib/multiple-select/multiple-select';
 
+import 'jest-extended';
 import { EventAggregator } from 'aurelia-event-aggregator';
 import { Container, DOM } from 'aurelia-framework';
-import 'jest-extended';
 
 import {
   BackendService,
@@ -19,6 +19,11 @@ import { FilterService } from '../filter.service';
 import { FilterFactory } from '../../filters/filterFactory';
 import { SlickgridConfig } from '../../slickgrid-config';
 import { SharedService } from '../shared.service';
+import * as utilities from '../../services/backend-utilities';
+
+const mockRefreshBackendDataset = jest.fn();
+// @ts-ignore
+utilities.refreshBackendDataset = mockRefreshBackendDataset;
 
 jest.mock('flatpickr', () => { });
 declare var Slick: any;
@@ -964,6 +969,8 @@ describe('FilterService', () => {
         firstName: { columnId: 'firstName', columnDef: mockColumn1, searchTerms: ['Jane'], operator: 'StartsWith' },
         isActive: { columnId: 'isActive', columnDef: mockColumn2, searchTerms: [false], operator: 'EQ' }
       });
+      expect(clearSpy).toHaveBeenCalledWith(false);
+      expect(mockRefreshBackendDataset).toHaveBeenCalledWith(gridOptionMock);
     });
   });
 });

--- a/src/aurelia-slickgrid/services/__tests__/sort.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/sort.service.spec.ts
@@ -370,7 +370,7 @@ describe('SortService', () => {
     });
   });
 
-  describe('loadLocalGridPresets method', () => {
+  describe('loadGridSorters method', () => {
     const mockColumns = [{ id: 'firstName', field: 'firstName' }, { id: 'lastName', field: 'lastName' }] as Column[];
 
     beforeEach(() => {
@@ -389,7 +389,7 @@ describe('SortService', () => {
       ];
 
       service.bindLocalOnSort(gridStub, dataViewStub);
-      service.loadLocalGridPresets(gridStub, dataViewStub);
+      service.loadGridSorters(gridOptionMock.presets.sorters);
 
       expect(spySetCols).toHaveBeenCalledWith(expectation);
       expect(spySortChanged).toHaveBeenCalledWith(gridStub, dataViewStub, expectation);
@@ -405,7 +405,7 @@ describe('SortService', () => {
       gridStub.getColumns = undefined;
 
       service.bindLocalOnSort(gridStub, dataViewStub);
-      service.loadLocalGridPresets(gridStub, dataViewStub);
+      service.loadGridSorters(gridOptionMock.presets.sorters);
 
       expect(spySetCols).not.toHaveBeenCalled();
     });
@@ -415,7 +415,7 @@ describe('SortService', () => {
       gridStub.getOptions = undefined;
 
       service.bindLocalOnSort(gridStub, dataViewStub);
-      service.loadLocalGridPresets(gridStub, dataViewStub);
+      service.loadGridSorters(gridOptionMock.presets.sorters);
 
       expect(spySetCols).not.toHaveBeenCalled();
     });

--- a/src/aurelia-slickgrid/services/__tests__/sort.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/sort.service.spec.ts
@@ -12,8 +12,13 @@ import {
 } from '../../models';
 import { Sorters } from '../../sorters';
 import { SortService } from '../sort.service';
+import * as utilities from '../../services/backend-utilities';
 
 declare var Slick: any;
+
+const mockRefreshBackendDataset = jest.fn();
+// @ts-ignore
+utilities.refreshBackendDataset = mockRefreshBackendDataset;
 
 const gridOptionMock = {
   enablePagination: true,
@@ -32,10 +37,12 @@ const dataViewStub = {
 };
 
 const backendServiceStub = {
+  buildQuery: jest.fn(),
   clearSorters: jest.fn(),
   getCurrentFilters: jest.fn(),
   getCurrentPagination: jest.fn(),
   getCurrentSorters: jest.fn(),
+  updateSorters: jest.fn(),
   processOnSortChanged: (event: Event, args: SortChangedArgs) => 'backend query',
 } as unknown as BackendService;
 
@@ -556,6 +563,68 @@ describe('SortService', () => {
         { firstName: 'Erla', lastName: 'Richard', age: 101, address: { zip: 444444 } },
         { firstName: 'Christopher', lastName: 'McDonald', age: 40, address: { zip: 555555 } },
       ]);
+    });
+  });
+
+  describe('updateSorting method', () => {
+    let mockColumn1: Column;
+    let mockColumn2: Column;
+    let mockNewSorters: CurrentSorter[];
+
+    beforeEach(() => {
+      gridStub.getOptions = () => gridOptionMock;
+      gridOptionMock.enableSorting = true;
+      gridOptionMock.backendServiceApi = undefined;
+
+      mockNewSorters = [
+        { columnId: 'firstName', direction: 'ASC' },
+        { columnId: 'isActive', direction: 'desc' }
+      ];
+      mockColumn1 = { id: 'firstName', name: 'firstName', field: 'firstName', sortable: true };
+      mockColumn2 = { id: 'isActive', name: 'isActive', field: 'isActive', sortable: true };
+      gridStub.getColumns = jest.fn();
+      jest.spyOn(gridStub, 'getColumns').mockReturnValue([mockColumn1, mockColumn2]);
+    });
+
+    it('should throw an error when there are no filters defined in the column definitions', (done) => {
+      try {
+        gridOptionMock.enableSorting = false;
+        service.bindLocalOnSort(gridStub, dataViewStub);
+        service.updateSorting([{ columnId: 'firstName', direction: 'ASC' }]);
+      } catch (e) {
+        expect(e.toString()).toContain('[Aurelia-Slickgrid] in order to use "updateSorting" method, you need to have Sortable Columns defined in your grid');
+        done();
+      }
+    });
+
+    it('should trigger an "emitSortChanged" local when using "bindLocalOnSort" and also expect sorters to be set in ColumnFilters', () => {
+      const emitSpy = jest.spyOn(service, 'emitSortChanged');
+
+      service.bindLocalOnSort(gridStub, dataViewStub);
+      service.updateSorting(mockNewSorters);
+
+      expect(emitSpy).toHaveBeenCalledWith('local');
+      expect(service.getCurrentLocalSorters()).toEqual([
+        { columnId: 'firstName', direction: 'ASC' },
+        { columnId: 'isActive', direction: 'DESC' }
+      ]);
+    });
+
+    it('should trigger an "emitSortChanged" remote when using "bindLocalOnSort" and also expect sorters to be set in ColumnFilters', () => {
+      gridOptionMock.backendServiceApi = {
+        service: backendServiceStub,
+        process: () => new Promise((resolve) => resolve(jest.fn())),
+      };
+      const emitSpy = jest.spyOn(service, 'emitSortChanged');
+      const backendUpdateSpy = jest.spyOn(backendServiceStub, 'updateSorters');
+
+      service.bindLocalOnSort(gridStub, dataViewStub);
+      service.updateSorting(mockNewSorters);
+
+      expect(emitSpy).toHaveBeenCalledWith('remote');
+      expect(service.getCurrentLocalSorters()).toEqual([]);
+      expect(backendUpdateSpy).toHaveBeenCalledWith(undefined, mockNewSorters);
+      expect(mockRefreshBackendDataset).toHaveBeenCalledWith(gridOptionMock);
     });
   });
 });

--- a/src/aurelia-slickgrid/services/filter.service.ts
+++ b/src/aurelia-slickgrid/services/filter.service.ts
@@ -1,5 +1,8 @@
 import { singleton, inject } from 'aurelia-framework';
 import { EventAggregator } from 'aurelia-event-aggregator';
+import * as $ from 'jquery';
+import * as isequal from 'lodash.isequal';
+
 import { FilterConditions } from './../filter-conditions/index';
 import { FilterFactory } from './../filters/index';
 import {
@@ -24,8 +27,6 @@ import {
 import { executeBackendCallback, refreshBackendDataset } from './backend-utilities';
 import { getDescendantProperty } from './utilities';
 import { SharedService } from './shared.service';
-import * as $ from 'jquery';
-import * as isequal from 'lodash.isequal';
 
 // using external non-typed js libraries
 declare var Slick: any;
@@ -482,7 +483,7 @@ export class FilterService {
   /** Update any filter(s) dynamically */
   updateFilters(filters: CurrentFilter[]) {
     if (!this._filtersMetadata || this._filtersMetadata.length === 0 || !this._gridOptions || !this._gridOptions.enableFiltering) {
-      throw new Error('[Aurelia-Slickgrid] in order to use "updateFilters" method, you need to have Filters defined in your grid and "enableFiltering" set in your Grid Options');
+      throw new Error('[Aurelia-Slickgrid] in order to use "updateFilters" method, you need to have Filterable Columns defined in your grid and "enableFiltering" set in your Grid Options');
     }
 
     if (Array.isArray(filters)) {

--- a/src/aurelia-slickgrid/services/sort.service.ts
+++ b/src/aurelia-slickgrid/services/sort.service.ts
@@ -189,19 +189,19 @@ export class SortService {
     const sortCols: ColumnSort[] = [];
 
     if (Array.isArray(sorters)) {
-      sorters.forEach((presetSorting: CurrentSorter) => {
-        const gridColumn = this._columnDefinitions.find((col: Column) => col.id === presetSorting.columnId);
+      sorters.forEach((sorter: CurrentSorter) => {
+        const gridColumn = this._columnDefinitions.find((col: Column) => col.id === sorter.columnId);
         if (gridColumn) {
           sortCols.push({
             columnId: gridColumn.id,
-            sortAsc: ((presetSorting.direction.toUpperCase() === SortDirection.ASC) ? true : false),
+            sortAsc: ((sorter.direction.toUpperCase() === SortDirection.ASC) ? true : false),
             sortCol: gridColumn
           });
 
           // keep current sorters
           this._currentLocalSorters.push({
             columnId: gridColumn.id + '',
-            direction: presetSorting.direction.toUpperCase() as SortDirectionString
+            direction: sorter.direction.toUpperCase() as SortDirectionString
           });
         }
       });

--- a/src/aurelia-slickgrid/services/sort.service.ts
+++ b/src/aurelia-slickgrid/services/sort.service.ts
@@ -183,11 +183,35 @@ export class SortService {
     return [];
   }
 
-  /** Load any presets, if there are any, that are defined in the Grid Options */
-  loadLocalGridPresets() {
-    const sorters = this._gridOptions && this._gridOptions.presets && this._gridOptions.presets.sorters;
+  /** Load defined Sorting (sorters) into the grid */
+  loadGridSorters(sorters: CurrentSorter[]): ColumnSort[] {
+    this._currentLocalSorters = []; // reset current local sorters
+    const sortCols: ColumnSort[] = [];
+
     if (Array.isArray(sorters)) {
-      this.loadGridSorting(sorters);
+      sorters.forEach((presetSorting: CurrentSorter) => {
+        const gridColumn = this._columnDefinitions.find((col: Column) => col.id === presetSorting.columnId);
+        if (gridColumn) {
+          sortCols.push({
+            columnId: gridColumn.id,
+            sortAsc: ((presetSorting.direction.toUpperCase() === SortDirection.ASC) ? true : false),
+            sortCol: gridColumn
+          });
+
+          // keep current sorters
+          this._currentLocalSorters.push({
+            columnId: gridColumn.id + '',
+            direction: presetSorting.direction.toUpperCase() as SortDirectionString
+          });
+        }
+      });
+
+      if (sortCols.length > 0) {
+        this.onLocalSortChanged(this._grid, this._dataView, sortCols);
+        this._grid.setSortColumns(sortCols); // use this to add sort icon(s) in UI
+      }
+
+      return sortCols;
     }
   }
 
@@ -287,44 +311,8 @@ export class SortService {
         this.emitSortChanged(EmitterType.remote);
       }
     } else {
-      this.loadGridSorting(sorters);
+      this.loadGridSorters(sorters);
       this.emitSortChanged(EmitterType.local);
-    }
-  }
-
-  // --
-  // private functions
-  // -------------------
-
-  /** Load a defined Sort into the grid */
-  private loadGridSorting(sorters: CurrentSorter[]): ColumnSort[] {
-    this._currentLocalSorters = []; // reset current local sorters
-    const sortCols: ColumnSort[] = [];
-
-    if (Array.isArray(sorters)) {
-      sorters.forEach((presetSorting: CurrentSorter) => {
-        const gridColumn = this._columnDefinitions.find((col: Column) => col.id === presetSorting.columnId);
-        if (gridColumn) {
-          sortCols.push({
-            columnId: gridColumn.id,
-            sortAsc: ((presetSorting.direction.toUpperCase() === SortDirection.ASC) ? true : false),
-            sortCol: gridColumn
-          });
-
-          // keep current sorters
-          this._currentLocalSorters.push({
-            columnId: gridColumn.id + '',
-            direction: presetSorting.direction.toUpperCase() as SortDirectionString
-          });
-        }
-      });
-
-      if (sortCols.length > 0) {
-        this.onLocalSortChanged(this._grid, this._dataView, sortCols);
-        this._grid.setSortColumns(sortCols); // use this to add sort icon(s) in UI
-      }
-
-      return sortCols;
     }
   }
 }

--- a/src/examples/slickgrid/example18.html
+++ b/src/examples/slickgrid/example18.html
@@ -40,6 +40,9 @@
       <button class="btn btn-default btn-xs" data-test="set-dynamic-filter" click.delegate="setFiltersDynamically()">
         Set Filters Dynamically
       </button>
+      <button class="btn btn-default btn-xs" data-test="set-dynamic-sorting" click.delegate="setSortingDynamically()">
+        Set Sorting Dynamically
+      </button>
     </div>
 
     <div class="col-sm-12">
@@ -51,7 +54,7 @@
         <label for="field1" class="col-sm-2 control-label">Group by field(s)</label>
         <div class="col-sm-3" repeat.for="groupField of selectedGroupingFields">
           <select class="form-control col-sm-6" change.delegate="groupByFieldName(column.id, $index)"
-            value.bind="selectedGroupingFields[$index]">
+                  value.bind="selectedGroupingFields[$index]">
             <option model.bind="''">...</option>
             <option model.bind="column.id" repeat.for="column of columnDefinitions">${column.name}</option>
           </select>
@@ -64,6 +67,6 @@
   </div>
 
   <aurelia-slickgrid grid-id="grid1" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
-    dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)">
+                     dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)">
   </aurelia-slickgrid>
 </template>

--- a/src/examples/slickgrid/example18.ts
+++ b/src/examples/slickgrid/example18.ts
@@ -360,6 +360,13 @@ export class Example18 {
     ]);
   }
 
+  setSortingDynamically() {
+    this.aureliaGrid.sortService.updateSorting([
+      // orders matter, whichever is first in array will be the first sorted column
+      { columnId: 'percentComplete', direction: 'ASC' },
+    ]);
+  }
+
   toggleDraggableGroupingRow() {
     this.clearGroupsAndSelects();
     this.gridObj.setPreHeaderPanelVisibility(!this.gridObj.getOptions().showPreHeaderPanel);

--- a/src/examples/slickgrid/example23.html
+++ b/src/examples/slickgrid/example23.html
@@ -15,16 +15,19 @@
   <b>Locale:</b> <span style="font-style: italic" data-test="selected-locale">${selectedLanguage + '.json'}</span>
 
   <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.filterService.clearFilters()"
-    data-test="clear-filter-button">Clear Filters
+          data-test="clear-filter-button">Clear Filters
   </button>
   <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.sortService.clearSorting()">Clear Sorting</button>
   <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" click.delegate="setFiltersDynamically()">
     Set Filters Dynamically
   </button>
+  <button class="btn btn-default btn-sm" data-test="set-dynamic-sorting" click.delegate="setSortingDynamically()">
+    Set Sorting Dynamically
+  </button>
 
   <aurelia-slickgrid grid-id="grid23" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
-    dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
-    asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)"
-    sg-on-row-count-changed.delegate="refreshMetrics($event.detail.eventData, $event.detail.args)">
+                     dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
+                     asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)"
+                     sg-on-row-count-changed.delegate="refreshMetrics($event.detail.eventData, $event.detail.args)">
   </aurelia-slickgrid>
 </template>

--- a/src/examples/slickgrid/example23.html
+++ b/src/examples/slickgrid/example23.html
@@ -14,10 +14,14 @@
   </button>
   <b>Locale:</b> <span style="font-style: italic" data-test="selected-locale">${selectedLanguage + '.json'}</span>
 
-  <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.filterService.clearFilters()"
-          data-test="clear-filter-button">Clear Filters
+  <button class="btn btn-default btn-sm" data-test="clear-filters"
+          click.delegate="aureliaGrid.filterService.clearFilters()">
+    Clear Filters
   </button>
-  <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.sortService.clearSorting()">Clear Sorting</button>
+  <button class="btn btn-default btn-sm" data-test="clear-sorting"
+          click.delegate="aureliaGrid.sortService.clearSorting()">
+    Clear Sorting
+  </button>
   <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" click.delegate="setFiltersDynamically()">
     Set Filters Dynamically
   </button>

--- a/src/examples/slickgrid/example23.ts
+++ b/src/examples/slickgrid/example23.ts
@@ -243,6 +243,14 @@ export class Example23 {
     ]);
   }
 
+  setSortingDynamically() {
+    this.aureliaGrid.sortService.updateSorting([
+      // orders matter, whichever is first in array will be the first sorted column
+      { columnId: 'finish', direction: 'DESC' },
+      { columnId: 'complete', direction: 'ASC' },
+    ]);
+  }
+
   switchLanguage() {
     const nextLocale = (this.selectedLanguage === 'en') ? 'fr' : 'en';
     this.i18n.setLocale(nextLocale).then(() => this.selectedLanguage = nextLocale);

--- a/src/examples/slickgrid/example23.ts
+++ b/src/examples/slickgrid/example23.ts
@@ -238,7 +238,7 @@ export class Example23 {
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.aureliaGrid.filterService.updateFilters([
       { columnId: 'duration', searchTerms: ['14..78'], operator: 'RangeInclusive' },
-      { columnId: 'complete', operator: 'RangeExclusive', searchTerms: [12, 82] },
+      { columnId: 'complete', operator: 'RangeExclusive', searchTerms: [10, 80] },
       { columnId: 'finish', operator: 'RangeInclusive', searchTerms: [presetLowestDay, presetHighestDay] },
     ]);
   }

--- a/src/examples/slickgrid/example4.html
+++ b/src/examples/slickgrid/example4.html
@@ -9,9 +9,14 @@
     items
   </span>
 
-  <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.filterService.clearFilters()">Clear
-    Filters</button>
-  <button class="btn btn-default btn-sm" click.delegate="aureliaGrid.sortService.clearSorting()">Clear Sorting</button>
+  <button class="btn btn-default btn-sm" data-test="clear-filters"
+          click.delegate="aureliaGrid.filterService.clearFilters()">
+    Clear Filters
+  </button>
+  <button class="btn btn-default btn-sm" data-test="clear-sorting"
+          click.delegate="aureliaGrid.sortService.clearSorting()">
+    Clear Sorting
+  </button>
   <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" click.delegate="setFiltersDynamically()">
     Set Filters Dynamically
   </button>

--- a/src/examples/slickgrid/example4.html
+++ b/src/examples/slickgrid/example4.html
@@ -15,10 +15,13 @@
   <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" click.delegate="setFiltersDynamically()">
     Set Filters Dynamically
   </button>
+  <button class="btn btn-default btn-sm" data-test="set-dynamic-sorting" click.delegate="setSortingDynamically()">
+    Set Sorting Dynamically
+  </button>
 
   <aurelia-slickgrid grid-id="grid4" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
-    dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
-    asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)"
-    sg-on-row-count-changed.delegate="refreshMetrics($event.detail.eventData, $event.detail.args)">
+                     dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
+                     asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)"
+                     sg-on-row-count-changed.delegate="refreshMetrics($event.detail.eventData, $event.detail.args)">
   </aurelia-slickgrid>
 </template>

--- a/src/examples/slickgrid/example4.ts
+++ b/src/examples/slickgrid/example4.ts
@@ -210,7 +210,7 @@ export class Example4 {
       // use columnDef searchTerms OR use presets as shown below
       presets: {
         filters: [
-          { columnId: 'duration', searchTerms: [10, 220] },
+          { columnId: 'duration', searchTerms: [10, 98] },
           // { columnId: 'complete', searchTerms: ['5'], operator: '>' },
           { columnId: 'usDateShort', operator: '<', searchTerms: ['4/20/25'] },
           // { columnId: 'effort-driven', searchTerms: [true] }
@@ -276,6 +276,14 @@ export class Example4 {
       { columnId: 'complete', searchTerms: [95], operator: '<' },
       { columnId: 'effort-driven', searchTerms: [true] },
       { columnId: 'start', operator: '>=', searchTerms: ['2001-02-28'] },
+    ]);
+  }
+
+  setSortingDynamically() {
+    this.aureliaGrid.sortService.updateSorting([
+      // orders matter, whichever is first in array will be the first sorted column
+      { columnId: 'duration', direction: 'ASC' },
+      { columnId: 'start', direction: 'DESC' },
     ]);
   }
 

--- a/src/examples/slickgrid/example5.html
+++ b/src/examples/slickgrid/example5.html
@@ -18,6 +18,9 @@
       <button class="btn btn-default btn-sm" data-test="set-dynamic-filter" click.delegate="setFiltersDynamically()">
         Set Filters Dynamically
       </button>
+      <button class="btn btn-default btn-sm" data-test="set-dynamic-sorting" click.delegate="setSortingDynamically()">
+        Set Sorting Dynamically
+      </button>
     </div>
     <div class="col-sm-8">
       <div class="alert alert-info" data-test="alert-odata-query">
@@ -27,16 +30,16 @@
       <span data-test="radioVersion">
         <label class="radio-inline control-label" for="radio2">
           <input type="radio" name="inlineRadioOptions" data-test="version2" id="radio2" checked value.bind="2"
-            click.delegate="setOdataVersion(2)"> 2
+                 click.delegate="setOdataVersion(2)"> 2
         </label>
         <label class="radio-inline control-label" for="radio4">
           <input type="radio" name="inlineRadioOptions" data-test="version4" id="radio4" value.bind="4"
-            click.delegate="setOdataVersion(4)"> 4
+                 click.delegate="setOdataVersion(4)"> 4
         </label>
       </span>
       <label class="checkbox-inline control-label" for="enableCount" style="margin-left: 20px">
         <input type="checkbox" id="enableCount" data-test="enable-count" checked.bind="isCountEnabled"
-          click.delegate="changeCountEnableFlag()">
+               click.delegate="changeCountEnableFlag()">
         <span style="font-weight: bold">Enable Count</span> (add to OData query)
       </label>
     </div>
@@ -52,7 +55,7 @@
   </div>
 
   <aurelia-slickgrid grid-id="grid5" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
-    dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
-    asg-on-grid-state-changed.delegate="gridStateChanged($event)">
+                     dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
+                     asg-on-grid-state-changed.delegate="gridStateChanged($event)">
   </aurelia-slickgrid>
 </template>

--- a/src/examples/slickgrid/example5.ts
+++ b/src/examples/slickgrid/example5.ts
@@ -287,6 +287,11 @@ export class Example5 {
     this.aureliaGrid.paginationService.goToLastPage();
   }
 
+  /** Dispatched event of a Grid State Changed event */
+  gridStateChanged(gridStateChanges: GridStateChange) {
+    console.log('Client sample, Grid State changed:: ', gridStateChanges);
+  }
+
   setFiltersDynamically() {
     // we can Set Filters Dynamically (or different filters) afterward through the FilterService
     this.aureliaGrid.filterService.updateFilters([
@@ -295,9 +300,10 @@ export class Example5 {
     ]);
   }
 
-  /** Dispatched event of a Grid State Changed event */
-  gridStateChanged(gridStateChanges: GridStateChange) {
-    console.log('Client sample, Grid State changed:: ', gridStateChanges);
+  setSortingDynamically() {
+    this.aureliaGrid.sortService.updateSorting([
+      { columnId: 'name', direction: 'DESC' },
+    ]);
   }
 
   // THE FOLLOWING METHODS ARE ONLY FOR DEMO PURPOSES DO NOT USE THIS CODE

--- a/src/examples/slickgrid/example6.html
+++ b/src/examples/slickgrid/example6.html
@@ -10,7 +10,8 @@
           <i class="fa fa-refresh fa-spin fa-lg fa-fw"></i>
         </span>
       </div>
-      <button class="btn btn-default btn-sm" click.delegate="clearAllFiltersAndSorts()">
+      <button class="btn btn-default btn-sm" data-test="clear-filters-sorting"
+              click.delegate="clearAllFiltersAndSorts()">
         <i class="fa fa-filter text-danger"></i>
         Clear all Filter & Sorts
       </button>

--- a/src/examples/slickgrid/example6.html
+++ b/src/examples/slickgrid/example6.html
@@ -36,6 +36,9 @@
         <button class="btn btn-default btn-xs" data-test="goto-last-page" click.delegate="goToLastPage()">
           <i class="fa fa-caret-right fa-lg"></i>
         </button>
+        <button class="btn btn-default btn-sm" data-test="set-dynamic-sorting" click.delegate="setSortingDynamically()">
+          Set Sorting Dynamically
+        </button>
       </div>
     </div>
     <div class="col-sm-7">
@@ -46,8 +49,8 @@
   </div>
 
   <aurelia-slickgrid grid-id="grid6" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
-    dataset.bind="dataset" grid-height="200" grid-width="900"
-    asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
-    asg-on-grid-state-changed.delegate="gridStateChanged($event)">
+                     dataset.bind="dataset" grid-height="200" grid-width="900"
+                     asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
+                     asg-on-grid-state-changed.delegate="gridStateChanged($event)">
   </aurelia-slickgrid>
 </template>

--- a/src/examples/slickgrid/example6.ts
+++ b/src/examples/slickgrid/example6.ts
@@ -270,6 +270,14 @@ export class Example6 {
     ]);
   }
 
+  setSortingDynamically() {
+    this.aureliaGrid.sortService.updateSorting([
+      // orders matter, whichever is first in array will be the first sorted column
+      { columnId: 'billingAddressZip', direction: 'DESC' },
+      { columnId: 'company', direction: 'ASC' },
+    ]);
+  }
+
   switchLanguage() {
     this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
     this.i18n.setLocale(this.selectedLanguage);

--- a/test/cypress/integration/example23.spec.js
+++ b/test/cypress/integration/example23.spec.js
@@ -164,8 +164,8 @@ describe('Example 23 - Range Filters', () => {
   });
 
   describe('Set Dymamic Filters', () => {
-    const dynamicMinComplete = 12;
-    const dynamicMaxComplete = 82;
+    const dynamicMinComplete = 10;
+    const dynamicMaxComplete = 80;
     const dynamicMinDuration = 14;
     const dynamicMaxDuration = 78;
     const dynamicLowestDay = moment().add(-5, 'days').format('YYYY-MM-DD');

--- a/test/cypress/integration/example23.spec.js
+++ b/test/cypress/integration/example23.spec.js
@@ -14,6 +14,22 @@ describe('Example 23 - Range Filters', () => {
     cy.get('h2').should('contain', 'Example 23: Filtering from Range of Search Values');
   });
 
+  it('should expect the grid to be sorted by "% Complete" descending and then by "Duration" ascending', () => {
+    cy.get('#grid23')
+      .get('.slick-header-column:nth(2)')
+      .find('.slick-sort-indicator-desc')
+      .should('have.length', 1)
+      .siblings('.slick-sort-indicator-numbered')
+      .contains('1');
+
+    cy.get('#grid23')
+      .get('.slick-header-column:nth(5)')
+      .find('.slick-sort-indicator-asc')
+      .should('have.length', 1)
+      .siblings('.slick-sort-indicator-numbered')
+      .contains('2');
+  });
+
   it('should have "% Complete" fields within the range (inclusive) of the filters presets', () => {
     cy.get('#grid23')
       .find('.slick-row')
@@ -95,7 +111,7 @@ describe('Example 23 - Range Filters', () => {
     const newMin = 10;
     const newMax = 40;
 
-    cy.get('[data-test=clear-filter-button]')
+    cy.get('[data-test=clear-filters]')
       .click({ force: true });
 
     cy.get('.search-filter.filter-duration')
@@ -208,6 +224,32 @@ describe('Example 23 - Range Filters', () => {
               expect(isDateBetween).to.eq(true);
             });
         });
+    });
+  });
+
+  describe('Set Dynamic Sorting', () => {
+    it('should click on "Clear Filters" then "Set Dynamic Sorting" buttons', () => {
+      cy.get('[data-test=clear-filters]')
+        .click();
+
+      cy.get('[data-test=set-dynamic-sorting]')
+        .click();
+    });
+
+    it('should expect the grid to be sorted by "Duration" ascending and "Start" descending', () => {
+      cy.get('#grid23')
+        .get('.slick-header-column:nth(2)')
+        .find('.slick-sort-indicator-asc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('2');
+
+      cy.get('#grid23')
+        .get('.slick-header-column:nth(4)')
+        .find('.slick-sort-indicator-desc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('1');
     });
   });
 });

--- a/test/cypress/integration/example4.spec.js
+++ b/test/cypress/integration/example4.spec.js
@@ -44,6 +44,36 @@ describe('Example 4 - Client Side Sort/Filter Grid', () => {
             });
         });
     });
+
+    it('should expect the grid to be sorted by "Duration" descending and "% Complete" ascending', () => {
+      cy.get('#grid4')
+        .get('.slick-header-column:nth(2)')
+        .find('.slick-sort-indicator-desc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('1');
+
+      cy.get('#grid4')
+        .get('.slick-header-column:nth(3)')
+        .find('.slick-sort-indicator-asc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('2');
+
+      cy.get('.slick-row')
+        .first()
+        .children('.slick-cell:nth(2)')
+        .should('contain', '98');
+
+      cy.get('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('bottom')
+        .wait(50);
+
+      cy.get('.slick-row')
+        .last()
+        .children('.slick-cell:nth(2)')
+        .should('contain', '10');
+    });
   });
 
   describe('Set Dymamic Filters', () => {
@@ -103,6 +133,56 @@ describe('Example 4 - Client Side Sort/Filter Grid', () => {
               expect(isDateValid).to.eq(true);
             });
         });
+    });
+  });
+
+  describe('Set Dynamic Sorting', () => {
+    it('should click on "Clear Filters" then "Set Dynamic Sorting" buttons', () => {
+      cy.get('[data-test=clear-filters]')
+        .click();
+
+      cy.get('[data-test=set-dynamic-sorting]')
+        .click();
+    });
+
+    it('should expect the grid to be sorted by "Duration" ascending and "Start" descending', () => {
+      cy.get('#grid4')
+        .get('.slick-header-column:nth(2)')
+        .find('.slick-sort-indicator-asc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('1');
+
+      cy.get('#grid4')
+        .get('.slick-header-column:nth(4)')
+        .find('.slick-sort-indicator-desc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('2');
+
+      cy.get('.slick-row')
+        .first()
+        .children('.slick-cell:nth(2)')
+        .should('contain', '0');
+
+      // cy.get('.slick-row')
+      //   .first()
+      //   .children('.slick-cell:nth(4)')
+      //   .should('not.contain', '');
+
+      cy.get('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('bottom')
+        .wait(50);
+
+      cy.get('.slick-row')
+        .last()
+        .children('.slick-cell:nth(2)')
+        .should('contain', '100');
+
+      cy.get('.slick-row')
+        .last()
+        .children('.slick-cell:nth(4)')
+        .should('contain', '');
     });
   });
 });

--- a/test/cypress/integration/example4.spec.js
+++ b/test/cypress/integration/example4.spec.js
@@ -8,7 +8,7 @@ describe('Example 4 - Client Side Sort/Filter Grid', () => {
   });
 
   describe('Load Grid with Presets', () => {
-    const presetDurationValues = [220, 10];
+    const presetDurationValues = [98, 10];
     const presetUsDateShort = '04/20/25';
 
     it('should have "Duration" fields within the inclusive range of the preset filters', () => {

--- a/test/cypress/integration/example5.spec.js
+++ b/test/cypress/integration/example5.spec.js
@@ -486,4 +486,45 @@ describe('Example 5 - OData Grid', () => {
         });
     });
   });
+
+  describe('Set Dynamic Sorting', () => {
+    it('should click on "Set Filters Dynamically" then on "Set Sorting Dynamically"', () => {
+      cy.get('[data-test=set-dynamic-filter]')
+        .click();
+
+      // wait for the query to finish
+      cy.get('[data-test=status]').should('contain', 'processing');
+      cy.get('[data-test=status]').should('contain', 'done');
+
+      cy.get('[data-test=set-dynamic-sorting]')
+        .click();
+
+      cy.get('[data-test=status]').should('contain', 'processing');
+      cy.get('[data-test=status]').should('contain', 'done');
+    });
+
+    it('should expect the grid to be sorted by "Name" descending', () => {
+      cy.get('#grid5')
+        .get('.slick-header-column:nth(1)')
+        .find('.slick-sort-indicator-desc')
+        .should('have.length', 1);
+
+      cy.get('.slick-row')
+        .first()
+        .children('.slick-cell:nth(1)')
+        .should('contain', 'Ayers Hood');
+
+      cy.get('.slick-row')
+        .last()
+        .children('.slick-cell:nth(1)')
+        .should('contain', 'Alexander Foley');
+
+
+
+      cy.get('[data-test=odata-query-result]')
+        .should(($span) => {
+          expect($span.text()).to.eq(`$top=10&$orderby=Name desc&$filter=(startswith(Name, 'A'))`);
+        });
+    });
+  });
 });

--- a/test/cypress/integration/example6.spec.js
+++ b/test/cypress/integration/example6.spec.js
@@ -327,4 +327,42 @@ describe('Example 6 - GraphQL Grid', () => {
           {totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
       });
   });
+
+  describe('Set Dynamic Sorting', () => {
+    it('should click on "Clear All Filters & Sorting" then "Set Dynamic Sorting" buttons', () => {
+      cy.get('[data-test=clear-filters-sorting]')
+        .click();
+
+      cy.get('[data-test=set-dynamic-sorting]')
+        .click();
+
+      // wait for the query to finish
+      cy.get('[data-test=status]').should('contain', 'processing');
+      cy.get('[data-test=status]').should('contain', 'done');
+    });
+
+    it('should expect the grid to be sorted by "Zip" descending then by "Company" ascending', () => {
+      cy.get('#grid6')
+        .get('.slick-header-column:nth(2)')
+        .find('.slick-sort-indicator-asc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('2');
+
+      cy.get('#grid6')
+        .get('.slick-header-column:nth(3)')
+        .find('.slick-sort-indicator-desc')
+        .should('have.length', 1)
+        .siblings('.slick-sort-indicator-numbered')
+        .contains('1');
+
+      cy.get('[data-test=graphql-query-result]')
+        .should(($span) => {
+          const text = removeSpaces($span.text()); // remove all white spaces
+          expect(text).to.eq(removeSpaces(`query{users(first:30,offset:0,
+            orderBy:[{field:"billing.address.zip",direction:DESC},{field:"company",direction:ASC}],locale:"en",userId:123){
+            totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
+        });
+    });
+  });
 });


### PR DESCRIPTION
- prior to this change, we could update Sorting (sorters) only through "presets" the caviat was that it was only on first page load. Now with this new change we will be to update Sorting on the fly at any time.

- [x] POC (Proof of Concept)
- [x] Should work with Regular Grid (JSON dataset)
- [x] Should work with Backend Services (OData & GraphQL)
- [x] Add Unit Tests
- [x] Add Cypress E2E tests
- [x] Update demos
- [ ] Update [sorting](https://github.com/ghiscoding/aurelia-slickgrid/wiki/Sorting) Wiki