### PR TITLE
(pagination): fix singleton issues found in Pagination and elsewhere

### DIFF
--- a/src/aurelia-slickgrid/constants.ts
+++ b/src/aurelia-slickgrid/constants.ts
@@ -1,7 +1,8 @@
 import { Locale } from './models/locale.interface';
 
 export class Constants {
-  static locales: Locale = {
+  // English Locale texts when using only 1 Locale instead of I18N
+  static readonly locales: Locale = {
     TEXT_ALL_SELECTED: 'All Selected',
     TEXT_CANCEL: 'Cancel',
     TEXT_CLEAR_ALL_FILTERS: 'Clear all Filters',
@@ -40,14 +41,32 @@ export class Constants {
     TEXT_TOGGLE_PRE_HEADER_ROW: 'Toggle Pre-Header Row',
     TEXT_X_OF_Y_SELECTED: '# of % selected',
   };
-  static VALIDATION_REQUIRED_FIELD = 'Field is required';
-  static VALIDATION_EDITOR_VALID_NUMBER = 'Please enter a valid number';
-  static VALIDATION_EDITOR_VALID_INTEGER = 'Please enter a valid integer number';
-  static VALIDATION_EDITOR_INTEGER_BETWEEN = 'Please enter a valid integer number between {{minValue}} and {{maxValue}}';
-  static VALIDATION_EDITOR_INTEGER_MAX = 'Please enter a valid integer number that is lower than {{maxValue}}';
-  static VALIDATION_EDITOR_INTEGER_MIN = 'Please enter a valid integer number that is greater than {{minValue}}';
-  static VALIDATION_EDITOR_NUMBER_BETWEEN = 'Please enter a valid number between {{minValue}} and {{maxValue}}';
-  static VALIDATION_EDITOR_NUMBER_MAX = 'Please enter a valid number that is lower than {{maxValue}}';
-  static VALIDATION_EDITOR_NUMBER_MIN = 'Please enter a valid number that is greater than {{minValue}}';
-  static VALIDATION_EDITOR_DECIMAL_BETWEEN = 'Please enter a valid number with a maximum of {{maxDecimal}} decimals';
+
+  // some Validation default texts
+  static readonly VALIDATION_REQUIRED_FIELD = 'Field is required';
+  static readonly VALIDATION_EDITOR_VALID_NUMBER = 'Please enter a valid number';
+  static readonly VALIDATION_EDITOR_VALID_INTEGER = 'Please enter a valid integer number';
+  static readonly VALIDATION_EDITOR_INTEGER_BETWEEN = 'Please enter a valid integer number between {{minValue}} and {{maxValue}}';
+  static readonly VALIDATION_EDITOR_INTEGER_MAX = 'Please enter a valid integer number that is lower than {{maxValue}}';
+  static readonly VALIDATION_EDITOR_INTEGER_MIN = 'Please enter a valid integer number that is greater than {{minValue}}';
+  static readonly VALIDATION_EDITOR_NUMBER_BETWEEN = 'Please enter a valid number between {{minValue}} and {{maxValue}}';
+  static readonly VALIDATION_EDITOR_NUMBER_MAX = 'Please enter a valid number that is lower than {{maxValue}}';
+  static readonly VALIDATION_EDITOR_NUMBER_MIN = 'Please enter a valid number that is greater than {{minValue}}';
+  static readonly VALIDATION_EDITOR_DECIMAL_BETWEEN = 'Please enter a valid number with a maximum of {{maxDecimal}} decimals';
+
+  // some of the Events from the Event Aggregator that are exposed to the outside as dispatch events
+  // we define the internal name of the events and their alias used as dispatch events
+  static readonly exposedEvents: { name: string; alias: string; }[] = [
+    { name: 'excelExportService:onBeforeExportToExcel', alias: 'asg-on-before-export-to-excel' },
+    { name: 'excelExportService:onAfterExportToExcel', alias: 'asg-on-after-export-to-excel' },
+    { name: 'exportService:onBeforeExportToFile', alias: 'asg-on-before-export-to-file' },
+    { name: 'exportService:onAfterExportToFile', alias: 'asg-on-after-export-to-file' },
+    { name: 'gridStateService:changed', alias: 'asg-on-grid-state-changed' },
+    { name: 'gridService:onItemAdded', alias: 'asg-on-item-added' },
+    { name: 'gridService:onItemDeleted', alias: 'asg-on-item-deleted' },
+    { name: 'gridService:onItemUpdated', alias: 'asg-on-item-updated' },
+    { name: 'gridService:onItemUpserted', alias: 'asg-on-item-upserted' },
+    { name: 'resizerService:onBeforeResize', alias: 'asg-on-before-resize' },
+    { name: 'resizerService:onAfterResize', alias: 'asg-on-after-resize' },
+  ];
 }

--- a/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid-constructor.spec.ts
+++ b/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid-constructor.spec.ts
@@ -294,7 +294,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
   let divContainer: HTMLDivElement;
   let cellDiv: HTMLDivElement;
   let globalEa: EventAggregator;
-  let localEa: EventAggregator;
+  let pluginEa: EventAggregator;
   let i18n: I18N;
   const http = new HttpStub();
 
@@ -318,7 +318,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
     document.body.appendChild(divContainer);
 
     globalEa = new EventAggregator();
-    localEa = new EventAggregator();
+    pluginEa = new EventAggregator();
     i18n = new I18N(globalEa, new BindingSignaler());
     container = new Container();
     customElement = new AureliaSlickgridCustomElement(
@@ -326,7 +326,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
       container,
       divContainer,
       globalEa,
-      localEa,
+      pluginEa,
       excelExportServiceStub,
       exportServiceStub,
       extensionServiceStub,
@@ -603,14 +603,14 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
       });
 
       it('should call the "executeAfterDataviewCreated" and "loadGridSorters" methods and Sorter Presets are provided in the Grid Options', () => {
-        const eaSpy = jest.spyOn(globalEa, 'publish');
+        const globalEaSpy = jest.spyOn(globalEa, 'publish');
         const sortSpy = jest.spyOn(sortServiceStub, 'loadGridSorters');
 
         customElement.gridOptions = { presets: { sorters: [{ columnId: 'field1', direction: 'DESC' }] } } as GridOption;
         customElement.bind();
         customElement.attached();
 
-        expect(eaSpy).toHaveBeenNthCalledWith(3, 'onGridCreated', expect.any(Object));
+        expect(globalEaSpy).toHaveBeenNthCalledWith(3, 'onGridCreated', expect.any(Object));
         expect(sortSpy).toHaveBeenCalled();
       });
 
@@ -1292,14 +1292,14 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
 
       it('should call trigger a gridStage change event when pagination change is triggered', () => {
         const mockPagination = { pageNumber: 2, pageSize: 20 } as Pagination;
-        const eaSpy = jest.spyOn(localEa, 'publish');
+        const pluginEaSpy = jest.spyOn(pluginEa, 'publish');
         jest.spyOn(gridStateServiceStub, 'getCurrentGridState').mockReturnValue({ columns: [], pagination: mockPagination } as GridState);
 
         customElement.bind();
         customElement.attached();
         customElement.paginationChanged(mockPagination);
 
-        expect(eaSpy).toHaveBeenCalledWith('gridStateService:changed', {
+        expect(pluginEaSpy).toHaveBeenCalledWith('gridStateService:changed', {
           change: { newValues: mockPagination, type: GridStateType.pagination },
           gridState: { columns: [], pagination: mockPagination }
         });
@@ -1314,16 +1314,16 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
           pageCount: 1,
           pageSizes: [5, 10, 15, 20],
         } as ServicePagination;
-        const eaSpy = jest.spyOn(localEa, 'publish');
+        const pluginEaSpy = jest.spyOn(pluginEa, 'publish');
         jest.spyOn(gridStateServiceStub, 'getCurrentGridState').mockReturnValue({ columns: [], pagination: mockPagination } as GridState);
 
         customElement.gridOptions.enablePagination = true;
         customElement.bind();
         customElement.attached();
         customElement.refreshGridData([{ firstName: 'John', lastName: 'Doe' }]);
-        localEa.publish('paginationService:on-pagination-changed', mockServicePagination);
+        pluginEa.publish('paginationService:onPaginationChanged', mockServicePagination);
 
-        expect(eaSpy).toHaveBeenCalledWith('gridStateService:changed', {
+        expect(pluginEaSpy).toHaveBeenCalledWith('gridStateService:changed', {
           change: { newValues: mockPagination, type: GridStateType.pagination },
           gridState: { columns: [], pagination: mockPagination }
         });
@@ -1331,7 +1331,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
 
       it('should call trigger a gridStage change and reset selected rows when pagination change is triggered and "enableRowSelection" is set', () => {
         const mockPagination = { pageNumber: 2, pageSize: 20 } as Pagination;
-        const eaSpy = jest.spyOn(localEa, 'publish');
+        const pluginEaSpy = jest.spyOn(pluginEa, 'publish');
         const setRowSpy = jest.spyOn(mockGrid, 'setSelectedRows');
         jest.spyOn(gridStateServiceStub, 'getCurrentGridState').mockReturnValue({ columns: [], pagination: mockPagination } as GridState);
 
@@ -1341,7 +1341,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
         customElement.paginationChanged(mockPagination);
 
         expect(setRowSpy).toHaveBeenCalledWith([]);
-        expect(eaSpy).toHaveBeenCalledWith('gridStateService:changed', {
+        expect(pluginEaSpy).toHaveBeenCalledWith('gridStateService:changed', {
           change: { newValues: mockPagination, type: GridStateType.pagination },
           gridState: { columns: [], pagination: mockPagination }
         });
@@ -1349,7 +1349,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
 
       it('should call trigger a gridStage change and reset selected rows when pagination change is triggered and "enableCheckboxSelector" is set', () => {
         const mockPagination = { pageNumber: 2, pageSize: 20 } as Pagination;
-        const eaSpy = jest.spyOn(localEa, 'publish');
+        const pluginEaSpy = jest.spyOn(pluginEa, 'publish');
         const setRowSpy = jest.spyOn(mockGrid, 'setSelectedRows');
         jest.spyOn(gridStateServiceStub, 'getCurrentGridState').mockReturnValue({ columns: [], pagination: mockPagination } as GridState);
 
@@ -1359,7 +1359,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
         customElement.paginationChanged(mockPagination);
 
         expect(setRowSpy).toHaveBeenCalledWith([]);
-        expect(eaSpy).toHaveBeenCalledWith('gridStateService:changed', {
+        expect(pluginEaSpy).toHaveBeenCalledWith('gridStateService:changed', {
           change: { newValues: mockPagination, type: GridStateType.pagination },
           gridState: { columns: [], pagination: mockPagination }
         });

--- a/src/aurelia-slickgrid/custom-elements/__tests__/slick-pagination-without-i18n.spec.ts
+++ b/src/aurelia-slickgrid/custom-elements/__tests__/slick-pagination-without-i18n.spec.ts
@@ -67,8 +67,6 @@ describe('Slick-Pagination Component without I18N', () => {
       aurelia.container.registerInstance(EventAggregator, ea);
       aurelia.container.registerInstance(PaginationService, paginationServiceStub);
     });
-
-    ea.publish(`paginationService:on-pagination-refreshed`, true);
   });
 
   describe('Integration Tests', () => {
@@ -106,7 +104,6 @@ describe('Slick-Pagination Component without I18N', () => {
       await customElement.unbind();
       await customElement.bind(bindings);
       await customElement.attached();
-      ea.publish(`paginationService:on-pagination-refreshed`, true);
 
       setTimeout(async () => {
         const pageInfoFromTo = await customElement.waitForElement('.page-info-from-to');

--- a/src/aurelia-slickgrid/custom-elements/__tests__/slick-pagination.spec.ts
+++ b/src/aurelia-slickgrid/custom-elements/__tests__/slick-pagination.spec.ts
@@ -93,7 +93,6 @@ describe('Slick-Pagination Component', () => {
     });
 
     await customElement.create(bootstrap);
-    ea.publish(`paginationService:on-pagination-refreshed`, true);
   });
 
   describe('Integration Tests', () => {
@@ -103,8 +102,7 @@ describe('Slick-Pagination Component', () => {
       customElement.dispose();
     });
 
-    it('should make sure Slick-Pagination is defined', async () => {
-      ea.publish(`paginationService:on-pagination-refreshed`, true);
+    it('should make sure Slick-Pagination is defined', () => {
       expect(customElement).toBeTruthy();
       expect(customElement.constructor).toBeDefined();
     });
@@ -118,7 +116,6 @@ describe('Slick-Pagination Component', () => {
     });
 
     it('should call changeToFirstPage() from the View and expect the pagination service to be called with correct method', async () => {
-      ea.publish(`paginationService:on-pagination-refreshed`, true);
       const spy = jest.spyOn(paginationServiceStub, 'goToFirstPage');
 
       // const input = fixture.debugElement.nativeElement.querySelector('input.form-control');

--- a/src/aurelia-slickgrid/custom-elements/slick-pagination.ts
+++ b/src/aurelia-slickgrid/custom-elements/slick-pagination.ts
@@ -1,12 +1,12 @@
 import { bindable, inject, Optional } from 'aurelia-framework';
-import { Subscription } from 'aurelia-event-aggregator';
+import { EventAggregator, Subscription } from 'aurelia-event-aggregator';
 import { I18N } from 'aurelia-i18n';
 
 import { Locale } from '../models/index';
 import { PaginationService } from '../services/pagination.service';
 import { disposeAllSubscriptions } from '../services/utilities';
 
-@inject(Optional.of(I18N))
+@inject(EventAggregator, Optional.of(I18N))
 export class SlickPaginationCustomElement {
   // we need to pass this service as a binding because it's transient and it must be created (then passed through the binding) in the Aurelia-Slickgrid custom element
   @bindable() paginationService: PaginationService;
@@ -21,7 +21,7 @@ export class SlickPaginationCustomElement {
   textOf: string;
   textPage: string;
 
-  constructor(private i18n: I18N) {
+  constructor(private globalEa: EventAggregator, private i18n: I18N) {
     // when using I18N, we'll translate necessary texts in the UI
     this.translatePaginationTexts(this.locales);
   }
@@ -66,9 +66,9 @@ export class SlickPaginationCustomElement {
     }
     this.translatePaginationTexts(this.locales);
 
-    if (this.enableTranslate && this.i18n && this.i18n.ea && this.i18n.ea.subscribe) {
+    if (this.enableTranslate && this.globalEa && this.globalEa.subscribe) {
       this._subscriptions.push(
-        this.i18n.ea.subscribe('i18n:locale:changed', () => this.translatePaginationTexts(this.locales))
+        this.globalEa.subscribe('i18n:locale:changed', () => this.translatePaginationTexts(this.locales))
       );
     }
   }

--- a/src/aurelia-slickgrid/custom-elements/slickgridEventAggregator.ts
+++ b/src/aurelia-slickgrid/custom-elements/slickgridEventAggregator.ts
@@ -1,0 +1,12 @@
+import { Disposable } from 'aurelia-framework';
+
+/**
+ * A class that will be used for internal communication of parent-child
+ *
+ * All methods are abstract for typings purposes only
+ */
+export abstract class SlickgridEventAggregator {
+  abstract publish(event: string, data: any): void;
+
+  abstract subscribe(event: string, callback: (data: any) => void): Disposable;
+}

--- a/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
@@ -1,6 +1,6 @@
 import { inject, Optional, singleton } from 'aurelia-framework';
-import { EventAggregator } from 'aurelia-event-aggregator';
 import { I18N } from 'aurelia-i18n';
+
 import { Constants } from '../constants';
 import {
   Column,
@@ -21,13 +21,14 @@ import { FilterService } from '../services/filter.service';
 import { SortService } from '../services/sort.service';
 import { SharedService } from '../services/shared.service';
 import { ExtensionUtility } from './extensionUtility';
+import { SlickgridEventAggregator } from '../custom-elements/slickgridEventAggregator';
 
 // using external non-typed js libraries
 declare var Slick: any;
 
 @singleton(true)
 @inject(
-  EventAggregator,
+  SlickgridEventAggregator,
   ExtensionUtility,
   FilterService,
   Optional.of(I18N),
@@ -40,7 +41,7 @@ export class HeaderMenuExtension implements Extension {
   private _locales: Locale;
 
   constructor(
-    private ea: EventAggregator,
+    private pluginEa: SlickgridEventAggregator,
     private extensionUtility: ExtensionUtility,
     private filterService: FilterService,
     private i18n: I18N,
@@ -210,7 +211,7 @@ export class HeaderMenuExtension implements Extension {
       const visibleColumns = this.extensionUtility.arrayRemoveItemByIndex(currentColumns, columnIndex);
       this.sharedService.visibleColumns = visibleColumns;
       this.sharedService.grid.setColumns(visibleColumns);
-      this.ea.publish('headerMenu:onColumnsChanged', { columns: visibleColumns });
+      this.pluginEa.publish('headerMenu:onColumnsChanged', { columns: visibleColumns });
     }
   }
 

--- a/src/aurelia-slickgrid/extensions/rowDetailViewExtension.ts
+++ b/src/aurelia-slickgrid/extensions/rowDetailViewExtension.ts
@@ -1,5 +1,5 @@
 import { inject, singleton } from 'aurelia-framework';
-import { EventAggregator, Subscription } from 'aurelia-event-aggregator';
+import { Subscription } from 'aurelia-event-aggregator';
 import * as DOMPurify from 'dompurify';
 
 import { AureliaViewOutput, Column, Extension, ExtensionName, GridOption, RowDetailView, SlickEventHandler } from '../models/index';
@@ -7,6 +7,7 @@ import { ExtensionUtility } from './extensionUtility';
 import { SharedService } from '../services/shared.service';
 import { AureliaUtilService } from '../services/aureliaUtil.service';
 import { addToArrayWhenNotExists, disposeAllSubscriptions } from '../services/utilities';
+import { SlickgridEventAggregator } from '../custom-elements/slickgridEventAggregator';
 
 // using external non-typed js libraries
 declare var Slick: any;
@@ -22,7 +23,7 @@ export interface CreatedView extends AureliaViewOutput {
 @singleton(true)
 @inject(
   AureliaUtilService,
-  EventAggregator,
+  SlickgridEventAggregator,
   ExtensionUtility,
   SharedService,
 )
@@ -37,7 +38,7 @@ export class RowDetailViewExtension implements Extension {
 
   constructor(
     private aureliaUtilService: AureliaUtilService,
-    private ea: EventAggregator,
+    private pluginEa: SlickgridEventAggregator,
     private extensionUtility: ExtensionUtility,
     private sharedService: SharedService,
   ) {
@@ -209,7 +210,7 @@ export class RowDetailViewExtension implements Extension {
 
         // on filter changed, we need to re-render all Views
         this._subscriptions.push(
-          this.ea.subscribe('filterService:filterChanged', () => this.redrawAllViewSlots())
+          this.pluginEa.subscribe('filterService:filterChanged', () => this.redrawAllViewSlots())
         );
       }
       return this._addon;

--- a/src/aurelia-slickgrid/services/__tests__/groupingAndColspan.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/groupingAndColspan.service.spec.ts
@@ -67,15 +67,15 @@ const template =
 describe('GroupingAndColspanService', () => {
   let service: GroupingAndColspanService;
   let slickgridEventHandler: SlickEventHandler;
-  let ea: EventAggregator;
+  let pluginEa: EventAggregator;
   let i18n: I18N;
 
   beforeEach(() => {
     const div = document.createElement('div');
     div.innerHTML = template;
     document.body.appendChild(div);
-    ea = new EventAggregator();
-    i18n = new I18N(ea, new BindingSignaler());
+    pluginEa = new EventAggregator();
+    i18n = new I18N(pluginEa, new BindingSignaler());
 
     i18n.setup({
       resources: {
@@ -104,7 +104,7 @@ describe('GroupingAndColspanService', () => {
       debug: false
     });
 
-    service = new GroupingAndColspanService(mockExtensionUtility, ea);
+    service = new GroupingAndColspanService(mockExtensionUtility, pluginEa);
     slickgridEventHandler = service.eventHandler;
   });
 
@@ -210,7 +210,7 @@ describe('GroupingAndColspanService', () => {
       const spy = jest.spyOn(service, 'renderPreHeaderRowGroupingTitles');
 
       service.init(gridStub, dataViewStub);
-      ea.publish('asg:onAfterResize', {});
+      pluginEa.publish('resizerService:onAfterResize', {});
       jest.runAllTimers(); // fast-forward timer
 
       expect(spy).toHaveBeenCalledTimes(2);

--- a/src/aurelia-slickgrid/services/__tests__/pagination.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/pagination.service.spec.ts
@@ -7,7 +7,6 @@ import { Column, GridOption } from '../../models';
 import * as utilities from '../backend-utilities';
 
 declare var Slick: any;
-const DEFAULT_AURELIA_EVENT_PREFIX = 'asg';
 
 const mockExecuteBackendProcess = jest.fn();
 // @ts-ignore
@@ -66,11 +65,11 @@ const gridStub = {
 describe('PaginationService', () => {
   let service: PaginationService;
   let sharedService: SharedService;
-  const ea = new EventAggregator();
+  const pluginEa = new EventAggregator();
 
   beforeEach(() => {
     sharedService = new SharedService();
-    service = new PaginationService(ea, sharedService);
+    service = new PaginationService(pluginEa, sharedService);
   });
 
   afterEach(() => {
@@ -389,7 +388,7 @@ describe('PaginationService', () => {
     });
 
     it('should call "setPagingOptions" from the DataView and trigger "onPaginationChanged" when using a Local Grid', () => {
-      const eaSpy = jest.spyOn(ea, 'publish');
+      const pluginEaSpy = jest.spyOn(pluginEa, 'publish');
       const setPagingSpy = jest.spyOn(dataviewStub, 'setPagingOptions');
 
       mockGridOption.backendServiceApi = null;
@@ -397,7 +396,7 @@ describe('PaginationService', () => {
       service.processOnPageChanged(1);
 
       expect(setPagingSpy).toHaveBeenCalledWith({ pageSize: 25, pageNum: 0 });
-      expect(eaSpy).toHaveBeenCalledWith(`paginationService:on-pagination-changed`, {
+      expect(pluginEaSpy).toHaveBeenCalledWith(`paginationService:onPaginationChanged`, {
         dataFrom: 26, dataTo: 50, pageSize: 25, pageCount: 4, pageNumber: 2, totalItems: 85, pageSizes: mockGridOption.pagination.pageSizes,
       });
     });
@@ -474,21 +473,21 @@ describe('PaginationService', () => {
       const refreshSpy = jest.spyOn(service, 'refreshPagination');
 
       service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
-      ea.publish(`filterService:filterCleared`, true);
+      pluginEa.publish(`filterService:filterCleared`, true);
 
       expect(resetSpy).toHaveBeenCalled();
       expect(refreshSpy).toHaveBeenCalledWith(true, true);
     });
 
     it('should call refreshPagination when "onFilterChanged" is triggered', () => {
-      const eaSpy = jest.spyOn(ea, 'publish');
+      const pluginEaSpy = jest.spyOn(pluginEa, 'publish');
       const resetSpy = jest.spyOn(service, 'resetPagination');
       const refreshSpy = jest.spyOn(service, 'refreshPagination');
 
       service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
-      ea.publish(`filterService:filterChanged`, { columnId: 'field1', operator: '=', searchTerms: [] });
+      pluginEa.publish(`filterService:filterChanged`, { columnId: 'field1', operator: '=', searchTerms: [] });
 
-      expect(eaSpy).toHaveBeenCalledWith('paginationService:on-pagination-changed', {
+      expect(pluginEaSpy).toHaveBeenCalledWith('paginationService:onPaginationChanged', {
         dataFrom: 1, dataTo: 25, pageCount: 4, pageNumber: 1, pageSize: 25, pageSizes: [5, 10, 15, 20], totalItems: 85
       });
       expect(resetSpy).toHaveBeenCalled();
@@ -525,16 +524,16 @@ describe('PaginationService', () => {
 
     it('should call "processOnItemAddedOrRemoved" and expect the (To) to be incremented by 1 when "onItemAdded" is triggered with a single item', (done) => {
       const mockItems = { name: 'John' };
-      const eaSpy = jest.spyOn(ea, 'publish');
+      const pluginEaSpy = jest.spyOn(pluginEa, 'publish');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
       service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
-      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-added`, mockItems);
+      pluginEa.publish('gridService:onItemAdded', mockItems);
 
       setTimeout(() => {
         expect(recalculateSpy).toHaveBeenCalledTimes(2);
-        expect(eaSpy).toHaveBeenCalledTimes(2); // 2x times (1x for onItemAdded then 1x for onPaginationChanged)
-        expect(eaSpy).toHaveBeenNthCalledWith(2, `paginationService:on-pagination-changed`, {
+        expect(pluginEaSpy).toHaveBeenCalledTimes(2); // 2x times (1x for onItemAdded then 1x for onPaginationChanged)
+        expect(pluginEaSpy).toHaveBeenNthCalledWith(2, `paginationService:onPaginationChanged`, {
           dataFrom: 26, dataTo: (50 + 1), pageSize: 25, pageCount: 4, pageNumber: 2, totalItems: (85 + 1), pageSizes: mockGridOption.pagination.pageSizes
         });
         expect(service.dataFrom).toBe(26);
@@ -545,16 +544,16 @@ describe('PaginationService', () => {
 
     it('should call "processOnItemAddedOrRemoved" and expect the (To) to be incremented by 2 when "onItemAdded" is triggered with an array of 2 new items', (done) => {
       const mockItems = [{ name: 'John' }, { name: 'Jane' }];
-      const eaSpy = jest.spyOn(ea, 'publish');
+      const pluginEaSpy = jest.spyOn(pluginEa, 'publish');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
       service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
-      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-added`, mockItems);
+      pluginEa.publish('gridService:onItemAdded', mockItems);
 
       setTimeout(() => {
         expect(recalculateSpy).toHaveBeenCalledTimes(2);
-        expect(eaSpy).toHaveBeenCalledTimes(2); // 2x times (1x for onItemAdded then 1x for onPaginationChanged)
-        expect(eaSpy).toHaveBeenNthCalledWith(2, `paginationService:on-pagination-changed`, {
+        expect(pluginEaSpy).toHaveBeenCalledTimes(2); // 2x times (1x for onItemAdded then 1x for onPaginationChanged)
+        expect(pluginEaSpy).toHaveBeenNthCalledWith(2, `paginationService:onPaginationChanged`, {
           dataFrom: 26, dataTo: (50 + mockItems.length), pageSize: 25, pageCount: 4, pageNumber: 2, totalItems: (85 + mockItems.length), pageSizes: mockGridOption.pagination.pageSizes
         });
         expect(service.dataFrom).toBe(26);
@@ -564,15 +563,15 @@ describe('PaginationService', () => {
     });
 
     it('should call "processOnItemAddedOrRemoved" and expect not onPaginationChanged to be triggered and the (To) to remain the same when "onItemAdded" is triggered without any items', (done) => {
-      const eaSpy = jest.spyOn(ea, 'publish');
+      const pluginEaSpy = jest.spyOn(pluginEa, 'publish');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
       service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
-      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-added`, null);
+      pluginEa.publish('gridService:onItemAdded', null);
 
       setTimeout(() => {
         expect(recalculateSpy).toHaveBeenCalledTimes(1);
-        expect(eaSpy).toHaveBeenCalledTimes(1);
+        expect(pluginEaSpy).toHaveBeenCalledTimes(1);
         expect(service.dataFrom).toBe(26);
         expect(service.dataTo).toBe(50);
         done();
@@ -581,17 +580,17 @@ describe('PaginationService', () => {
 
     it('should call "processOnItemAddedOrRemoved" and expect the (To) to be decremented by 2 when "onItemDeleted" is triggered with a single item', (done) => {
       const mockItems = { name: 'John' };
-      const eaSpy = jest.spyOn(ea, 'publish');
+      const pluginEaSpy = jest.spyOn(pluginEa, 'publish');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
       service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
-      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-deleted`, mockItems);
+      pluginEa.publish('gridService:onItemDeleted', mockItems);
 
       setTimeout(() => {
         // called 2x times by init() then by processOnItemAddedOrRemoved()
         expect(recalculateSpy).toHaveBeenCalledTimes(2);
-        expect(eaSpy).toHaveBeenCalledTimes(2); // 2x times (1x for onItemDeleted then 1x for onPaginationChanged)
-        expect(eaSpy).toHaveBeenNthCalledWith(2, `paginationService:on-pagination-changed`, {
+        expect(pluginEaSpy).toHaveBeenCalledTimes(2); // 2x times (1x for onItemDeleted then 1x for onPaginationChanged)
+        expect(pluginEaSpy).toHaveBeenNthCalledWith(2, `paginationService:onPaginationChanged`, {
           dataFrom: 26, dataTo: (50 - 1), pageSize: 25, pageCount: 4, pageNumber: 2, totalItems: (85 - 1), pageSizes: mockGridOption.pagination.pageSizes
         });
         expect(service.dataFrom).toBe(26);
@@ -602,16 +601,16 @@ describe('PaginationService', () => {
 
     it('should call "processOnItemAddedOrRemoved" and expect the (To) to be decremented by 2 when "onItemDeleted" is triggered with an array of 2 new items', (done) => {
       const mockItems = [{ name: 'John' }, { name: 'Jane' }];
-      const eaSpy = jest.spyOn(ea, 'publish');
+      const pluginEaSpy = jest.spyOn(pluginEa, 'publish');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
       service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
-      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-deleted`, mockItems);
+      pluginEa.publish('gridService:onItemDeleted', mockItems);
 
       setTimeout(() => {
         expect(recalculateSpy).toHaveBeenCalledTimes(2); // called 2x times by init() then by processOnItemAddedOrRemoved()
-        expect(eaSpy).toHaveBeenCalledTimes(2); // 2x times (1x for onItemDeleted then 1x for onPaginationChanged)
-        expect(eaSpy).toHaveBeenNthCalledWith(2, `paginationService:on-pagination-changed`, {
+        expect(pluginEaSpy).toHaveBeenCalledTimes(2); // 2x times (1x for onItemDeleted then 1x for onPaginationChanged)
+        expect(pluginEaSpy).toHaveBeenNthCalledWith(2, `paginationService:onPaginationChanged`, {
           dataFrom: 26, dataTo: (50 - mockItems.length), pageSize: 25, pageCount: 4, pageNumber: 2, totalItems: (85 - mockItems.length), pageSizes: mockGridOption.pagination.pageSizes
         });
         done();
@@ -619,20 +618,20 @@ describe('PaginationService', () => {
     });
 
     it('should call "processOnItemAddedOrRemoved" and expect the (To) to remain the same when "onItemDeleted" is triggered without any items', (done) => {
-      const eaSpy = jest.spyOn(ea, 'publish');
+      const pluginEaSpy = jest.spyOn(pluginEa, 'publish');
       const recalculateSpy = jest.spyOn(service, 'recalculateFromToIndexes');
 
       // service.totalItems = 85;
       service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
-      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-deleted`, null);
+      pluginEa.publish('gridService:onItemDeleted', null);
 
       setTimeout(() => {
         // called 1x time by init() only
         expect(recalculateSpy).toHaveBeenCalledTimes(1);
-        expect(eaSpy).toHaveBeenCalledTimes(1);
+        expect(pluginEaSpy).toHaveBeenCalledTimes(1);
         expect(service.dataFrom).toBe(26);
         expect(service.dataTo).toBe(50);
-        expect(eaSpy).toHaveBeenCalledWith('asg:on-item-deleted', null);
+        expect(pluginEaSpy).toHaveBeenCalledWith('gridService:onItemDeleted', null);
         done();
       });
     });
@@ -643,7 +642,7 @@ describe('PaginationService', () => {
       const mockItems = { name: 'John' };
 
       service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
-      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-added`, mockItems);
+      pluginEa.publish('gridService:onItemAdded', mockItems);
       service.changeItemPerPage(200);
 
       setTimeout(() => {
@@ -659,7 +658,7 @@ describe('PaginationService', () => {
       const mockItems = { name: 'John' };
 
       service.init(gridStub, dataviewStub, mockGridOption.pagination, mockGridOption.backendServiceApi);
-      ea.publish(`${DEFAULT_AURELIA_EVENT_PREFIX}:on-item-added`, mockItems);
+      pluginEa.publish('gridService:onItemAdded', mockItems);
       service.changeItemPerPage(100);
 
       setTimeout(() => {

--- a/src/aurelia-slickgrid/services/excelExport.service.ts
+++ b/src/aurelia-slickgrid/services/excelExport.service.ts
@@ -23,11 +23,12 @@ import {
 import { Constants } from '../constants';
 import { exportWithFormatterWhenDefined } from './export-utilities';
 import { addWhiteSpaces, sanitizeHtmlToText, titleCase, mapMomentDateFormatWithFieldType } from './utilities';
+import { SlickgridEventAggregator } from '../custom-elements/slickgridEventAggregator';
 
 const DEFAULT_AURELIA_EVENT_PREFIX = 'asg';
 
 @singleton(true)
-@inject(Optional.of(I18N), EventAggregator)
+@inject(EventAggregator, SlickgridEventAggregator, Optional.of(I18N))
 export class ExcelExportService {
   private _aureliaEventPrefix: string;
   private _fileFormat = FileType.xlsx;
@@ -43,7 +44,7 @@ export class ExcelExportService {
   private _stylesheetFormats: any;
   private _workbook: ExcelWorkbook;
 
-  constructor(private i18n: I18N, private ea: EventAggregator) { }
+  constructor(private globalEa: EventAggregator, private pluginEa: SlickgridEventAggregator, private i18n: I18N) { }
 
   private get datasetIdName(): string {
     return this._gridOptions && this._gridOptions.datasetIdPropertyName || 'id';
@@ -88,7 +89,8 @@ export class ExcelExportService {
     }
 
     return new Promise((resolve, reject) => {
-      this.ea.publish(`${this._aureliaEventPrefix}:onBeforeExportToExcel`, true);
+      this.pluginEa.publish(`excelExportService:onBeforeExportToExcel`, true);
+      this.globalEa.publish(`${this._aureliaEventPrefix}:onBeforeExportToExcel`, true); // @deprecated, should remove it in the future
       this._excelExportOptions = $.extend(true, {}, this._gridOptions.excelExportOptions, options);
       this._fileFormat = this._excelExportOptions.format || FileType.xlsx;
 
@@ -141,7 +143,8 @@ export class ExcelExportService {
 
           // start downloading but add the Blob property only on the start download not on the event itself
           this.startDownloadFile({ ...downloadOptions, blob: excelBlob, data: this._sheet.data });
-          this.ea.publish(`${this._aureliaEventPrefix}:onAfterExportToExcel`, downloadOptions);
+          this.pluginEa.publish(`excelExportService:onAfterExportToExcel`, downloadOptions);
+          this.globalEa.publish(`${this._aureliaEventPrefix}:onAfterExportToExcel`, downloadOptions); // @deprecated, should remove it in the future
           resolve(true);
         } catch (error) {
           reject(error);

--- a/src/aurelia-slickgrid/services/filter.service.ts
+++ b/src/aurelia-slickgrid/services/filter.service.ts
@@ -1,5 +1,4 @@
 import { singleton, inject } from 'aurelia-framework';
-import { EventAggregator } from 'aurelia-event-aggregator';
 import * as $ from 'jquery';
 import * as isequal from 'lodash.isequal';
 
@@ -27,6 +26,7 @@ import {
 import { executeBackendCallback, refreshBackendDataset } from './backend-utilities';
 import { getDescendantProperty } from './utilities';
 import { SharedService } from './shared.service';
+import { SlickgridEventAggregator } from '../custom-elements/slickgridEventAggregator';
 
 // using external non-typed js libraries
 declare var Slick: any;
@@ -36,7 +36,7 @@ let timer: any;
 const DEFAULT_FILTER_TYPING_DEBOUNCE = 500;
 
 @singleton(true)
-@inject(EventAggregator, FilterFactory, SharedService)
+@inject(SlickgridEventAggregator, FilterFactory, SharedService)
 export class FilterService {
   private _eventHandler: SlickEventHandler;
   private _isFilterFirstRender = true;
@@ -47,7 +47,7 @@ export class FilterService {
   private _grid: any;
   private _onSearchChange: SlickEvent;
 
-  constructor(private ea: EventAggregator, private filterFactory: FilterFactory, private sharedService: SharedService) {
+  constructor(private pluginEa: SlickgridEventAggregator, private filterFactory: FilterFactory, private sharedService: SharedService) {
     this._onSearchChange = new Slick.Event();
     this._eventHandler = new Slick.EventHandler();
   }
@@ -241,7 +241,7 @@ export class FilterService {
 
     // emit an event when filters are all cleared
     if (triggerChange) {
-      this.ea.publish('filterService:filterCleared', true);
+      this.pluginEa.publish('filterService:filterCleared', true);
     }
   }
 
@@ -400,9 +400,9 @@ export class FilterService {
       if (backendService && backendService.getCurrentFilters) {
         currentFilters = backendService.getCurrentFilters() as CurrentFilter[];
       }
-      this.ea.publish('filterService:filterChanged', currentFilters);
+      this.pluginEa.publish('filterService:filterChanged', currentFilters);
     } else if (caller === EmitterType.local) {
-      this.ea.publish('filterService:filterChanged', this.getCurrentLocalFilters());
+      this.pluginEa.publish('filterService:filterChanged', this.getCurrentLocalFilters());
     }
   }
 

--- a/src/aurelia-slickgrid/services/grid-odata.service.ts
+++ b/src/aurelia-slickgrid/services/grid-odata.service.ts
@@ -64,7 +64,7 @@ export class GridOdataService implements BackendService {
     this._odataService = new OdataQueryBuilderService();
   }
 
-  init(serviceOptions: OdataOption, pagination?: Pagination, grid?: any): void {
+  init(serviceOptions: Partial<OdataOption>, pagination?: Pagination, grid?: any): void {
     this._grid = grid;
     const mergedOptions = { ...this.defaultOptions, ...serviceOptions };
 

--- a/src/aurelia-slickgrid/services/gridState.service.ts
+++ b/src/aurelia-slickgrid/services/gridState.service.ts
@@ -1,5 +1,5 @@
 import { inject, singleton } from 'aurelia-framework';
-import { EventAggregator, Subscription } from 'aurelia-event-aggregator';
+import { Subscription } from 'aurelia-event-aggregator';
 
 import {
   Column,
@@ -17,12 +17,13 @@ import { ExtensionService } from './extension.service';
 import { FilterService } from './filter.service';
 import { SharedService } from './shared.service';
 import { SortService } from './sort.service';
+import { SlickgridEventAggregator } from '../custom-elements/slickgridEventAggregator';
 
 // using external non-typed js libraries
 declare var Slick: any;
 
 @singleton(true)
-@inject(EventAggregator, ExtensionService, FilterService, SharedService, SortService)
+@inject(SlickgridEventAggregator, ExtensionService, FilterService, SharedService, SortService)
 export class GridStateService {
   private _eventHandler = new Slick.EventHandler();
   private _columns: Column[] = [];
@@ -31,7 +32,7 @@ export class GridStateService {
   private subscriptions: Subscription[] = [];
 
   constructor(
-    private ea: EventAggregator,
+    private pluginEa: SlickgridEventAggregator,
     private extensionService: ExtensionService,
     private filterService: FilterService,
     private sharedService: SharedService,
@@ -207,7 +208,7 @@ export class GridStateService {
   resetColumns(columnDefinitions?: Column[]) {
     const columns: Column[] = columnDefinitions || this._columns;
     const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(columns);
-    this.ea.publish('gridStateService:changed', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
+    this.pluginEa.publish('gridStateService:changed', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
   }
 
   /** if we use Row Selection or the Checkbox Selector, we need to reset any selection */
@@ -228,31 +229,31 @@ export class GridStateService {
   subscribeToAllGridChanges(grid: any) {
     // Subscribe to Event Emitter of Filter changed
     this.subscriptions.push(
-      this.ea.subscribe('filterService:filterChanged', (currentFilters: CurrentFilter[]) => {
+      this.pluginEa.subscribe('filterService:filterChanged', (currentFilters: CurrentFilter[]) => {
         this.resetRowSelection();
-        this.ea.publish('gridStateService:changed', { change: { newValues: currentFilters, type: GridStateType.filter }, gridState: this.getCurrentGridState() });
+        this.pluginEa.publish('gridStateService:changed', { change: { newValues: currentFilters, type: GridStateType.filter }, gridState: this.getCurrentGridState() });
       })
     );
     // Subscribe to Event Emitter of Filter cleared
     this.subscriptions.push(
-      this.ea.subscribe('filterService:filterCleared', () => {
+      this.pluginEa.subscribe('filterService:filterCleared', () => {
         this.resetRowSelection();
-        this.ea.publish('gridStateService:changed', { change: { newValues: [], type: GridStateType.filter }, gridState: this.getCurrentGridState() });
+        this.pluginEa.publish('gridStateService:changed', { change: { newValues: [], type: GridStateType.filter }, gridState: this.getCurrentGridState() });
       })
     );
 
     // Subscribe to Event Emitter of Sort changed
     this.subscriptions.push(
-      this.ea.subscribe('sortService:sortChanged', (currentSorters: CurrentSorter[]) => {
+      this.pluginEa.subscribe('sortService:sortChanged', (currentSorters: CurrentSorter[]) => {
         this.resetRowSelection();
-        this.ea.publish('gridStateService:changed', { change: { newValues: currentSorters, type: GridStateType.sorter }, gridState: this.getCurrentGridState() });
+        this.pluginEa.publish('gridStateService:changed', { change: { newValues: currentSorters, type: GridStateType.sorter }, gridState: this.getCurrentGridState() });
       })
     );
     // Subscribe to Event Emitter of Sort cleared
     this.subscriptions.push(
-      this.ea.subscribe('sortService:sortCleared', () => {
+      this.pluginEa.subscribe('sortService:sortCleared', () => {
         this.resetRowSelection();
-        this.ea.publish('gridStateService:changed', { change: { newValues: [], type: GridStateType.sorter }, gridState: this.getCurrentGridState() });
+        this.pluginEa.publish('gridStateService:changed', { change: { newValues: [], type: GridStateType.sorter }, gridState: this.getCurrentGridState() });
       })
     );
 
@@ -266,9 +267,9 @@ export class GridStateService {
 
     // subscribe to HeaderMenu (hide column)
     this.subscriptions.push(
-      this.ea.subscribe('headerMenu:onColumnsChanged', (visibleColumns: Column[]) => {
+      this.pluginEa.subscribe('headerMenu:onColumnsChanged', (visibleColumns: Column[]) => {
         const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(visibleColumns);
-        this.ea.publish('gridStateService:changed', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
+        this.pluginEa.publish('gridStateService:changed', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
       })
     );
   }
@@ -290,7 +291,7 @@ export class GridStateService {
       this._eventHandler.subscribe(slickEvent, (e: Event, args: any) => {
         const columns: Column[] = args && args.columns;
         const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(columns);
-        this.ea.publish('gridStateService:changed', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
+        this.pluginEa.publish('gridStateService:changed', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
       });
     }
   }
@@ -307,7 +308,7 @@ export class GridStateService {
       this._eventHandler.subscribe(slickGridEvent, (e: Event, args: any) => {
         const columns: Column[] = grid.getColumns();
         const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(columns);
-        this.ea.publish('gridStateService:changed', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
+        this.pluginEa.publish('gridStateService:changed', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
       });
     }
   }

--- a/src/aurelia-slickgrid/services/groupingAndColspan.service.ts
+++ b/src/aurelia-slickgrid/services/groupingAndColspan.service.ts
@@ -1,4 +1,3 @@
-import { EventAggregator } from 'aurelia-event-aggregator';
 import { inject, singleton } from 'aurelia-framework';
 import * as $ from 'jquery';
 
@@ -8,18 +7,19 @@ import {
   SlickEventHandler,
 } from './../models/index';
 import { ExtensionUtility } from '../extensions/extensionUtility';
+import { SlickgridEventAggregator } from '../custom-elements/slickgridEventAggregator';
 
 // using external non-typed js libraries
 declare var Slick: any;
 
 @singleton(true)
-@inject(ExtensionUtility, EventAggregator)
+@inject(ExtensionUtility, SlickgridEventAggregator)
 export class GroupingAndColspanService {
   private _eventHandler: SlickEventHandler;
   private _grid: any;
   private _aureliaEventPrefix: string;
 
-  constructor(private extensionUtility: ExtensionUtility, private ea: EventAggregator) {
+  constructor(private extensionUtility: ExtensionUtility, private pluginEa: SlickgridEventAggregator) {
     this._eventHandler = new Slick.EventHandler();
   }
 
@@ -55,7 +55,7 @@ export class GroupingAndColspanService {
         this._eventHandler.subscribe(grid.onColumnsResized, () => this.renderPreHeaderRowGroupingTitles());
         this._eventHandler.subscribe(grid.onColumnsReordered, () => this.renderPreHeaderRowGroupingTitles());
         this._eventHandler.subscribe(dataView.onRowCountChanged, () => this.renderPreHeaderRowGroupingTitles());
-        this.ea.subscribe(`${this._aureliaEventPrefix}:onAfterResize`, () => this.renderPreHeaderRowGroupingTitles());
+        this.pluginEa.subscribe(`resizerService:onAfterResize`, () => this.renderPreHeaderRowGroupingTitles());
 
         // also not sure why at this point, but it seems that I need to call the 1st create in a delayed execution
         // probably some kind of timing issues and delaying it until the grid is fully ready does help

--- a/src/aurelia-slickgrid/services/resizer.service.ts
+++ b/src/aurelia-slickgrid/services/resizer.service.ts
@@ -1,8 +1,10 @@
 import { singleton, inject } from 'aurelia-framework';
 import { EventAggregator } from 'aurelia-event-aggregator';
+import * as $ from 'jquery';
+
 import { GridOption } from './../models/index';
 import { getScrollBarWidth } from './utilities';
-import * as $ from 'jquery';
+import { SlickgridEventAggregator } from '../custom-elements/slickgridEventAggregator';
 
 // global constants, height/width are in pixels
 const DATAGRID_MIN_HEIGHT = 180;
@@ -18,7 +20,7 @@ export interface GridDimension {
 }
 
 @singleton(true)
-@inject(EventAggregator)
+@inject(EventAggregator, SlickgridEventAggregator)
 export class ResizerService {
   private _fixedHeight: number | null | undefined;
   private _fixedWidth: number | null | undefined;
@@ -28,7 +30,7 @@ export class ResizerService {
   private _timer: any;
   aureliaEventPrefix: string;
 
-  constructor(private ea: EventAggregator) { }
+  constructor(private globalEa: EventAggregator, private pluginEa: SlickgridEventAggregator) { }
 
   /** Getter for the Grid Options pulled through the Grid Object */
   private get _gridOptions(): GridOption {
@@ -67,7 +69,9 @@ export class ResizerService {
     // -- 2nd bind a trigger on the Window DOM element, so that it happens also when resizing after first load
     // -- bind auto-resize to Window object only if it exist
     $(window).on(`resize.grid.${this._gridUid}`, (event: Event) => {
-      this.ea.publish(`${this.aureliaEventPrefix}:onBeforeResize`, event);
+      this.pluginEa.publish(`resizerService:onBeforeResize`, event);
+      this.globalEa.publish(`${this.aureliaEventPrefix}:onBeforeResize`, event); // @deprecated, should remove it in the future
+
       if (!this._resizePaused) {
         this.resizeGrid(0, newSizes);
       }
@@ -207,7 +211,8 @@ export class ResizerService {
 
   resizeGridCallback(newSizes: GridDimension | undefined) {
     const lastDimensions = this.resizeGridWithDimensions(newSizes);
-    this.ea.publish(`${this.aureliaEventPrefix}:onAfterResize`, lastDimensions);
+    this.pluginEa.publish(`resizerService:onAfterResize`, lastDimensions);
+    this.globalEa.publish(`${this.aureliaEventPrefix}:onAfterResize`, lastDimensions); // @deprecated, should remove it in the future
     return lastDimensions;
   }
 

--- a/src/aurelia-slickgrid/services/sort.service.ts
+++ b/src/aurelia-slickgrid/services/sort.service.ts
@@ -1,5 +1,4 @@
 import { inject, singleton } from 'aurelia-framework';
-import { EventAggregator } from 'aurelia-event-aggregator';
 
 import {
   Column,
@@ -16,12 +15,13 @@ import {
 import { executeBackendCallback, refreshBackendDataset } from './backend-utilities';
 import { getDescendantProperty } from './utilities';
 import { sortByFieldType } from '../sorters/sorterUtilities';
+import { SlickgridEventAggregator } from '../custom-elements/slickgridEventAggregator';
 
 // using external non-typed js libraries
 declare var Slick: any;
 
 @singleton(true)
-@inject(EventAggregator)
+@inject(SlickgridEventAggregator)
 export class SortService {
   private _currentLocalSorters: CurrentSorter[] = [];
   private _eventHandler: SlickEventHandler;
@@ -29,7 +29,7 @@ export class SortService {
   private _grid: any;
   private _isBackendGrid = false;
 
-  constructor(private ea: EventAggregator) {
+  constructor(private pluginEa: SlickgridEventAggregator) {
     this._eventHandler = new Slick.EventHandler();
   }
 
@@ -132,7 +132,7 @@ export class SortService {
     this._currentLocalSorters = [];
 
     // emit an event when sorts are all cleared
-    this.ea.publish('sortService:sortCleared', true);
+    this.pluginEa.publish('sortService:sortCleared', true);
   }
 
   /**
@@ -147,12 +147,12 @@ export class SortService {
       if (backendService && backendService.getCurrentSorters) {
         currentSorters = backendService.getCurrentSorters() as CurrentSorter[];
       }
-      this.ea.publish('sortService:sortChanged', currentSorters);
+      this.pluginEa.publish('sortService:sortChanged', currentSorters);
     } else if (sender === EmitterType.local) {
       if (currentLocalSorters) {
         this._currentLocalSorters = currentLocalSorters;
       }
-      this.ea.publish('sortService:sortChanged', this.getCurrentLocalSorters());
+      this.pluginEa.publish('sortService:sortChanged', this.getCurrentLocalSorters());
     }
   }
 

--- a/src/examples/slickgrid/example13.html
+++ b/src/examples/slickgrid/example13.html
@@ -49,6 +49,9 @@
   </div>
 
   <aurelia-slickgrid grid-id="grid1" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
-    dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)">
+                     dataset.bind="dataset"
+                     asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
+                     asg-on-before-export-to-excel.delegate="processing = true"
+                     asg-on-after-export-to-excel.delegate="processing = false">
   </aurelia-slickgrid>
 </template>

--- a/src/examples/slickgrid/example13.ts
+++ b/src/examples/slickgrid/example13.ts
@@ -45,14 +45,6 @@ export class Example13 {
   attached() {
     // populate the dataset once the grid is ready
     this.loadData(500);
-
-    this.subOnBeforeExport = this.ea.subscribe('asg:onBeforeExportToFile', () => this.processing = true);
-    this.subOnAfterExport = this.ea.subscribe('asg:onAfterExportToFile', () => this.processing = false);
-  }
-
-  detached() {
-    this.subOnAfterExport.dispose();
-    this.subOnBeforeExport.dispose();
   }
 
   aureliaGridReady(aureliaGrid: AureliaGridInstance) {

--- a/src/examples/slickgrid/example6.ts
+++ b/src/examples/slickgrid/example6.ts
@@ -52,7 +52,6 @@ export class Example6 {
   processing = false;
   selectedLanguage: string;
   status = { text: '', class: '' };
-  subscription: Subscription;
 
   constructor(private ea: EventAggregator, private http: HttpClient, private i18n: I18N) {
     // define the grid options & columns and then create the grid itself
@@ -62,12 +61,10 @@ export class Example6 {
     const defaultLang = 'en';
     this.i18n.setLocale(defaultLang);
     this.selectedLanguage = defaultLang;
-    this.subscription = this.ea.subscribe('gridStateService:changed', (data) => console.log(data));
   }
 
   detached() {
     this.saveCurrentGridState();
-    this.subscription.dispose();
   }
 
   aureliaGridReady(aureliaGrid: AureliaGridInstance) {


### PR DESCRIPTION
- we now have 2 instances a Event Aggregator, 1x is Global (mostly for I18N) and another 1x is for the plugin itself (events that are sent only internally and in a transient mode)