### PR TITLE
fix(graphql): disable pagination should remove any page info from query

### DIFF
--- a/src/aurelia-slickgrid/services/__tests__/graphql.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/graphql.service.spec.ts
@@ -198,7 +198,7 @@ describe('GraphqlService', () => {
     });
 
     it('should exclude pagination from the query string when the option is disabled', () => {
-      const expectation = `query{ users{ totalCount, nodes{ id, field1, field2 }}}`;
+      const expectation = `query{ users{ id, field1, field2 }}`;
       const columns = [{ id: 'field1', field: 'field1', width: 100 }, { id: 'field2', field: 'field2', width: 100 }];
       gridOptionMock.enablePagination = false;
 
@@ -254,7 +254,7 @@ describe('GraphqlService', () => {
       expect(removeSpaces(query)).toBe(removeSpaces(expectation));
     });
 
-    it('should be able to provide "filteringOptions" and see the query string include the sorting', () => {
+    it('should be able to provide "filteringOptions" and see the query string include the filters', () => {
       const expectation = `query{ users(first:20, offset:40,filterBy:[{field:field1, operator: >, value:"2000-10-10"}]){ totalCount, nodes{ id, field1, field2 }}}`;
       const columns = [{ id: 'field1', field: 'field1', width: 100 }, { id: 'field2', field: 'field2', width: 100 }];
 
@@ -263,6 +263,32 @@ describe('GraphqlService', () => {
       const query = service.buildQuery();
 
       expect(removeSpaces(query)).toBe(removeSpaces(expectation));
+    });
+
+    it('should be able to provide "sortingOptions" and see the query string include the sorting but without pagination when that is excluded', () => {
+      const expectation = `query{ users(orderBy:[{field:field1, direction:DESC}]){ id, field1, field2 }}`;
+      const columns = [{ id: 'field1', field: 'field1', width: 100 }, { id: 'field2', field: 'field2', width: 100 }];
+      gridOptionMock.enablePagination = false;
+
+      service.init({ datasetName: 'users', columnDefinitions: columns, sortingOptions: [{ field: 'field1', direction: 'DESC' }] }, paginationOptions, gridStub);
+      service.updatePagination(3, 20);
+      const query = service.buildQuery();
+
+      expect(removeSpaces(query)).toBe(removeSpaces(expectation));
+      gridOptionMock.enablePagination = true; // reset it for the next test
+    });
+
+    it('should be able to provide "filteringOptions" and see the query string include the filters but without pagination when that is excluded', () => {
+      const expectation = `query{ users(filterBy:[{field:field1, operator: >, value:"2000-10-10"}]){ id, field1, field2 }}`;
+      const columns = [{ id: 'field1', field: 'field1', width: 100 }, { id: 'field2', field: 'field2', width: 100 }];
+      gridOptionMock.enablePagination = false;
+
+      service.init({ datasetName: 'users', columnDefinitions: columns, filteringOptions: [{ field: 'field1', operator: '>', value: '2000-10-10' }] }, paginationOptions, gridStub);
+      service.updatePagination(3, 20);
+      const query = service.buildQuery();
+
+      expect(removeSpaces(query)).toBe(removeSpaces(expectation));
+      gridOptionMock.enablePagination = true; // reset it for the next test
     });
 
     it('should include default locale "en" in the query string when option "addLocaleIntoQuery" is enabled and i18n is not defined', () => {

--- a/src/aurelia-slickgrid/services/graphql.service.ts
+++ b/src/aurelia-slickgrid/services/graphql.service.ts
@@ -103,23 +103,27 @@ export class GraphqlService implements BackendService {
       columnIds.unshift('id');
     }
 
-    const filters = this.buildFilterQuery(columnIds);
-    let graphqlFields = [];
+    const columnsQuery = this.buildFilterQuery(columnIds);
+    let graphqlNodeFields = [];
 
-    if (this.options.isWithCursor) {
-      // ...pageInfo { hasNextPage, endCursor }, edges { cursor, node { _filters_ } }
-      const pageInfoQb = new QueryBuilder('pageInfo');
-      pageInfoQb.find('hasNextPage', 'endCursor');
-      dataQb.find(['cursor', { node: filters }]);
-      graphqlFields = ['totalCount', pageInfoQb, dataQb];
+    if (this._gridOptions.enablePagination !== false) {
+      if (this.options.isWithCursor) {
+        // ...pageInfo { hasNextPage, endCursor }, edges { cursor, node { _columns_ } }
+        const pageInfoQb = new QueryBuilder('pageInfo');
+        pageInfoQb.find('hasNextPage', 'endCursor');
+        dataQb.find(['cursor', { node: columnsQuery }]);
+        graphqlNodeFields = ['totalCount', pageInfoQb, dataQb];
+      } else {
+        // ...nodes { _columns_ }
+        dataQb.find(columnsQuery);
+        graphqlNodeFields = ['totalCount', dataQb];
+      }
+      // all properties to be returned by the query
+      datasetQb.find(graphqlNodeFields);
     } else {
-      // ...nodes { _filters_ }
-      dataQb.find(filters);
-      graphqlFields = ['totalCount', dataQb];
+      // include all columns to be returned
+      datasetQb.find(columnsQuery);
     }
-
-    // properties to be returned by the query
-    datasetQb.find(graphqlFields);
 
     // add dataset filters, could be Pagination and SortingFilters and/or FieldFilters
     let datasetFilters: GraphqlDatasetFilter = {};
@@ -155,7 +159,8 @@ export class GraphqlService implements BackendService {
       }
     }
 
-    // query { users(first: 20, orderBy: [], filterBy: [])}
+    // with pagination:: query { users(first: 20, offset: 0, orderBy: [], filterBy: []) { totalCount: 100, nodes: { _columns_ }}}
+    // without pagination:: query { users(orderBy: [], filterBy: []) { _columns_ }}
     datasetQb.filter(datasetFilters);
     queryQb.find(datasetQb);
 

--- a/src/examples/slickgrid/example23.ts
+++ b/src/examples/slickgrid/example23.ts
@@ -195,7 +195,7 @@ export class Example23 {
     for (let i = startingIndex; i < (startingIndex + itemCount); i++) {
       const randomDuration = randomBetween(0, 365);
       const randomYear = randomBetween(moment().year(), moment().year() + 1);
-      const randomMonth = randomBetween(1, 12);
+      const randomMonth = randomBetween(0, 12);
       const randomDay = randomBetween(10, 28);
       const randomPercent = randomBetween(0, 100);
 
@@ -207,7 +207,7 @@ export class Example23 {
         percentComplete: randomPercent,
         percentCompleteNumber: randomPercent,
         start: (i % 4) ? null : new Date(randomYear, randomMonth, randomDay),          // provide a Date format
-        finish: new Date(randomYear, (randomMonth + 1), randomDay),
+        finish: new Date(randomYear, randomMonth, randomDay),
         completed: (randomPercent === 100) ? true : false,
       });
     }


### PR DESCRIPTION
- for example a GraphQL query like this 
  - `query{ users(first:20, offset:40){ totalCount, nodes{ id, field1, field2 }}}` 
- without pagination should simply be
  - `query{ users{ id, field1, field2 }}`