### PR TITLE
fix(sort): add sort icons to grouping examples

### DIFF
--- a/src/aurelia-slickgrid/services/__tests__/filter.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/filter.service.spec.ts
@@ -1020,4 +1020,16 @@ describe('FilterService', () => {
       expect(clearSpy).toHaveBeenCalledWith(false);
     });
   });
+
+  describe('setSortColumnIcons method', () => {
+    it('should set the sorting icon by calling "setSortColumns" on the grid object', () => {
+      const mockSortColumns = [{ columnId: 'duration', sortAsc: true }];
+      const spy = jest.spyOn(gridStub, 'setSortColumns');
+
+      service.init(gridStub);
+      service.setSortColumnIcons(mockSortColumns);
+
+      expect(spy).toHaveBeenCalledWith(mockSortColumns);
+    });
+  });
 });

--- a/src/aurelia-slickgrid/services/filter.service.ts
+++ b/src/aurelia-slickgrid/services/filter.service.ts
@@ -483,6 +483,18 @@ export class FilterService {
   }
 
   /**
+   * Set the sort icons in the UI (ONLY the icons, it does not do any sorting)
+   * The column sort icons are not necessarily inter-connected to the sorting functionality itself,
+   * you can change the sorting icons separately by passing an array of columnId/sortAsc and that will change ONLY the icons
+   * @param sortColumns
+   */
+  setSortColumnIcons(sortColumns: { columnId: string, sortAsc: boolean }[]) {
+    if (this._grid && Array.isArray(sortColumns)) {
+      this._grid.setSortColumns(sortColumns);
+    }
+  }
+
+  /**
    * Update Filters dynamically just by providing an array of filter(s).
    * You can also choose emit (default) a Filter Changed event that will be picked by the Grid State Service.
    *

--- a/src/examples/slickgrid/example13.ts
+++ b/src/examples/slickgrid/example13.ts
@@ -234,9 +234,13 @@ export class Example13 {
       aggregateCollapsed: false,
       lazyTotalsCalculation: true
     } as Grouping);
+
+    // you need to manually add the sort icon(s) in UI
+    this.aureliaGrid.filterService.setSortColumnIcons([{ columnId: 'duration', sortAsc: true }]);
   }
 
   groupByDurationOrderByCount(aggregateCollapsed) {
+    this.aureliaGrid.filterService.setSortColumnIcons([]);
     this.dataviewObj.setGrouping({
       getter: 'duration',
       formatter: (g) => `Duration:  ${g.value} <span style="color:green">(${g.count} items)</span>`,
@@ -253,6 +257,7 @@ export class Example13 {
   }
 
   groupByDurationEffortDriven() {
+    this.aureliaGrid.filterService.setSortColumnIcons([]);
     this.dataviewObj.setGrouping([
       {
         getter: 'duration',
@@ -278,6 +283,7 @@ export class Example13 {
   }
 
   groupByDurationEffortDrivenPercent() {
+    this.aureliaGrid.filterService.setSortColumnIcons([]);
     this.dataviewObj.setGrouping([
       {
         getter: 'duration',

--- a/src/examples/slickgrid/example18.ts
+++ b/src/examples/slickgrid/example18.ts
@@ -302,10 +302,14 @@ export class Example18 {
     }
   }
 
-  groupByDurationOrderByCount(isOrderingByCount = false) {
-    this.durationOrderByCount = isOrderingByCount;
+  groupByDurationOrderByCount(sortedByCount = false) {
+    this.durationOrderByCount = sortedByCount;
     this.clearGrouping();
     this.groupByDuration();
+
+    // you need to manually add the sort icon(s) in UI
+    const sortColumns = sortedByCount ? [] : [{ columnId: 'duration', sortAsc: true }];
+    this.aureliaGrid.filterService.setSortColumnIcons(sortColumns);
   }
 
   groupByDurationEffortDriven() {


### PR DESCRIPTION
- when calling grouping and sort, user must manually update the sort icons
- the sort icons are not inter-connected to the sorting itself, they must be set separately, exposing a quick method in the filter service to deal with that