### PR TITLE
break(column): change "headerKey" to "nameKey" to align with column name

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid-constructor.spec.ts
+++ b/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid-constructor.spec.ts
@@ -81,11 +81,9 @@ const extensionServiceStub = {
 } as unknown as ExtensionService;
 
 const mockExtensionUtility = {
-  loadExtensionDynamically: jest.fn()
+  loadExtensionDynamically: jest.fn(),
+  translateItems: jest.fn(),
 } as unknown as ExtensionUtility;
-export class ExtensionUtilityStub {
-  loadExtensionDynamically() { }
-}
 
 const groupingAndColspanServiceStub = {
   init: jest.fn(),

--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -464,6 +464,7 @@ export class AureliaSlickgridCustomElement {
           this.extensionService.translateGridMenu();
           this.extensionService.translateHeaderMenu();
           this.translateCustomFooterTexts();
+          this.translateColumnHeaderTitleKeys();
         }
       })
     );
@@ -943,6 +944,13 @@ export class AureliaSlickgridCustomElement {
         }
       }
     }
+  }
+
+  /** translate all columns (including hidden columns) */
+  private translateColumnHeaderTitleKeys() {
+    // eventually deprecate the "headerKey" and use only the "nameKey"
+    this.extensionUtility.translateItems(this.sharedService.allColumns, 'headerKey', 'name');
+    this.extensionUtility.translateItems(this.sharedService.allColumns, 'nameKey', 'name');
   }
 
   /**

--- a/src/aurelia-slickgrid/extensions/__tests__/cellMenuExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/cellMenuExtension.spec.ts
@@ -43,7 +43,7 @@ Slick.Plugins = {
 };
 
 describe('CellMenuExtension', () => {
-  const columnsMock: Column[] = [{ id: 'field1', field: 'field1', width: 100, headerKey: 'TITLE' }, { id: 'field2', field: 'field2', width: 75 }];
+  const columnsMock: Column[] = [{ id: 'field1', field: 'field1', width: 100, nameKey: 'TITLE' }, { id: 'field2', field: 'field2', width: 75 }];
   let extensionUtility: ExtensionUtility;
   let ea: EventAggregator;
   let i18n: I18N;

--- a/src/aurelia-slickgrid/extensions/__tests__/columnPickerExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/columnPickerExtension.spec.ts
@@ -27,7 +27,7 @@ Slick.Controls = {
 };
 
 describe('columnPickerExtension', () => {
-  const columnsMock: Column[] = [{ id: 'field1', field: 'field1', width: 100, headerKey: 'TITLE' }, { id: 'field2', field: 'field2', width: 75 }];
+  const columnsMock: Column[] = [{ id: 'field1', field: 'field1', width: 100, nameKey: 'TITLE' }, { id: 'field2', field: 'field2', width: 75 }];
   let extensionUtility: ExtensionUtility;
   let i18n: I18N;
   let extension: ColumnPickerExtension;
@@ -155,7 +155,7 @@ describe('columnPickerExtension', () => {
       expect(SharedService.prototype.gridOptions.columnPicker.forceFitTitle).toBe('Ajustement forcé des colonnes');
       expect(SharedService.prototype.gridOptions.columnPicker.syncResizeTitle).toBe('Redimension synchrone');
       expect(columnsMock).toEqual([
-        { id: 'field1', field: 'field1', width: 100, name: 'Titre', headerKey: 'TITLE' },
+        { id: 'field1', field: 'field1', width: 100, name: 'Titre', nameKey: 'TITLE' },
         { id: 'field2', field: 'field2', width: 75 }
       ]);
     });

--- a/src/aurelia-slickgrid/extensions/__tests__/contextMenuExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/contextMenuExtension.spec.ts
@@ -59,7 +59,7 @@ Slick.Plugins = {
 };
 
 describe('contextMenuExtension', () => {
-  const columnsMock: Column[] = [{ id: 'field1', field: 'field1', width: 100, headerKey: 'TITLE' }, { id: 'field2', field: 'field2', width: 75 }];
+  const columnsMock: Column[] = [{ id: 'field1', field: 'field1', width: 100, nameKey: 'TITLE' }, { id: 'field2', field: 'field2', width: 75 }];
   let extensionUtility: ExtensionUtility;
   let ea: EventAggregator;
   let i18n: I18N;

--- a/src/aurelia-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
@@ -73,7 +73,7 @@ const template =
   </div>`;
 
 describe('gridMenuExtension', () => {
-  const columnsMock: Column[] = [{ id: 'field1', field: 'field1', width: 100, headerKey: 'TITLE' }, { id: 'field2', field: 'field2', width: 75 }];
+  const columnsMock: Column[] = [{ id: 'field1', field: 'field1', width: 100, nameKey: 'TITLE' }, { id: 'field2', field: 'field2', width: 75 }];
   let extensionUtility: ExtensionUtility;
   let i18n: I18N;
   let extension: GridMenuExtension;
@@ -699,7 +699,7 @@ describe('gridMenuExtension', () => {
         expect(SharedService.prototype.gridOptions.gridMenu.forceFitTitle).toBe('Ajustement forcé des colonnes');
         expect(SharedService.prototype.gridOptions.gridMenu.syncResizeTitle).toBe('Redimension synchrone');
         expect(columnsMock).toEqual([
-          { id: 'field1', field: 'field1', width: 100, name: 'Titre', headerKey: 'TITLE' },
+          { id: 'field1', field: 'field1', width: 100, name: 'Titre', nameKey: 'TITLE' },
           { id: 'field2', field: 'field2', width: 75 }
         ]);
       });

--- a/src/aurelia-slickgrid/extensions/__tests__/headerMenuExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/headerMenuExtension.spec.ts
@@ -55,7 +55,7 @@ Slick.Plugins = {
 };
 
 describe('headerMenuExtension', () => {
-  const columnsMock: Column[] = [{ id: 'field1', field: 'field1', width: 100, headerKey: 'TITLE' }, { id: 'field2', field: 'field2', width: 75 }];
+  const columnsMock: Column[] = [{ id: 'field1', field: 'field1', width: 100, nameKey: 'TITLE' }, { id: 'field2', field: 'field2', width: 75 }];
   let extensionUtility: ExtensionUtility;
   let ea: EventAggregator;
   let i18n: I18N;
@@ -225,7 +225,7 @@ describe('headerMenuExtension', () => {
     });
 
     describe('addHeaderMenuCustomCommands method', () => {
-      const mockColumn = { id: 'field1', field: 'field1', width: 100, headerKey: 'TITLE', sortable: true, filterable: true } as any;
+      const mockColumn = { id: 'field1', field: 'field1', width: 100, nameKey: 'TITLE', sortable: true, filterable: true } as any;
 
       beforeEach(() => {
         jest.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue([mockColumn]);
@@ -304,7 +304,7 @@ describe('headerMenuExtension', () => {
         const setColumnsSpy = jest.spyOn(gridStub, 'setColumns');
         const visibleSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
         const updatedColumnsMock = [{
-          id: 'field1', field: 'field1', headerKey: 'TITLE', width: 100,
+          id: 'field1', field: 'field1', nameKey: 'TITLE', width: 100,
           header: { menu: { items: [{ command: 'hide', iconCssClass: 'fa fa-times', positionOrder: 55, title: 'Cacher la colonne' }] } }
         }] as Column[];
 

--- a/src/aurelia-slickgrid/extensions/columnPickerExtension.ts
+++ b/src/aurelia-slickgrid/extensions/columnPickerExtension.ts
@@ -84,7 +84,9 @@ export class ColumnPickerExtension implements Extension {
         this.sharedService.gridOptions.columnPicker.syncResizeTitle = this.extensionUtility.getPickerTitleOutputString('syncResizeTitle', 'columnPicker');
       }
       // translate all columns (including hidden columns)
+      // eventually deprecate the "headerKey" and use only the "nameKey"
       this.extensionUtility.translateItems(this.sharedService.allColumns, 'headerKey', 'name');
+      this.extensionUtility.translateItems(this.sharedService.allColumns, 'nameKey', 'name');
 
       // update the Titles of each sections (command, customTitle, ...)
       if (this._addon && this._addon.updateAllTitles) {

--- a/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
@@ -187,7 +187,9 @@ export class GridMenuExtension implements Extension {
       this.sharedService.gridOptions.gridMenu.syncResizeTitle = this.extensionUtility.getPickerTitleOutputString('syncResizeTitle', 'gridMenu');
 
       // translate all columns (including non-visible)
+      // eventually deprecate the "headerKey" and use only the "nameKey"
       this.extensionUtility.translateItems(this.sharedService.allColumns, 'headerKey', 'name');
+      this.extensionUtility.translateItems(this.sharedService.allColumns, 'nameKey', 'name');
 
       // update the Titles of each sections (command, customTitle, ...)
       if (this._addon && this._addon.updateAllTitles) {

--- a/src/aurelia-slickgrid/models/column.interface.ts
+++ b/src/aurelia-slickgrid/models/column.interface.ts
@@ -127,7 +127,7 @@ export interface Column {
   /** CSS class that can be added to the column header */
   headerCssClass?: string;
 
-  /** Column header translation key that can be used by the Translate Service (i18n) */
+  /** @deprecated (please use "nameKey" instead) Column header translation key that can be used by the Translate Service (i18n) */
   headerKey?: string;
 
   /** ID of the column, each row have to be unique or SlickGrid will throw an error. */
@@ -150,6 +150,9 @@ export interface Column {
 
   /** Field Name to be displayed in the Grid (UI) */
   name?: string;
+
+  /** Field Name translation key that can be used by the translate Service (i18n) to display the text for each column header title */
+  nameKey?: string;
 
   /** an event that can be used for triggering an action after a cell change */
   onCellChange?: (e: KeyboardEvent | MouseEvent, args: OnEventArgs) => void;

--- a/src/aurelia-slickgrid/services/__tests__/excelExport.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/excelExport.service.spec.ts
@@ -597,8 +597,8 @@ describe('ExcelExportService', () => {
         mockColumns = [
           { id: 'id', field: 'id', excludeFromExport: true },
           { id: 'userId', field: 'userId', name: 'User Id', width: 100 },
-          { id: 'firstName', headerKey: 'FIRST_NAME', width: 100, formatter: myBoldHtmlFormatter },
-          { id: 'lastName', field: 'lastName', headerKey: 'LAST_NAME', width: 100, formatter: myBoldHtmlFormatter, exportCustomFormatter: myUppercaseFormatter, sanitizeDataExport: true, exportWithFormatter: true },
+          { id: 'firstName', nameKey: 'FIRST_NAME', width: 100, formatter: myBoldHtmlFormatter },
+          { id: 'lastName', field: 'lastName', nameKey: 'LAST_NAME', width: 100, formatter: myBoldHtmlFormatter, exportCustomFormatter: myUppercaseFormatter, sanitizeDataExport: true, exportWithFormatter: true },
           { id: 'position', field: 'position', name: 'Position', width: 100, formatter: Formatters.translate, exportWithFormatter: true },
           { id: 'order', field: 'order', width: 100, exportWithFormatter: true, formatter: Formatters.multiple, params: { formatters: [myBoldHtmlFormatter, myCustomObjectFormatter] } },
         ] as Column[];
@@ -606,7 +606,7 @@ describe('ExcelExportService', () => {
         jest.spyOn(gridStub, 'getColumns').mockReturnValue(mockColumns);
       });
 
-      it(`should have the LastName header title translated when defined as a "headerKey" and "i18n" is set in grid option`, async () => {
+      it(`should have the LastName header title translated when defined as a "nameKey" and "i18n" is set in grid option`, async () => {
         mockCollection = [{ id: 0, userId: '1E06', firstName: 'John', lastName: 'Z', position: 'SALES_REP', order: 10 }];
         jest.spyOn(dataViewStub, 'getLength').mockReturnValue(mockCollection.length);
         jest.spyOn(dataViewStub, 'getItem').mockReturnValue(null).mockReturnValueOnce(mockCollection[0]);
@@ -745,8 +745,8 @@ describe('ExcelExportService', () => {
         mockColumns = [
           { id: 'id', field: 'id', excludeFromExport: true },
           { id: 'userId', field: 'userId', name: 'User Id', width: 100 },
-          { id: 'firstName', field: 'firstName', headerKey: 'FIRST_NAME', width: 100, formatter: myBoldHtmlFormatter },
-          { id: 'lastName', field: 'lastName', headerKey: 'LAST_NAME', width: 100, formatter: myBoldHtmlFormatter, exportCustomFormatter: myUppercaseFormatter, sanitizeDataExport: true, exportWithFormatter: true },
+          { id: 'firstName', field: 'firstName', nameKey: 'FIRST_NAME', width: 100, formatter: myBoldHtmlFormatter },
+          { id: 'lastName', field: 'lastName', nameKey: 'LAST_NAME', width: 100, formatter: myBoldHtmlFormatter, exportCustomFormatter: myUppercaseFormatter, sanitizeDataExport: true, exportWithFormatter: true },
           { id: 'position', field: 'position', name: 'Position', width: 100, formatter: Formatters.translate, exportWithFormatter: true },
           {
             id: 'order', field: 'order', type: FieldType.number,
@@ -843,8 +843,8 @@ describe('ExcelExportService', () => {
         mockColumns = [
           { id: 'id', field: 'id', excludeFromExport: true },
           { id: 'userId', field: 'userId', name: 'User Id', width: 100 },
-          { id: 'firstName', field: 'firstName', headerKey: 'FIRST_NAME', width: 100, formatter: myBoldHtmlFormatter },
-          { id: 'lastName', field: 'lastName', headerKey: 'LAST_NAME', width: 100, formatter: myBoldHtmlFormatter, exportCustomFormatter: myUppercaseFormatter, sanitizeDataExport: true, exportWithFormatter: true },
+          { id: 'firstName', field: 'firstName', nameKey: 'FIRST_NAME', width: 100, formatter: myBoldHtmlFormatter },
+          { id: 'lastName', field: 'lastName', nameKey: 'LAST_NAME', width: 100, formatter: myBoldHtmlFormatter, exportCustomFormatter: myUppercaseFormatter, sanitizeDataExport: true, exportWithFormatter: true },
           { id: 'position', field: 'position', name: 'Position', width: 100, formatter: Formatters.translate },
           {
             id: 'order', field: 'order', type: FieldType.number,

--- a/src/aurelia-slickgrid/services/__tests__/export.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/export.service.spec.ts
@@ -573,8 +573,8 @@ describe('ExportService', () => {
         mockColumns = [
           { id: 'id', field: 'id', excludeFromExport: true },
           { id: 'userId', field: 'userId', name: 'User Id', width: 100, exportCsvForceToKeepAsString: true },
-          { id: 'firstName', headerKey: 'FIRST_NAME', width: 100, formatter: myBoldHtmlFormatter },
-          { id: 'lastName', field: 'lastName', headerKey: 'LAST_NAME', width: 100, formatter: myBoldHtmlFormatter, exportCustomFormatter: myUppercaseFormatter, sanitizeDataExport: true, exportWithFormatter: true },
+          { id: 'firstName', nameKey: 'FIRST_NAME', width: 100, formatter: myBoldHtmlFormatter },
+          { id: 'lastName', field: 'lastName', nameKey: 'LAST_NAME', width: 100, formatter: myBoldHtmlFormatter, exportCustomFormatter: myUppercaseFormatter, sanitizeDataExport: true, exportWithFormatter: true },
           { id: 'position', field: 'position', name: 'Position', width: 100, formatter: Formatters.translate, exportWithFormatter: true },
           { id: 'order', field: 'order', width: 100, exportWithFormatter: true, formatter: Formatters.multiple, params: { formatters: [myBoldHtmlFormatter, myCustomObjectFormatter] } },
         ] as Column[];
@@ -741,8 +741,8 @@ describe('ExportService', () => {
         mockColumns = [
           { id: 'id', field: 'id', excludeFromExport: true },
           { id: 'userId', field: 'userId', name: 'User Id', width: 100, exportCsvForceToKeepAsString: true },
-          { id: 'firstName', field: 'firstName', headerKey: 'FIRST_NAME', width: 100, formatter: myBoldHtmlFormatter },
-          { id: 'lastName', field: 'lastName', headerKey: 'LAST_NAME', width: 100, formatter: myBoldHtmlFormatter, exportCustomFormatter: myUppercaseFormatter, sanitizeDataExport: true, exportWithFormatter: true },
+          { id: 'firstName', field: 'firstName', nameKey: 'FIRST_NAME', width: 100, formatter: myBoldHtmlFormatter },
+          { id: 'lastName', field: 'lastName', nameKey: 'LAST_NAME', width: 100, formatter: myBoldHtmlFormatter, exportCustomFormatter: myUppercaseFormatter, sanitizeDataExport: true, exportWithFormatter: true },
           { id: 'position', field: 'position', name: 'Position', width: 100, formatter: Formatters.translate, exportWithFormatter: true },
           {
             id: 'order', field: 'order', type: FieldType.number,
@@ -856,8 +856,8 @@ describe('ExportService', () => {
         mockColumns = [
           { id: 'id', field: 'id', excludeFromExport: true },
           { id: 'userId', field: 'userId', name: 'User Id', width: 100, exportCsvForceToKeepAsString: true },
-          { id: 'firstName', field: 'firstName', headerKey: 'FIRST_NAME', width: 100, formatter: myBoldHtmlFormatter },
-          { id: 'lastName', field: 'lastName', headerKey: 'LAST_NAME', width: 100, formatter: myBoldHtmlFormatter, exportCustomFormatter: myUppercaseFormatter, sanitizeDataExport: true, exportWithFormatter: true },
+          { id: 'firstName', field: 'firstName', nameKey: 'FIRST_NAME', width: 100, formatter: myBoldHtmlFormatter },
+          { id: 'lastName', field: 'lastName', nameKey: 'LAST_NAME', width: 100, formatter: myBoldHtmlFormatter, exportCustomFormatter: myUppercaseFormatter, sanitizeDataExport: true, exportWithFormatter: true },
           { id: 'position', field: 'position', name: 'Position', width: 100, formatter: Formatters.translate, exportWithFormatter: true },
           {
             id: 'order', field: 'order', type: FieldType.number,

--- a/src/aurelia-slickgrid/services/__tests__/extension.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/extension.service.spec.ts
@@ -193,8 +193,8 @@ describe('ExtensionService', () => {
 
       it('should call "translateItems" method is "enableTranslate" is set to true in the grid options, then column name property should be translated', () => {
         const gridOptionsMock = { enableTranslate: true } as GridOption;
-        const columnBeforeTranslate = { id: 'field1', field: 'field1', name: 'Hello', headerKey: 'HELLO' };
-        const columnAfterTranslate = { id: 'field1', field: 'field1', name: 'Bonjour', headerKey: 'HELLO' };
+        const columnBeforeTranslate = { id: 'field1', field: 'field1', name: 'Hello', nameKey: 'HELLO' };
+        const columnAfterTranslate = { id: 'field1', field: 'field1', name: 'Bonjour', nameKey: 'HELLO' };
         const columnsMock = [columnBeforeTranslate] as Column[];
         const columnSpy = jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsMock);
         const gridSpy = jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
@@ -552,8 +552,8 @@ describe('ExtensionService', () => {
 
     describe('translateColumnHeaders method', () => {
       it('should translate items with default locale when no arguments is passed to the method', () => {
-        const columnsBeforeTranslateMock = [{ id: 'field1', field: 'field1', name: 'Hello', headerKey: 'HELLO' }] as Column[];
-        const columnsAfterTranslateMock = [{ id: 'field1', field: 'field1', name: 'Bonjour', headerKey: 'HELLO' }] as Column[];
+        const columnsBeforeTranslateMock = [{ id: 'field1', field: 'field1', name: 'Hello', nameKey: 'HELLO' }] as Column[];
+        const columnsAfterTranslateMock = [{ id: 'field1', field: 'field1', name: 'Bonjour', nameKey: 'HELLO' }] as Column[];
         jest.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue(columnsBeforeTranslateMock);
         const columnSpy = jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsBeforeTranslateMock);
         const renderSpy = jest.spyOn(service, 'renderColumnHeaders');
@@ -566,8 +566,8 @@ describe('ExtensionService', () => {
       });
 
       it('should translate items with locale provided as argument to the method', () => {
-        const columnsBeforeTranslateMock = [{ id: 'field1', field: 'field1', headerKey: 'HELLO' }] as Column[];
-        const columnsAfterTranslateMock = [{ id: 'field1', field: 'field1', name: 'Hello', headerKey: 'HELLO' }] as Column[];
+        const columnsBeforeTranslateMock = [{ id: 'field1', field: 'field1', nameKey: 'HELLO' }] as Column[];
+        const columnsAfterTranslateMock = [{ id: 'field1', field: 'field1', name: 'Hello', nameKey: 'HELLO' }] as Column[];
         jest.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue(columnsBeforeTranslateMock);
         const columnSpy = jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsBeforeTranslateMock);
         const renderSpy = jest.spyOn(service, 'renderColumnHeaders');
@@ -580,8 +580,8 @@ describe('ExtensionService', () => {
       });
 
       it('should translate items with locale & column definitions provided as arguments to the method', () => {
-        const columnsBeforeTranslateMock = [{ id: 'field1', field: 'field1', headerKey: 'HELLO' }] as Column[];
-        const columnsAfterTranslateMock = [{ id: 'field1', field: 'field1', name: 'Hello', headerKey: 'HELLO' }] as Column[];
+        const columnsBeforeTranslateMock = [{ id: 'field1', field: 'field1', nameKey: 'HELLO' }] as Column[];
+        const columnsAfterTranslateMock = [{ id: 'field1', field: 'field1', name: 'Hello', nameKey: 'HELLO' }] as Column[];
         const colDefSpy = jest.spyOn(SharedService.prototype, 'columnDefinitions', 'get');
         const columnSpy = jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsBeforeTranslateMock);
         const renderSpy = jest.spyOn(service, 'renderColumnHeaders');
@@ -597,12 +597,12 @@ describe('ExtensionService', () => {
 
     describe('renderColumnHeaders method', () => {
       beforeEach(() => {
-        const columnsMock = [{ id: 'field1', field: 'field1', headerKey: 'HELLO' }] as Column[];
+        const columnsMock = [{ id: 'field1', field: 'field1', nameKey: 'HELLO' }] as Column[];
         jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsMock);
       });
 
       it('should call "setColumns" on the Shared Service with the Shared "columnDefinitions" when no arguments is provided', () => {
-        const columnsMock = [{ id: 'field1', field: 'field1', headerKey: 'HELLO' }] as Column[];
+        const columnsMock = [{ id: 'field1', field: 'field1', nameKey: 'HELLO' }] as Column[];
         jest.spyOn(SharedService.prototype, 'grid', 'get').mockReturnValue(gridStub);
         const colSpy = jest.spyOn(SharedService.prototype, 'columnDefinitions', 'get').mockReturnValue(columnsMock);
         const setColumnsSpy = jest.spyOn(gridStub, 'setColumns');
@@ -615,8 +615,8 @@ describe('ExtensionService', () => {
 
       it('should override "allColumns" on the Shared Service and call "setColumns" with the collection provided as argument', () => {
         const columnsMock = [
-          { id: 'field1', field: 'field1', headerKey: 'HELLO' },
-          { id: 'field2', field: 'field2', headerKey: 'WORLD' }
+          { id: 'field1', field: 'field1', nameKey: 'HELLO' },
+          { id: 'field2', field: 'field2', nameKey: 'WORLD' }
         ] as Column[];
         jest.spyOn(SharedService.prototype, 'grid', 'get').mockReturnValue(gridStub);
         const allColsSpy = jest.spyOn(SharedService.prototype, 'allColumns', 'set');
@@ -631,7 +631,7 @@ describe('ExtensionService', () => {
       it(`should call "setColumns" with the collection provided as argument but NOT override "allColumns" on the Shared Service
     when collection provided is smaller than "allColumns" that already exists`, () => {
         const columnsMock = [
-          { id: 'field1', field: 'field1', headerKey: 'HELLO' }
+          { id: 'field1', field: 'field1', nameKey: 'HELLO' }
         ] as Column[];
         jest.spyOn(SharedService.prototype, 'grid', 'get').mockReturnValue(gridStub);
         const spyAllCols = jest.spyOn(SharedService.prototype, 'allColumns', 'set');
@@ -649,8 +649,8 @@ describe('ExtensionService', () => {
         const expectedExtension = { name: ExtensionName.columnPicker, addon: instanceMock, instance: instanceMock, class: null } as ExtensionModel;
         const gridOptionsMock = { enableColumnPicker: true } as GridOption;
         const columnsMock = [
-          { id: 'field1', field: 'field1', headerKey: 'HELLO' },
-          { id: 'field2', field: 'field2', headerKey: 'WORLD' }
+          { id: 'field1', field: 'field1', nameKey: 'HELLO' },
+          { id: 'field2', field: 'field2', nameKey: 'WORLD' }
         ] as Column[];
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
         jest.spyOn(SharedService.prototype, 'grid', 'get').mockReturnValue(gridStub);
@@ -674,8 +674,8 @@ describe('ExtensionService', () => {
         const expectedExtension = { name: ExtensionName.gridMenu, addon: instanceMock, instance: instanceMock, class: null } as ExtensionModel;
         const gridOptionsMock = { enableGridMenu: true } as GridOption;
         const columnsMock = [
-          { id: 'field1', field: 'field1', headerKey: 'HELLO' },
-          { id: 'field2', field: 'field2', headerKey: 'WORLD' }
+          { id: 'field1', field: 'field1', nameKey: 'HELLO' },
+          { id: 'field2', field: 'field2', nameKey: 'WORLD' }
         ] as Column[];
 
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
@@ -735,7 +735,7 @@ describe('ExtensionService', () => {
     it('should throw an error if "enableTranslate" is set but the I18N Service is null and "translateItems" private method is called', (done) => {
       try {
         const gridOptionsMock = { enableTranslate: true } as GridOption;
-        const columnBeforeTranslate = { id: 'field1', field: 'field1', name: 'Hello', headerKey: 'HELLO' };
+        const columnBeforeTranslate = { id: 'field1', field: 'field1', name: 'Hello', nameKey: 'HELLO' };
         const columnsMock = [columnBeforeTranslate] as Column[];
         jest.spyOn(SharedService.prototype, 'allColumns', 'get').mockReturnValue(columnsMock);
         jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);

--- a/src/aurelia-slickgrid/services/excelExport.service.ts
+++ b/src/aurelia-slickgrid/services/excelExport.service.ts
@@ -307,8 +307,8 @@ export class ExcelExportService {
     // Populate the Column Header, pull the name defined
     columns.forEach((columnDef) => {
       let headerTitle = '';
-      if (columnDef.headerKey && this._gridOptions.enableTranslate && this.i18n && this.i18n.tr) {
-        headerTitle = this.i18n.tr(columnDef.headerKey);
+      if ((columnDef.headerKey || columnDef.nameKey) && this._gridOptions.enableTranslate && this.i18n && this.i18n.tr) {
+        headerTitle = this.i18n.tr((columnDef.headerKey || columnDef.nameKey));
       } else {
         headerTitle = columnDef.name || titleCase(columnDef.field);
       }

--- a/src/aurelia-slickgrid/services/export.service.ts
+++ b/src/aurelia-slickgrid/services/export.service.ts
@@ -254,8 +254,8 @@ export class ExportService {
     // Populate the Column Header, pull the name defined
     columns.forEach((columnDef) => {
       let headerTitle = '';
-      if (columnDef.headerKey && this._gridOptions.enableTranslate && this.i18n && this.i18n.tr) {
-        headerTitle = this.i18n.tr(columnDef.headerKey);
+      if ((columnDef.headerKey || columnDef.nameKey) && this._gridOptions.enableTranslate && this.i18n && this.i18n.tr) {
+        headerTitle = this.i18n.tr((columnDef.headerKey || columnDef.nameKey));
       } else {
         headerTitle = columnDef.name || titleCase(columnDef.field);
       }

--- a/src/aurelia-slickgrid/services/extension.service.ts
+++ b/src/aurelia-slickgrid/services/extension.service.ts
@@ -138,7 +138,9 @@ export class ExtensionService {
       // make sure all columns are translated before creating ColumnPicker/GridMenu Controls
       // this is to avoid having hidden columns not being translated on first load
       if (this.sharedService.gridOptions.enableTranslate) {
+        // eventually deprecate the "headerKey" and use only the "nameKey"
         this.translateItems(this.sharedService.allColumns, 'headerKey', 'name');
+        this.translateItems(this.sharedService.allColumns, 'nameKey', 'name');
       }
 
       // Auto Tooltip Plugin
@@ -387,8 +389,11 @@ export class ExtensionService {
       columnDefinitions = this.sharedService.columnDefinitions;
     }
 
+    // eventually deprecate the "headerKey" and use only the "nameKey"
     this.translateItems(columnDefinitions, 'headerKey', 'name');
     this.translateItems(this.sharedService.allColumns, 'headerKey', 'name');
+    this.translateItems(columnDefinitions, 'nameKey', 'name');
+    this.translateItems(this.sharedService.allColumns, 'nameKey', 'name');
 
     // re-render the column headers
     this.renderColumnHeaders(columnDefinitions);

--- a/src/examples/slickgrid/example12.ts
+++ b/src/examples/slickgrid/example12.ts
@@ -31,7 +31,7 @@ export class Example12 {
       <li>You first need to "enableTranslate" in the Grid Options</li>
       <li>In the Column Definitions, you have following options</li>
       <ul>
-        <li>To translate a header title, use "headerKey" with a translate key (headerKey: 'TITLE')</li>
+        <li>To translate a header title, use "nameKey" with a translate key (nameKey: 'TITLE')</li>
         <li>For the cell values, you need to use a Formatter, there's 2 ways of doing it</li>
         <ul>
           <li>formatter: myCustomTranslateFormatter <b>&lt;= "Title" column uses it</b></li>
@@ -82,7 +82,7 @@ export class Example12 {
   defineGrid() {
     this.columnDefinitions = [
       {
-        id: 'title', name: 'Title', field: 'id', headerKey: 'TITLE', minWidth: 100,
+        id: 'title', name: 'Title', field: 'id', nameKey: 'TITLE', minWidth: 100,
         formatter: taskTranslateFormatter,
         sortable: true,
         filterable: true,
@@ -90,17 +90,17 @@ export class Example12 {
       },
       { id: 'description', name: 'Description', field: 'description', filterable: true, sortable: true, minWidth: 80 },
       {
-        id: 'duration', name: 'Duration (days)', field: 'duration', headerKey: 'DURATION', sortable: true,
+        id: 'duration', name: 'Duration (days)', field: 'duration', nameKey: 'DURATION', sortable: true,
         formatter: Formatters.percentCompleteBar, minWidth: 100,
         exportWithFormatter: false,
         filterable: true,
         type: FieldType.number,
         filter: { model: Filters.slider, /* operator: '>=',*/ params: { hideSliderNumber: true } }
       },
-      { id: 'start', name: 'Start', field: 'start', headerKey: 'START', formatter: Formatters.dateIso, outputType: FieldType.dateIso, type: FieldType.date, minWidth: 100, filterable: true, filter: { model: Filters.compoundDate } },
-      { id: 'finish', name: 'Finish', field: 'finish', headerKey: 'FINISH', formatter: Formatters.dateIso, outputType: FieldType.dateIso, type: FieldType.date, minWidth: 100, filterable: true, filter: { model: Filters.compoundDate } },
+      { id: 'start', name: 'Start', field: 'start', nameKey: 'START', formatter: Formatters.dateIso, outputType: FieldType.dateIso, type: FieldType.date, minWidth: 100, filterable: true, filter: { model: Filters.compoundDate } },
+      { id: 'finish', name: 'Finish', field: 'finish', nameKey: 'FINISH', formatter: Formatters.dateIso, outputType: FieldType.dateIso, type: FieldType.date, minWidth: 100, filterable: true, filter: { model: Filters.compoundDate } },
       {
-        id: 'completedBool', name: 'Completed', field: 'completedBool', headerKey: 'COMPLETED', minWidth: 100,
+        id: 'completedBool', name: 'Completed', field: 'completedBool', nameKey: 'COMPLETED', minWidth: 100,
         sortable: true,
         formatter: Formatters.checkmark,
         exportCustomFormatter: Formatters.translateBoolean,
@@ -112,7 +112,7 @@ export class Example12 {
         }
       },
       {
-        id: 'completed', name: 'Completed', field: 'completed', headerKey: 'COMPLETED', formatter: Formatters.translate, sortable: true,
+        id: 'completed', name: 'Completed', field: 'completed', nameKey: 'COMPLETED', formatter: Formatters.translate, sortable: true,
         minWidth: 100,
         exportWithFormatter: true, // you can set this property in the column definition OR in the grid options, column def has priority over grid options
         filterable: true,
@@ -127,7 +127,7 @@ export class Example12 {
         }
       }
       // OR via your own custom translate formatter
-      // { id: 'completed', name: 'Completed', field: 'completed', headerKey: 'COMPLETED', formatter: translateFormatter, sortable: true, minWidth: 100 }
+      // { id: 'completed', name: 'Completed', field: 'completed', nameKey: 'COMPLETED', formatter: translateFormatter, sortable: true, minWidth: 100 }
     ];
 
     this.gridOptions = {
@@ -191,7 +191,7 @@ export class Example12 {
   }
 
   dynamicallyAddTitleHeader() {
-    const newCol = { id: `title${this.duplicateTitleHeaderCount++}`, field: 'id', headerKey: 'TITLE', formatter: taskTranslateFormatter, sortable: true, minWidth: 100, filterable: true, params: { useFormatterOuputToFilter: true } };
+    const newCol = { id: `title${this.duplicateTitleHeaderCount++}`, field: 'id', nameKey: 'TITLE', formatter: taskTranslateFormatter, sortable: true, minWidth: 100, filterable: true, params: { useFormatterOuputToFilter: true } };
     this.columnDefinitions.push(newCol);
   }
 
@@ -210,8 +210,9 @@ export class Example12 {
     });
   }
 
-  switchLanguage() {
-    this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
-    this.i18n.setLocale(this.selectedLanguage);
+  async switchLanguage() {
+    const nextLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
+    await this.i18n.setLocale(nextLanguage);
+    this.selectedLanguage = nextLanguage;
   }
 }

--- a/src/examples/slickgrid/example15.ts
+++ b/src/examples/slickgrid/example15.ts
@@ -86,7 +86,7 @@ export class Example15 {
         id: 'title',
         name: 'Title',
         field: 'title',
-        headerKey: 'TITLE',
+        nameKey: 'TITLE',
         filterable: true,
         sortable: true,
         type: FieldType.string,
@@ -105,7 +105,7 @@ export class Example15 {
       {
         id: 'duration', name: 'Duration (days)', field: 'duration', sortable: true, type: FieldType.number, exportCsvForceToKeepAsString: true,
         minWidth: 55, width: 100,
-        headerKey: 'DURATION',
+        nameKey: 'DURATION',
         filterable: true,
         filter: {
           collection: multiSelectFilterArray,
@@ -118,15 +118,15 @@ export class Example15 {
         }
       },
       {
-        id: 'complete', name: '% Complete', field: 'percentComplete', headerKey: 'PERCENT_COMPLETE', minWidth: 70, type: FieldType.number, sortable: true, width: 100,
+        id: 'complete', name: '% Complete', field: 'percentComplete', nameKey: 'PERCENT_COMPLETE', minWidth: 70, type: FieldType.number, sortable: true, width: 100,
         formatter: Formatters.percentCompleteBar, filterable: true, filter: { model: Filters.slider, operator: '>' }
       },
       {
-        id: 'start', name: 'Start', field: 'start', headerKey: 'START', formatter: Formatters.dateIso, sortable: true, minWidth: 75, exportWithFormatter: true, width: 100,
+        id: 'start', name: 'Start', field: 'start', nameKey: 'START', formatter: Formatters.dateIso, sortable: true, minWidth: 75, exportWithFormatter: true, width: 100,
         type: FieldType.date, filterable: true, filter: { model: Filters.compoundDate }
       },
       {
-        id: 'completed', field: 'completed', headerKey: 'COMPLETED', minWidth: 85, maxWidth: 85, formatter: Formatters.checkmark, width: 100,
+        id: 'completed', field: 'completed', nameKey: 'COMPLETED', minWidth: 85, maxWidth: 85, formatter: Formatters.checkmark, width: 100,
         type: FieldType.boolean,
         sortable: true,
         filterable: true,
@@ -209,9 +209,10 @@ export class Example15 {
     localStorage[LOCAL_STORAGE_KEY] = JSON.stringify(gridState);
   }
 
-  switchLanguage() {
-    const nextLocale = (this.selectedLanguage === 'en') ? 'fr' : 'en';
-    this.i18n.setLocale(nextLocale).then(() => this.selectedLanguage = nextLocale);
+  async switchLanguage() {
+    const nextLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
+    await this.i18n.setLocale(nextLanguage);
+    this.selectedLanguage = nextLanguage;
   }
 
   useDefaultPresets() {

--- a/src/examples/slickgrid/example23.ts
+++ b/src/examples/slickgrid/example23.ts
@@ -92,7 +92,7 @@ export class Example23 {
   defineGrid() {
     this.columnDefinitions = [
       {
-        id: 'title', name: 'Title', field: 'id', headerKey: 'TITLE', minWidth: 100,
+        id: 'title', name: 'Title', field: 'id', nameKey: 'TITLE', minWidth: 100,
         formatter: taskTranslateFormatter,
         sortable: true,
         filterable: true,
@@ -107,7 +107,7 @@ export class Example23 {
         }
       },
       {
-        id: 'percentComplete', name: '% Complete', field: 'percentComplete', headerKey: 'PERCENT_COMPLETE', minWidth: 120,
+        id: 'percentComplete', name: '% Complete', field: 'percentComplete', nameKey: 'PERCENT_COMPLETE', minWidth: 120,
         sortable: true,
         formatter: Formatters.progressBar,
         type: FieldType.number,
@@ -121,11 +121,11 @@ export class Example23 {
         }
       },
       {
-        id: 'start', name: 'Start', field: 'start', headerKey: 'START', formatter: Formatters.dateIso, sortable: true, minWidth: 75, width: 100, exportWithFormatter: true,
+        id: 'start', name: 'Start', field: 'start', nameKey: 'START', formatter: Formatters.dateIso, sortable: true, minWidth: 75, width: 100, exportWithFormatter: true,
         type: FieldType.date, filterable: true, filter: { model: Filters.compoundDate }
       },
       {
-        id: 'finish', name: 'Finish', field: 'finish', headerKey: 'FINISH', formatter: Formatters.dateIso, sortable: true, minWidth: 75, width: 120, exportWithFormatter: true,
+        id: 'finish', name: 'Finish', field: 'finish', nameKey: 'FINISH', formatter: Formatters.dateIso, sortable: true, minWidth: 75, width: 120, exportWithFormatter: true,
         type: FieldType.date,
         filterable: true,
         filter: {
@@ -133,7 +133,7 @@ export class Example23 {
         }
       },
       {
-        id: 'duration', field: 'duration', headerKey: 'DURATION', maxWidth: 90,
+        id: 'duration', field: 'duration', nameKey: 'DURATION', maxWidth: 90,
         type: FieldType.number,
         sortable: true,
         filterable: true, filter: {
@@ -142,7 +142,7 @@ export class Example23 {
         }
       },
       {
-        id: 'completed', name: 'Completed', field: 'completed', headerKey: 'COMPLETED', minWidth: 85, maxWidth: 90,
+        id: 'completed', name: 'Completed', field: 'completed', nameKey: 'COMPLETED', minWidth: 85, maxWidth: 90,
         formatter: Formatters.checkmark,
         exportWithFormatter: true, // you can set this property in the column definition OR in the grid options, column def has priority over grid options
         filterable: true,
@@ -262,9 +262,10 @@ export class Example23 {
     ]);
   }
 
-  switchLanguage() {
-    const nextLocale = (this.selectedLanguage === 'en') ? 'fr' : 'en';
-    this.i18n.setLocale(nextLocale).then(() => this.selectedLanguage = nextLocale);
+  async switchLanguage() {
+    const nextLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
+    await this.i18n.setLocale(nextLanguage);
+    this.selectedLanguage = nextLanguage;
   }
 
   predefinedFilterChanged(newPredefinedFilter) {

--- a/src/examples/slickgrid/example24.ts
+++ b/src/examples/slickgrid/example24.ts
@@ -122,27 +122,27 @@ export class Example24 {
     this.columnDefinitions = [
       { id: 'id', name: '#', field: 'id', maxWidth: 45, sortable: true, filterable: true },
       {
-        id: 'title', name: 'Title', field: 'id', headerKey: 'TITLE', minWidth: 100,
+        id: 'title', name: 'Title', field: 'id', nameKey: 'TITLE', minWidth: 100,
         formatter: taskTranslateFormatter,
         sortable: true,
         filterable: true,
         params: { useFormatterOuputToFilter: true }
       },
       {
-        id: 'percentComplete', headerKey: 'PERCENT_COMPLETE', field: 'percentComplete', minWidth: 100,
+        id: 'percentComplete', nameKey: 'PERCENT_COMPLETE', field: 'percentComplete', minWidth: 100,
         exportWithFormatter: false,
         sortable: true, filterable: true,
         filter: { model: Filters.slider, operator: '>=' },
         formatter: Formatters.percentCompleteBar, type: FieldType.number,
       },
       {
-        id: 'start', name: 'Start', field: 'start', headerKey: 'START', minWidth: 100,
+        id: 'start', name: 'Start', field: 'start', nameKey: 'START', minWidth: 100,
         formatter: Formatters.dateIso, outputType: FieldType.dateIso, type: FieldType.date,
         filterable: true, filter: { model: Filters.compoundDate }
       },
-      { id: 'finish', name: 'Finish', field: 'finish', headerKey: 'FINISH', formatter: Formatters.dateIso, outputType: FieldType.dateIso, type: FieldType.date, minWidth: 100, filterable: true, filter: { model: Filters.compoundDate } },
+      { id: 'finish', name: 'Finish', field: 'finish', nameKey: 'FINISH', formatter: Formatters.dateIso, outputType: FieldType.dateIso, type: FieldType.date, minWidth: 100, filterable: true, filter: { model: Filters.compoundDate } },
       {
-        id: 'priority', headerKey: 'PRIORITY', field: 'priority',
+        id: 'priority', nameKey: 'PRIORITY', field: 'priority',
         exportCustomFormatter: priorityExportFormatter,
         formatter: priorityFormatter,
         sortable: true, filterable: true,
@@ -156,7 +156,7 @@ export class Example24 {
         }
       },
       {
-        id: 'completed', headerKey: 'COMPLETED', field: 'completed',
+        id: 'completed', nameKey: 'COMPLETED', field: 'completed',
         exportCustomFormatter: Formatters.translateBoolean,
         formatter: Formatters.checkmark,
         sortable: true, filterable: true,
@@ -449,8 +449,9 @@ export class Example24 {
     // actionColumn.cellMenu.hideOptionSection = !showBothList;
   }
 
-  switchLanguage() {
-    this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
-    this.i18n.setLocale(this.selectedLanguage);
+  async switchLanguage() {
+    const nextLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
+    await this.i18n.setLocale(nextLanguage);
+    this.selectedLanguage = nextLanguage;
   }
 }

--- a/src/examples/slickgrid/example25.ts
+++ b/src/examples/slickgrid/example25.ts
@@ -246,8 +246,9 @@ export class Example25 {
     ]);
   }
 
-  switchLanguage() {
-    this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
-    this.i18n.setLocale(this.selectedLanguage);
+  async switchLanguage() {
+    const nextLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
+    await this.i18n.setLocale(nextLanguage);
+    this.selectedLanguage = nextLanguage;
   }
 }

--- a/src/examples/slickgrid/example3.ts
+++ b/src/examples/slickgrid/example3.ts
@@ -593,9 +593,10 @@ export class Example3 {
     return true;
   }
 
-  switchLanguage() {
-    this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
-    this.i18n.setLocale(this.selectedLanguage);
+  async switchLanguage() {
+    const nextLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
+    await this.i18n.setLocale(nextLanguage);
+    this.selectedLanguage = nextLanguage;
   }
 
   undo() {

--- a/src/examples/slickgrid/example6.ts
+++ b/src/examples/slickgrid/example6.ts
@@ -77,7 +77,7 @@ export class Example6 {
   defineGrid() {
     this.columnDefinitions = [
       {
-        id: 'name', field: 'name', headerKey: 'NAME', width: 60,
+        id: 'name', field: 'name', nameKey: 'NAME', width: 60,
         type: FieldType.string,
         sortable: true,
         filterable: true,
@@ -86,14 +86,14 @@ export class Example6 {
         }
       },
       {
-        id: 'gender', field: 'gender', headerKey: 'GENDER', filterable: true, sortable: true, width: 60,
+        id: 'gender', field: 'gender', nameKey: 'GENDER', filterable: true, sortable: true, width: 60,
         filter: {
           model: Filters.singleSelect,
           collection: [{ value: '', label: '' }, { value: 'male', label: 'male', labelKey: 'MALE' }, { value: 'female', label: 'female', labelKey: 'FEMALE' }]
         }
       },
       {
-        id: 'company', field: 'company', headerKey: 'COMPANY', width: 60,
+        id: 'company', field: 'company', nameKey: 'COMPANY', width: 60,
         sortable: true,
         filterable: true,
         filter: {
@@ -104,9 +104,9 @@ export class Example6 {
           } as MultipleSelectOption
         }
       },
-      { id: 'billingAddressStreet', field: 'billing.address.street', headerKey: 'BILLING.ADDRESS.STREET', width: 60, filterable: true, sortable: true },
+      { id: 'billingAddressStreet', field: 'billing.address.street', nameKey: 'BILLING.ADDRESS.STREET', width: 60, filterable: true, sortable: true },
       {
-        id: 'billingAddressZip', field: 'billing.address.zip', headerKey: 'BILLING.ADDRESS.ZIP', width: 60,
+        id: 'billingAddressZip', field: 'billing.address.zip', nameKey: 'BILLING.ADDRESS.ZIP', width: 60,
         type: FieldType.number,
         filterable: true, sortable: true,
         filter: {
@@ -271,8 +271,9 @@ export class Example6 {
     ]);
   }
 
-  switchLanguage() {
-    this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
-    this.i18n.setLocale(this.selectedLanguage);
+  async switchLanguage() {
+    const nextLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
+    await this.i18n.setLocale(nextLanguage);
+    this.selectedLanguage = nextLanguage;
   }
 }

--- a/src/examples/slickgrid/example8.ts
+++ b/src/examples/slickgrid/example8.ts
@@ -60,12 +60,12 @@ export class Example8 {
 
   defineGrid() {
     this.columnDefinitions = [
-      { id: 'title', name: 'Title', field: 'title', headerKey: 'TITLE' },
-      { id: 'duration', name: 'Duration', field: 'duration', headerKey: 'DURATION', sortable: true },
-      { id: 'percentComplete', name: '% Complete', field: 'percentComplete', headerKey: 'PERCENT_COMPLETE', sortable: true },
-      { id: 'start', name: 'Start', field: 'start', headerKey: 'START' },
-      { id: 'finish', name: 'Finish', field: 'finish', headerKey: 'FINISH' },
-      { id: 'completed', name: 'Completed', field: 'completed', headerKey: 'COMPLETED', formatter: Formatters.checkmark }
+      { id: 'title', name: 'Title', field: 'title', nameKey: 'TITLE' },
+      { id: 'duration', name: 'Duration', field: 'duration', nameKey: 'DURATION', sortable: true },
+      { id: 'percentComplete', name: '% Complete', field: 'percentComplete', nameKey: 'PERCENT_COMPLETE', sortable: true },
+      { id: 'start', name: 'Start', field: 'start', nameKey: 'START' },
+      { id: 'finish', name: 'Finish', field: 'finish', nameKey: 'FINISH' },
+      { id: 'completed', name: 'Completed', field: 'completed', nameKey: 'COMPLETED', formatter: Formatters.checkmark }
     ];
 
     this.columnDefinitions.forEach((columnDef) => {
@@ -154,8 +154,9 @@ export class Example8 {
     this.dataset = mockDataset;
   }
 
-  switchLanguage() {
-    this.selectedLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
-    this.i18n.setLocale(this.selectedLanguage);
+  async switchLanguage() {
+    const nextLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
+    await this.i18n.setLocale(nextLanguage);
+    this.selectedLanguage = nextLanguage;
   }
 }

--- a/src/examples/slickgrid/example9.ts
+++ b/src/examples/slickgrid/example9.ts
@@ -58,18 +58,18 @@ export class Example9 {
 
   defineGrid() {
     this.columnDefinitions = [
-      { id: 'title', name: 'Title', field: 'title', headerKey: 'TITLE', filterable: true, type: FieldType.string },
-      { id: 'duration', name: 'Duration', field: 'duration', headerKey: 'DURATION', sortable: true, filterable: true, type: FieldType.string },
+      { id: 'title', name: 'Title', field: 'title', nameKey: 'TITLE', filterable: true, type: FieldType.string },
+      { id: 'duration', name: 'Duration', field: 'duration', nameKey: 'DURATION', sortable: true, filterable: true, type: FieldType.string },
       {
-        id: 'percentComplete', name: '% Complete', field: 'percentComplete', headerKey: 'PERCENT_COMPLETE', sortable: true, filterable: true,
+        id: 'percentComplete', name: '% Complete', field: 'percentComplete', nameKey: 'PERCENT_COMPLETE', sortable: true, filterable: true,
         type: FieldType.number,
         formatter: Formatters.percentCompleteBar,
         filter: { model: Filters.compoundSlider, params: { hideSliderNumber: false } }
       },
-      { id: 'start', name: 'Start', field: 'start', headerKey: 'START', filterable: true, type: FieldType.dateUs, filter: { model: Filters.compoundDate } },
-      { id: 'finish', name: 'Finish', field: 'finish', headerKey: 'FINISH', filterable: true, type: FieldType.dateUs, filter: { model: Filters.compoundDate } },
+      { id: 'start', name: 'Start', field: 'start', nameKey: 'START', filterable: true, type: FieldType.dateUs, filter: { model: Filters.compoundDate } },
+      { id: 'finish', name: 'Finish', field: 'finish', nameKey: 'FINISH', filterable: true, type: FieldType.dateUs, filter: { model: Filters.compoundDate } },
       {
-        id: 'completed', name: 'Completed', field: 'completed', headerKey: 'COMPLETED', maxWidth: 80, formatter: Formatters.checkmark,
+        id: 'completed', name: 'Completed', field: 'completed', nameKey: 'COMPLETED', maxWidth: 80, formatter: Formatters.checkmark,
         type: FieldType.boolean,
         minWidth: 100,
         sortable: true,
@@ -208,9 +208,10 @@ export class Example9 {
     return phone;
   }
 
-  switchLanguage() {
-    const nextLocale = (this.selectedLanguage === 'en') ? 'fr' : 'en';
-    this.i18n.setLocale(nextLocale).then(() => this.selectedLanguage = nextLocale);
+  async switchLanguage() {
+    const nextLanguage = (this.selectedLanguage === 'en') ? 'fr' : 'en';
+    await this.i18n.setLocale(nextLanguage);
+    this.selectedLanguage = nextLanguage;
   }
 
   toggleGridMenu(e) {


### PR DESCRIPTION
- deprecate "headerKey" in the future and use "nameKey" instead which aligns with the "name" property in the column definitions