### PR TITLE
feat(selection): preserve row selection & add it to Grid State & Presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "jszip": "^3.2.2",
     "lodash.isequal": "^4.5.0",
     "moment-mini": "^2.22.1",
-    "slickgrid": "^2.4.17",
+    "slickgrid": "^2.4.18",
     "text-encoding-utf-8": "^1.0.2"
   },
   "devDependencies": {
@@ -198,11 +198,11 @@
       "excel-builder-webpacker": "^1.0.4",
       "flatpickr": ">=4.2.4",
       "i18next-xhr-backend": ">=1.5.0",
-      "jquery": ">=3.2.1",
+      "jquery": "^3.4.1",
       "jquery-ui-dist": "^1.12.1",
       "lodash.isequal": "^4.5.0",
       "moment-mini": ">=2.18.1",
-      "slickgrid": "^2.4.17",
+      "slickgrid": "^2.4.18",
       "text-encoding-utf-8": "^1.0.2"
     }
   },

--- a/src/aurelia-slickgrid/global-grid-options.ts
+++ b/src/aurelia-slickgrid/global-grid-options.ts
@@ -67,6 +67,9 @@ export const GlobalGridOptions: GridOption = {
       ofKey: 'OF',
     }
   },
+  dataView: {
+    syncGridSelection: true // when enabled, this will preserve the row selection even after filtering/sorting/grouping
+  },
   datasetIdPropertyName: 'id',
   defaultAureliaEventPrefix: 'asg',
   defaultSlickgridEventPrefix: 'sg',

--- a/src/aurelia-slickgrid/models/currentColumn.interface.ts
+++ b/src/aurelia-slickgrid/models/currentColumn.interface.ts
@@ -1,5 +1,3 @@
-import { OperatorString, OperatorType, SearchTerm } from './../models/index';
-
 export interface CurrentColumn {
   /** Column id (in the column definitions) */
   columnId: string;

--- a/src/aurelia-slickgrid/models/currentRowSelection.interface.ts
+++ b/src/aurelia-slickgrid/models/currentRowSelection.interface.ts
@@ -1,0 +1,11 @@
+export interface CurrentRowSelection {
+  /**
+   * Grid Row Indexes, based on the row position in the grid (what you see in the UI).
+   * NOTE: when using Pagination, this value will be showing ONLY what is shown in the current Page,
+   * this is a limitation from SlickGrid itself, so it is RECOMMENDED to use the "dataContextIds" to know the exact set of selections following your dataset IDs
+   */
+  gridRowIndexes?: number[];
+
+  /** Selection by the Object Data Context IDs, in other words the selected IDs from your dataset */
+  dataContextIds?: Array<number | string>;
+}

--- a/src/aurelia-slickgrid/models/gridState.interface.ts
+++ b/src/aurelia-slickgrid/models/gridState.interface.ts
@@ -1,4 +1,4 @@
-import { CurrentColumn, CurrentFilter, CurrentSorter } from './index';
+import { CurrentColumn, CurrentFilter, CurrentPagination, CurrentRowSelection, CurrentSorter } from './index';
 
 export interface GridState {
   /** Columns (and their state: visibility/position) that are currently applied in the grid */
@@ -11,8 +11,8 @@ export interface GridState {
   sorters?: CurrentSorter[] | null;
 
   /** Pagination (and it's state, pageNumber, pageSize) that are currently applied in the grid */
-  pagination?: {
-    pageNumber: number;
-    pageSize: number;
-  } | null;
+  pagination?: CurrentPagination | null;
+
+  /** Row Selections (by their dataContext IDs and/or grid row indexes) */
+  rowSelection?: CurrentRowSelection | null;
 }

--- a/src/aurelia-slickgrid/models/gridStateChange.interface.ts
+++ b/src/aurelia-slickgrid/models/gridStateChange.interface.ts
@@ -1,12 +1,15 @@
-import { Column, CurrentFilter, CurrentPagination, CurrentSorter, GridState, GridStateType } from './index';
+import { Column, CurrentFilter, CurrentPagination, CurrentRowSelection, CurrentSorter, GridState, GridStateType } from './index';
 
 export interface GridStateChange {
-  /** Changes that were triggered */
+  /** Last Grid State Change that was triggered (only 1 type of change at a time) */
   change?: {
-    newValues: Column[] | CurrentFilter[] | CurrentSorter[] | CurrentPagination;
+    /** Grid State change, the values of the new change */
+    newValues: Column[] | CurrentFilter[] | CurrentSorter[] | CurrentPagination | CurrentRowSelection;
+
+    /** The Grid State Type of change that was made (filter/sorter/...) */
     type: GridStateType;
   };
 
-  /** Current grid state */
+  /** Current Grid State, that will include all of the current states (columns/filters/sorters) and some optional ones (pagination/rowSelection) */
   gridState?: GridState;
 }

--- a/src/aurelia-slickgrid/models/gridStateType.enum.ts
+++ b/src/aurelia-slickgrid/models/gridStateType.enum.ts
@@ -2,5 +2,6 @@ export enum GridStateType {
   columns = 'columns',
   filter = 'filter',
   pagination = 'pagination',
-  sorter = 'sorter'
+  rowSelection = 'rowSelection',
+  sorter = 'sorter',
 }

--- a/src/aurelia-slickgrid/models/index.ts
+++ b/src/aurelia-slickgrid/models/index.ts
@@ -25,6 +25,7 @@ export * from './contextMenu.interface';
 export * from './currentColumn.interface';
 export * from './currentFilter.interface';
 export * from './currentPagination.interface';
+export * from './currentRowSelection.interface';
 export * from './currentSorter.interface';
 export * from './customFooterOption.interface';
 export * from './delimiterType.enum';

--- a/src/aurelia-slickgrid/services/__tests__/grid.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/grid.service.spec.ts
@@ -24,6 +24,7 @@ const filterServiceStub = {
 } as unknown as FilterService;
 
 const gridStateServiceStub = {
+  needToPreserveRowSelection: jest.fn(),
   resetColumns: jest.fn(),
 } as unknown as GridStateService;
 

--- a/src/aurelia-slickgrid/services/__tests__/gridState.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/gridState.service.spec.ts
@@ -7,6 +7,7 @@ import {
   BackendService,
   GridOption,
   CurrentPagination,
+  CurrentRowSelection,
   CurrentSorter,
   CurrentFilter,
   Column,
@@ -30,14 +31,24 @@ const backendServiceStub = {
   getCurrentSorters: () => { },
 } as BackendService;
 
+const dataViewStub = {
+  mapIdsToRows: jest.fn(),
+  mapRowsToIds: jest.fn(),
+  onBeforePagingInfoChanged: new Slick.Event(),
+  onPagingInfoChanged: new Slick.Event(),
+};
+
 const gridStub = {
   autosizeColumns: jest.fn(),
   getScrollbarDimensions: jest.fn(),
   getOptions: () => gridOptionMock,
   getColumns: jest.fn(),
+  getSelectionModel: jest.fn(),
+  getSelectedRows: jest.fn(),
+  setSelectedRows: jest.fn(),
   onColumnsReordered: new Slick.Event(),
   onColumnsResized: new Slick.Event(),
-  setSelectedRows: jest.fn(),
+  onSelectedRowsChanged: new Slick.Event(),
 };
 
 const extensionServiceStub = {
@@ -59,7 +70,8 @@ describe('GridStateService', () => {
     ea = new EventAggregator();
     sharedService = new SharedService();
     service = new GridStateService(ea, extensionServiceStub, filterServiceStub, sharedService, sortServiceStub);
-    service.init(gridStub);
+    service.init(gridStub, dataViewStub);
+    jest.spyOn(gridStub, 'getSelectionModel').mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -85,7 +97,8 @@ describe('GridStateService', () => {
       const gridStateSpy = jest.spyOn(service, 'subscribeToAllGridChanges');
       const eaSpy = jest.spyOn(ea, 'subscribe');
 
-      service.init(gridStub);
+      service.init(gridStub, dataViewStub);
+      jest.spyOn(gridStub, 'getSelectionModel').mockReturnValue(true);
 
       expect(gridStateSpy).toHaveBeenCalled();
       expect(eaSpy).toHaveBeenCalledTimes(5);
@@ -130,7 +143,8 @@ describe('GridStateService', () => {
         const gridStateSpy = jest.spyOn(service, 'getCurrentGridState').mockReturnValue(gridStateMock);
         const extensionSpy = jest.spyOn(extensionServiceStub, 'getExtensionByName').mockReturnValue(extensionMock);
 
-        service.init(gridStub);
+        service.init(gridStub, dataViewStub);
+        jest.spyOn(gridStub, 'getSelectionModel').mockReturnValue(true);
         slickgridEvent.notify({ columns: columnsMock }, new Slick.EventData(), gridStub);
 
         expect(gridStateSpy).toHaveBeenCalled();
@@ -153,7 +167,8 @@ describe('GridStateService', () => {
         const gridColumnResizeSpy = jest.spyOn(gridStub.onColumnsResized, 'subscribe');
         const gridStateSpy = jest.spyOn(service, 'getCurrentGridState').mockReturnValue(gridStateMock);
 
-        service.init(gridStub);
+        service.init(gridStub, dataViewStub);
+        jest.spyOn(gridStub, 'getSelectionModel').mockReturnValue(true);
         gridStub.onColumnsReordered.notify({ impactedColumns: columnsMock }, new Slick.EventData(), gridStub);
         service.resetColumns();
 
@@ -276,7 +291,317 @@ describe('GridStateService', () => {
     });
   });
 
+  describe('getCurrentRowSelections method', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should return null when "enableCheckboxSelector" flag is disabled', () => {
+      const gridOptionsMock = { enableCheckboxSelector: false, enableRowSelection: false } as GridOption;
+      jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+
+      const output = service.getCurrentRowSelections();
+
+      expect(output).toBeNull();
+    });
+
+    it('should return the current row selections in the grid when "enableCheckboxSelector" flag is enabled', () => {
+      const selectedGridRows = [2];
+      const selectedRowIds = [99];
+      const gridOptionsMock = { enableCheckboxSelector: true } as GridOption;
+      jest.spyOn(gridStub, 'getSelectedRows').mockReturnValue(selectedGridRows);
+      jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+      const sharedSpy = jest.spyOn(dataViewStub, 'mapRowsToIds').mockReturnValue(selectedRowIds);
+
+      const output = service.getCurrentRowSelections();
+
+      expect(sharedSpy).toHaveBeenCalled();
+      expect(output).toEqual({ gridRowIndexes: selectedGridRows, dataContextIds: selectedRowIds });
+    });
+
+    it('should return the current row selections in the grid when "enableRowSelection" flag is enabled', () => {
+      const selectedGridRows = [2];
+      const selectedRowIds = [99];
+      const gridOptionsMock = { enableRowSelection: true } as GridOption;
+      jest.spyOn(gridStub, 'getSelectedRows').mockReturnValue(selectedGridRows);
+      jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+      const sharedSpy = jest.spyOn(dataViewStub, 'mapRowsToIds').mockReturnValue(selectedRowIds);
+
+      const output = service.getCurrentRowSelections();
+
+      expect(sharedSpy).toHaveBeenCalled();
+      expect(output).toEqual({ gridRowIndexes: selectedGridRows, dataContextIds: selectedRowIds });
+    });
+
+    it('should call "getCurrentGridState" method and return the Row Selection when either "enableCheckboxSelector" or "enableRowSelection" flag is enabled', () => {
+      const selectedGridRows = [2];
+      const selectedRowIds = [99];
+      const gridOptionsMock = { enableCheckboxSelector: true } as GridOption;
+      jest.spyOn(gridStub, 'getSelectedRows').mockReturnValue(selectedGridRows);
+      jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+      const columnMock = [{ columnId: 'field1', cssClass: 'red', headerCssClass: '', width: 100 }] as CurrentColumn[];
+      const filterMock = [{ columnId: 'field1', operator: 'EQ', searchTerms: [] }] as CurrentFilter[];
+      const sorterMock = [{ columnId: 'field1', direction: 'ASC' }, { columnId: 'field2', direction: 'DESC' }] as CurrentSorter[];
+      const selectionMock = { gridRowIndexes: selectedGridRows, dataContextIds: selectedRowIds } as CurrentRowSelection;
+
+      const columnSpy = jest.spyOn(service, 'getCurrentColumns').mockReturnValue(columnMock);
+      const filterSpy = jest.spyOn(service, 'getCurrentFilters').mockReturnValue(filterMock);
+      const sorterSpy = jest.spyOn(service, 'getCurrentSorters').mockReturnValue(sorterMock);
+      const selectionSpy = jest.spyOn(service, 'getCurrentRowSelections').mockReturnValue(selectionMock);
+
+      const output = service.getCurrentGridState();
+
+      expect(columnSpy).toHaveBeenCalled();
+      expect(filterSpy).toHaveBeenCalled();
+      expect(sorterSpy).toHaveBeenCalled();
+      expect(selectionSpy).toHaveBeenCalled();
+      expect(output).toEqual({ columns: columnMock, filters: filterMock, sorters: sorterMock, rowSelection: selectionMock } as GridState);
+    });
+
+    it('should call the "mapIdsToRows" from the DataView and get the data IDs from the "selectedRowDataContextIds" array when Pagination is enabled', () => {
+      const mockRowIndexes = [3, 44];
+      const mockRowIds = [333, 444];
+      const gridOptionsMock = { enablePagination: true, enableRowSelection: true } as GridOption;
+      jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+      const mapIdSpy = jest.spyOn(dataViewStub, 'mapIdsToRows').mockReturnValue(mockRowIndexes);
+
+      service.selectedRowDataContextIds = mockRowIds;
+      const output = service.getCurrentRowSelections();
+
+      expect(mapIdSpy).toHaveBeenCalled();
+      expect(output).toEqual({ dataContextIds: mockRowIds, gridRowIndexes: mockRowIndexes });
+    });
+  });
+
+  describe('Row Selection - bindSlickGridRowSelectionToGridStateChange method', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('without Pagination', () => {
+      beforeEach(() => {
+        const gridOptionsMock = { enablePagination: false, enableRowSelection: true } as GridOption;
+        jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+      });
+
+      it('should call the "onGridStateChanged" event with the row selection when Pagination is disabled and "onSelectedRowsChanged" is triggered', (done) => {
+        const mockRowIndexes = [3, 44];
+        const mockRowIds = [333, 444];
+        const eaSpy = jest.spyOn(ea, 'publish');
+        const columnMock = [{ columnId: 'field1', cssClass: 'red', headerCssClass: '', width: 100 }] as CurrentColumn[];
+        const filterMock = [{ columnId: 'field1', operator: 'EQ', searchTerms: [] }] as CurrentFilter[];
+        const sorterMock = [{ columnId: 'field1', direction: 'ASC' }, { columnId: 'field2', direction: 'DESC' }] as CurrentSorter[];
+
+        jest.spyOn(gridStub, 'getSelectedRows').mockReturnValue(mockRowIndexes);
+        const mapRowsSpy = jest.spyOn(dataViewStub, 'mapRowsToIds').mockReturnValue(mockRowIds);
+        jest.spyOn(service, 'getCurrentColumns').mockReturnValue(columnMock);
+        jest.spyOn(service, 'getCurrentFilters').mockReturnValue(filterMock);
+        jest.spyOn(service, 'getCurrentSorters').mockReturnValue(sorterMock);
+
+        service.init(gridStub, dataViewStub);
+        service.selectedRowDataContextIds = mockRowIds;
+        gridStub.onSelectedRowsChanged.notify({ rows: mockRowIndexes, previousSelectedRows: [] });
+
+        setTimeout(() => {
+          expect(mapRowsSpy).toHaveBeenCalled();
+          expect(eaSpy).toHaveBeenLastCalledWith(`gridStateService:changed`, {
+            change: { newValues: { dataContextIds: mockRowIds, gridRowIndexes: mockRowIndexes, }, type: 'rowSelection', },
+            gridState: {
+              columns: columnMock,
+              filters: filterMock,
+              sorters: sorterMock,
+              rowSelection: { dataContextIds: mockRowIds, gridRowIndexes: mockRowIndexes, },
+            },
+          });
+          done();
+        });
+      });
+    });
+
+    describe('with Pagination (bindSlickGridRowSelectionWithPaginationToGridStateChange)', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+        service.dispose();
+        const gridOptionsMock = { enablePagination: true, enableRowSelection: true } as GridOption;
+        jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+      });
+
+      it('should call the "onGridStateChanged" event with the row selection when Pagination is disabled and "onSelectedRowsChanged" is triggered', (done) => {
+        const mockPreviousRowIndexes = [3, 33];
+        const mockRowIndexes = [3, 44];
+        const mockRowIds = [333, 444];
+        const columnMock = [{ columnId: 'field1', cssClass: 'red', headerCssClass: '', width: 100 }] as CurrentColumn[];
+        const filterMock = [{ columnId: 'field1', operator: 'EQ', searchTerms: [] }] as CurrentFilter[];
+        const sorterMock = [{ columnId: 'field1', direction: 'ASC' }, { columnId: 'field2', direction: 'DESC' }] as CurrentSorter[];
+        const paginationMock = { pageNumber: 3, pageSize: 25 } as CurrentPagination;
+
+        jest.spyOn(gridStub, 'getSelectedRows').mockReturnValue(mockRowIndexes);
+        jest.spyOn(service, 'getCurrentColumns').mockReturnValue(columnMock);
+        jest.spyOn(service, 'getCurrentFilters').mockReturnValue(filterMock);
+        jest.spyOn(service, 'getCurrentSorters').mockReturnValue(sorterMock);
+        jest.spyOn(service, 'getCurrentPagination').mockReturnValue(paginationMock);
+        const eaSpy = jest.spyOn(ea, 'publish');
+        const mapRowsSpy = jest.spyOn(dataViewStub, 'mapRowsToIds').mockReturnValue(mockRowIds);
+
+        service.init(gridStub, dataViewStub);
+        service.selectedRowDataContextIds = mockRowIds;
+
+        // the regular event flow is 1.onBeforePagingInfoChanged, 2.onPagingInfoChanged then 3.onSelectedRowsChanged
+        dataViewStub.onBeforePagingInfoChanged.notify({ pageSize: paginationMock.pageSize, pageNum: 0 });
+        dataViewStub.onPagingInfoChanged.notify({ pageSize: paginationMock.pageSize, pageNum: (paginationMock.pageNumber - 1) });
+        gridStub.onSelectedRowsChanged.notify({ rows: mockRowIndexes, previousSelectedRows: mockPreviousRowIndexes });
+
+        setTimeout(() => {
+          expect(mapRowsSpy).toHaveBeenCalled();
+          expect(eaSpy).toHaveBeenLastCalledWith(`gridStateService:changed`, {
+            change: { newValues: { dataContextIds: mockRowIds, gridRowIndexes: mockRowIndexes, }, type: 'rowSelection' },
+            gridState: {
+              columns: columnMock,
+              filters: filterMock,
+              sorters: sorterMock,
+              pagination: paginationMock,
+              rowSelection: { dataContextIds: mockRowIds, gridRowIndexes: mockRowIndexes, },
+            },
+          });
+          done();
+        });
+      });
+
+      it('should call the "setSelectedRows" grid method inside the "onPagingInfoChanged" event when the rows are not yet selected in the grid', (done) => {
+        const currentSelectedRowIndexes = [4, 44];
+        const shouldBeSelectedRowIndexes = [3, 44];
+        const mockRowIds = [333, 444];
+        const columnMock = [{ columnId: 'field1', cssClass: 'red', headerCssClass: '', width: 100 }] as CurrentColumn[];
+        const paginationMock = { pageNumber: 3, pageSize: 25 } as CurrentPagination;
+
+        jest.spyOn(service, 'getCurrentColumns').mockReturnValue(columnMock);
+        jest.spyOn(service, 'getCurrentPagination').mockReturnValue(paginationMock);
+        const setSelectSpy = jest.spyOn(gridStub, 'setSelectedRows');
+
+        service.init(gridStub, dataViewStub);
+        service.selectedRowDataContextIds = mockRowIds;
+
+        // this comparison which has different arrays, will trigger the expectation we're looking for
+        jest.spyOn(dataViewStub, 'mapIdsToRows').mockReturnValue(shouldBeSelectedRowIndexes);
+        jest.spyOn(gridStub, 'getSelectedRows').mockReturnValueOnce(currentSelectedRowIndexes);
+
+        // the regular event flow is 1.onBeforePagingInfoChanged, 2.onPagingInfoChanged then 3.onSelectedRowsChanged
+        dataViewStub.onBeforePagingInfoChanged.notify({ pageSize: paginationMock.pageSize, pageNum: 0 });
+        dataViewStub.onPagingInfoChanged.notify({ pageSize: paginationMock.pageSize, pageNum: (paginationMock.pageNumber - 1) });
+
+        setTimeout(() => {
+          expect(setSelectSpy).toHaveBeenCalledWith(shouldBeSelectedRowIndexes);
+          done();
+        });
+      });
+
+      it('should call the "setSelectedRows" grid method inside the "onSelectedRowsChanged" when the rows are not yet selected in the grid before calling "onGridStateChanged" event', (done) => {
+        const mockPreviousRowIndexes = [3, 33];
+        const mockRowIndexes = [3, 44];
+        const currentSelectedRowIndexes = [4, 44];
+        const shouldBeSelectedRowIndexes = [3, 44];
+        const mockRowIds = [333, 444];
+        const columnMock = [{ columnId: 'field1', cssClass: 'red', headerCssClass: '', width: 100 }] as CurrentColumn[];
+        const paginationMock = { pageNumber: 3, pageSize: 25 } as CurrentPagination;
+
+        jest.spyOn(service, 'getCurrentColumns').mockReturnValue(columnMock);
+        jest.spyOn(service, 'getCurrentPagination').mockReturnValue(paginationMock);
+        const eaSpy = jest.spyOn(ea, 'publish');
+        const mapRowsSpy = jest.spyOn(dataViewStub, 'mapRowsToIds').mockReturnValue(mockRowIds);
+        const setSelectSpy = jest.spyOn(gridStub, 'setSelectedRows');
+
+        service.init(gridStub, dataViewStub);
+        service.selectedRowDataContextIds = mockRowIds;
+
+        // this comparison which has different arrays, will trigger the expectation we're looking for
+        jest.spyOn(dataViewStub, 'mapIdsToRows').mockReturnValue(shouldBeSelectedRowIndexes);
+        const getSelectSpy = jest.spyOn(gridStub, 'getSelectedRows').mockReturnValueOnce(currentSelectedRowIndexes).mockReturnValue(shouldBeSelectedRowIndexes);
+
+        // the regular event flow is 1.onBeforePagingInfoChanged, 2.onPagingInfoChanged then 3.onSelectedRowsChanged
+        dataViewStub.onBeforePagingInfoChanged.notify({ pageSize: paginationMock.pageSize, pageNum: 0 });
+        // dataViewStub.onPagingInfoChanged.notify({ pageSize: paginationMock.pageSize, pageNum: (paginationMock.pageNumber - 1) });
+        gridStub.onSelectedRowsChanged.notify({ rows: mockRowIndexes, previousSelectedRows: mockPreviousRowIndexes });
+
+        setTimeout(() => {
+          expect(mapRowsSpy).toHaveBeenCalled();
+          expect(getSelectSpy).toHaveBeenCalledTimes(2);
+          expect(setSelectSpy).toHaveBeenCalledWith(shouldBeSelectedRowIndexes);
+          expect(eaSpy).toHaveBeenLastCalledWith(`gridStateService:changed`, {
+            change: { newValues: { dataContextIds: mockRowIds, gridRowIndexes: shouldBeSelectedRowIndexes, }, type: 'rowSelection' },
+            gridState: {
+              columns: columnMock,
+              filters: null,
+              sorters: null,
+              pagination: paginationMock,
+              rowSelection: { dataContextIds: mockRowIds, gridRowIndexes: shouldBeSelectedRowIndexes, },
+            },
+          });
+          done();
+        });
+      });
+
+      it('should set new rows in the "selectedRowDataContextIds" setter when "onSelectedRowsChanged" is triggered with new selected row additions', (done) => {
+        const mockPreviousRowIndexes = [3, 77];
+        const mockPreviousDataIds = [333, 777];
+        const mockNewRowIndexes = [3, 77, 55];
+        const mockNewDataIds = [333, 777, 555];
+        const columnMock = [{ columnId: 'field1', cssClass: 'red', headerCssClass: '', width: 100 }] as CurrentColumn[];
+        const paginationMock = { pageNumber: 3, pageSize: 25 } as CurrentPagination;
+
+        jest.spyOn(service, 'getCurrentColumns').mockReturnValue(columnMock);
+        jest.spyOn(service, 'getCurrentPagination').mockReturnValue(paginationMock);
+        const mapRowsSpy = jest.spyOn(dataViewStub, 'mapRowsToIds').mockReturnValue(mockNewDataIds);
+
+        service.init(gridStub, dataViewStub);
+        service.selectedRowDataContextIds = mockPreviousDataIds;
+
+        // the regular event flow is 1.onBeforePagingInfoChanged, 2.onPagingInfoChanged then 3.onSelectedRowsChanged
+        dataViewStub.onBeforePagingInfoChanged.notify({ pageSize: paginationMock.pageSize, pageNum: 0 });
+        dataViewStub.onPagingInfoChanged.notify({ pageSize: paginationMock.pageSize, pageNum: (paginationMock.pageNumber - 1) });
+        gridStub.onSelectedRowsChanged.notify({ rows: mockNewRowIndexes, previousSelectedRows: mockPreviousRowIndexes });
+
+        setTimeout(() => {
+          expect(mapRowsSpy).toHaveBeenCalled();
+          expect(service.selectedRowDataContextIds).toEqual(mockNewDataIds);
+          done();
+        });
+      });
+
+      it('should set remove some rows (deletions/uncheck) in the "selectedRowDataContextIds" setter when "onSelectedRowsChanged" is triggered with new selected row delitions', (done) => {
+        const mockPreviousRowIndexes = [3, 77, 55];
+        const mockPreviousDataIds = [333, 777, 555];
+        const mockNewRowIndexes = [3, 77];
+        const mockNewDataIds = [333, 777];
+        const columnMock = [{ columnId: 'field1', cssClass: 'red', headerCssClass: '', width: 100 }] as CurrentColumn[];
+        const paginationMock = { pageNumber: 3, pageSize: 25 } as CurrentPagination;
+
+        jest.spyOn(service, 'getCurrentColumns').mockReturnValue(columnMock);
+        jest.spyOn(service, 'getCurrentPagination').mockReturnValue(paginationMock);
+        const mapRowsSpy = jest.spyOn(dataViewStub, 'mapRowsToIds').mockReturnValue([555]); // remove [555], will remain [333, 777]
+
+        service.init(gridStub, dataViewStub);
+        service.selectedRowDataContextIds = mockPreviousDataIds;
+
+        // the regular event flow is 1.onBeforePagingInfoChanged, 2.onPagingInfoChanged then 3.onSelectedRowsChanged
+        dataViewStub.onBeforePagingInfoChanged.notify({ pageSize: paginationMock.pageSize, pageNum: 0 });
+        dataViewStub.onPagingInfoChanged.notify({ pageSize: paginationMock.pageSize, pageNum: (paginationMock.pageNumber - 1) });
+        gridStub.onSelectedRowsChanged.notify({ rows: mockNewRowIndexes, previousSelectedRows: mockPreviousRowIndexes });
+        gridStub.onSelectedRowsChanged.notify({ rows: mockNewRowIndexes, previousSelectedRows: mockPreviousRowIndexes });
+
+        setTimeout(() => {
+          expect(mapRowsSpy).toHaveBeenCalled();
+          expect(service.selectedRowDataContextIds).toEqual(mockNewDataIds);
+          done();
+        });
+      });
+    });
+  });
+
   describe('getCurrentSorters method', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
     it('should return null when no BackendService is used and SortService is missing the "getCurrentLocalSorters" method', () => {
       const gridSpy = jest.spyOn(gridStub, 'getOptions').mockReturnValue({});
 
@@ -369,6 +694,47 @@ describe('GridStateService', () => {
     });
   });
 
+  describe('needToPreserveRowSelection method', () => {
+    it('should return false when there are no "dataView" property defined in the grid options', () => {
+      const gridOptionsMock = { dataView: null } as GridOption;
+      jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+
+      const output = service.needToPreserveRowSelection();
+
+      expect(output).toBeFalsy();
+    });
+
+    it('should return false when "dataView" property is defined in the grid options with "syncGridSelection" property', () => {
+      const gridOptionsMock = { dataView: null } as GridOption;
+      jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+
+      const output = service.needToPreserveRowSelection();
+
+      expect(output).toBeFalsy();
+    });
+
+    it('should return true when the "dataView" grid option is a boolean and is set to True', () => {
+      const gridOptionsMock = { dataView: { syncGridSelection: true }, enableRowSelection: true } as GridOption;
+      jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+
+      const output = service.needToPreserveRowSelection();
+
+      expect(output).toBeTruthy();
+    });
+
+    it('should return true when the "dataView" grid option is provided as an object', () => {
+      const gridOptionsMock = {
+        dataView: { syncGridSelection: { preserveHidden: true, preserveHiddenOnSelectionChange: false } },
+        enableRowSelection: true
+      } as GridOption;
+      jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+
+      const output = service.needToPreserveRowSelection();
+
+      expect(output).toBeTruthy();
+    });
+  });
+
   describe('resetColumns method', () => {
     it('should call the method without any column definitions and expect "gridStateService:changed" to be triggered with empty changes', () => {
       const gridStateMock = { columns: [], filters: [], sorters: [] } as GridState;
@@ -399,11 +765,11 @@ describe('GridStateService', () => {
     });
   });
 
-  describe('resetRowSelection method', () => {
+  describe('resetRowSelectionWhenRequired method', () => {
     it('should call the method and do nothing when row selection is not in use', () => {
-      const gridSpy = jest.spyOn(gridStub, 'setSelectedRows');
-      service.resetRowSelection();
-      expect(gridSpy).not.toHaveBeenCalled();
+      const setSelectSpy = jest.spyOn(gridStub, 'setSelectedRows');
+      service.resetRowSelectionWhenRequired();
+      expect(setSelectSpy).not.toHaveBeenCalled();
     });
 
     it('should call the method and call the grid selection reset when the selection extension is used', () => {
@@ -413,7 +779,7 @@ describe('GridStateService', () => {
       const setSelectionSpy = jest.spyOn(gridStub, 'setSelectedRows');
       const extensionSpy = jest.spyOn(extensionServiceStub, 'getExtensionByName').mockReturnValue(extensionMock);
 
-      service.resetRowSelection();
+      service.resetRowSelectionWhenRequired();
 
       expect(gridOptionSpy).toHaveBeenCalled();
       expect(extensionSpy).toHaveBeenCalledWith(ExtensionName.rowSelection);
@@ -428,6 +794,9 @@ describe('GridStateService', () => {
     let sorterMock: CurrentSorter[];
 
     beforeEach(() => {
+      const gridOptionsMock = { enablePagination: false, enableCheckboxSelector: false } as GridOption;
+      jest.spyOn(gridStub, 'getOptions').mockReturnValue(gridOptionsMock);
+
       columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
       filterMock = [{ columnId: 'field1', operator: 'EQ', searchTerms: [] }, { columnId: 'field2', operator: '>=', searchTerms: [2] }] as CurrentFilter[];
       sorterMock = [{ columnId: 'field1', direction: 'ASC' }] as CurrentSorter[];
@@ -469,15 +838,18 @@ describe('GridStateService', () => {
       expect(eaSpy).toHaveBeenNthCalledWith(2, `gridStateService:changed`, stateChangeMock);
     });
 
-    it('should trigger a "gridStateService:changed" event when "sortService:sortCleared" is triggered', () => {
+    it('should trigger a "gridStateService:changed" event when "sortService:sortCleared" is triggered', (done) => {
       const gridStateMock = { columns: currentColumnsMock, filters: filterMock, sorters: sorterMock } as GridState;
 
       const stateChangeMock = { change: { newValues: [], type: GridStateType.sorter }, gridState: gridStateMock } as GridStateChange;
 
       const eaSpy = jest.spyOn(ea, 'publish');
-
       ea.publish('sortService:sortCleared', sorterMock);
-      expect(eaSpy).toHaveBeenNthCalledWith(2, `gridStateService:changed`, stateChangeMock);
+
+      setTimeout(() => {
+        expect(eaSpy).toHaveBeenNthCalledWith(2, `gridStateService:changed`, stateChangeMock);
+        done();
+      });
     });
 
     it('should trigger a "gridStateService:changed" event when "headerMenu:onColumnsChanged" is triggered', () => {

--- a/src/aurelia-slickgrid/services/grid.service.ts
+++ b/src/aurelia-slickgrid/services/grid.service.ts
@@ -469,7 +469,8 @@ export class GridService {
     }
 
     // when user has row selection enabled, we should clear any selection to avoid confusion after a delete
-    if (this._grid && this._gridOptions && (this._gridOptions.enableCheckboxSelector || this._gridOptions.enableRowSelection)) {
+    const isSyncGridSelectionEnabled = this.gridStateService && this.gridStateService.needToPreserveRowSelection() || false;
+    if (!isSyncGridSelectionEnabled && this._grid && this._gridOptions && (this._gridOptions.enableCheckboxSelector || this._gridOptions.enableRowSelection)) {
       this.setSelectedRows([]);
     }
 

--- a/src/aurelia-slickgrid/services/gridState.service.ts
+++ b/src/aurelia-slickgrid/services/gridState.service.ts
@@ -1,11 +1,13 @@
 import { inject, singleton } from 'aurelia-framework';
 import { Subscription } from 'aurelia-event-aggregator';
+import * as isequal from 'lodash.isequal';
 
 import {
   Column,
   CurrentColumn,
   CurrentFilter,
   CurrentPagination,
+  CurrentRowSelection,
   CurrentSorter,
   ExtensionName,
   GridOption,
@@ -28,8 +30,11 @@ export class GridStateService {
   private _eventHandler = new Slick.EventHandler();
   private _columns: Column[] = [];
   private _currentColumns: CurrentColumn[] = [];
+  private _dataView: any;
   private _grid: any;
-  private subscriptions: Subscription[] = [];
+  private _subscriptions: Subscription[] = [];
+  private _selectedRowDataContextIds: Array<number | string> = []; // used with row selection
+  private _wasRecheckedAfterPageChange = true; // used with row selection & pagination
 
   constructor(
     private pluginEa: SlickgridEventAggregator,
@@ -44,12 +49,23 @@ export class GridStateService {
     return (this._grid && this._grid.getOptions) ? this._grid.getOptions() : {};
   }
 
+  /** Getter of the selected data context object IDs */
+  get selectedRowDataContextIds(): Array<number | string> {
+    return this._selectedRowDataContextIds;
+  }
+
+  /** Setter of the selected data context object IDs */
+  set selectedRowDataContextIds(dataContextIds: Array<number | string>) {
+    this._selectedRowDataContextIds = dataContextIds;
+  }
+
   /**
    * Initialize the Service
    * @param grid
    */
-  init(grid: any): void {
+  init(grid: any, dataView: any): void {
     this._grid = grid;
+    this._dataView = dataView;
     this.subscribeToAllGridChanges(grid);
   }
 
@@ -62,7 +78,7 @@ export class GridStateService {
     this._eventHandler.unsubscribeAll();
 
     // also dispose of all Subscriptions
-    this.subscriptions = disposeAllSubscriptions(this.subscriptions);
+    this._subscriptions = disposeAllSubscriptions(this._subscriptions);
   }
 
   /**
@@ -73,13 +89,19 @@ export class GridStateService {
     const gridState: GridState = {
       columns: this.getCurrentColumns(),
       filters: this.getCurrentFilters(),
-      sorters: this.getCurrentSorters()
+      sorters: this.getCurrentSorters(),
     };
 
     const currentPagination = this.getCurrentPagination();
     if (currentPagination) {
       gridState.pagination = currentPagination;
     }
+
+    const currentRowSelection = this.getCurrentRowSelections();
+    if (currentRowSelection) {
+      gridState.rowSelection = currentRowSelection;
+    }
+
     return gridState;
   }
 
@@ -193,6 +215,32 @@ export class GridStateService {
    * Get the current Sorters (and their state, columnId, direction) that are currently applied in the grid
    * @return current sorters
    */
+  getCurrentRowSelections(): CurrentRowSelection | null {
+    if (this._grid && this._gridOptions && this._dataView) {
+      const selectionModel = this._grid.getSelectionModel();
+      const isRowSelectionEnabled = this._gridOptions.enableRowSelection || this._gridOptions.enableCheckboxSelector;
+
+      if (isRowSelectionEnabled && selectionModel && this._grid.getSelectedRows && this._dataView.mapRowsToIds) {
+        let gridRowIndexes: number[] = [];
+        let dataContextIds: Array<number | string> = [];
+
+        if (this._gridOptions.enablePagination) {
+          gridRowIndexes = this._dataView.mapIdsToRows(this._selectedRowDataContextIds || []); // note that this will return only what is visible in current page
+          dataContextIds = this._selectedRowDataContextIds;
+        } else {
+          gridRowIndexes = this._grid.getSelectedRows() || [];
+          dataContextIds = this._dataView.mapRowsToIds(gridRowIndexes) || [];
+        }
+        return { gridRowIndexes, dataContextIds };
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get the current Sorters (and their state, columnId, direction) that are currently applied in the grid
+   * @return current sorters
+   */
   getCurrentSorters(): CurrentSorter[] | null {
     if (this._gridOptions && this._gridOptions.backendServiceApi) {
       const backendService = this._gridOptions.backendServiceApi.service;
@@ -205,6 +253,20 @@ export class GridStateService {
     return null;
   }
 
+  /** Check whether the row selection needs to be preserved */
+  needToPreserveRowSelection(): boolean {
+    let preservedRowSelection = false;
+    if (this._gridOptions && this._gridOptions.dataView && this._gridOptions.dataView.hasOwnProperty('syncGridSelection')) {
+      const syncGridSelection = this._gridOptions.dataView.syncGridSelection;
+      if (typeof syncGridSelection === 'boolean') {
+        preservedRowSelection = this._gridOptions.dataView.syncGridSelection as boolean;
+      } else {
+        preservedRowSelection = syncGridSelection.preserveHidden;
+      }
+    }
+    return preservedRowSelection;
+  }
+
   resetColumns(columnDefinitions?: Column[]) {
     const columns: Column[] = columnDefinitions || this._columns;
     const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(columns);
@@ -212,8 +274,8 @@ export class GridStateService {
   }
 
   /** if we use Row Selection or the Checkbox Selector, we need to reset any selection */
-  resetRowSelection() {
-    if (this._gridOptions.enableRowSelection || this._gridOptions.enableCheckboxSelector) {
+  resetRowSelectionWhenRequired() {
+    if (!this.needToPreserveRowSelection() && this._gridOptions.enableRowSelection || this._gridOptions.enableCheckboxSelector) {
       // this also requires the Row Selection Model to be registered as well
       const rowSelectionExtension = this.extensionService && this.extensionService.getExtensionByName && this.extensionService.getExtensionByName(ExtensionName.rowSelection);
       if (rowSelectionExtension && rowSelectionExtension.instance) {
@@ -228,31 +290,31 @@ export class GridStateService {
    */
   subscribeToAllGridChanges(grid: any) {
     // Subscribe to Event Emitter of Filter changed
-    this.subscriptions.push(
+    this._subscriptions.push(
       this.pluginEa.subscribe('filterService:filterChanged', (currentFilters: CurrentFilter[]) => {
-        this.resetRowSelection();
+        this.resetRowSelectionWhenRequired();
         this.pluginEa.publish('gridStateService:changed', { change: { newValues: currentFilters, type: GridStateType.filter }, gridState: this.getCurrentGridState() });
       })
     );
     // Subscribe to Event Emitter of Filter cleared
-    this.subscriptions.push(
+    this._subscriptions.push(
       this.pluginEa.subscribe('filterService:filterCleared', () => {
-        this.resetRowSelection();
+        this.resetRowSelectionWhenRequired();
         this.pluginEa.publish('gridStateService:changed', { change: { newValues: [], type: GridStateType.filter }, gridState: this.getCurrentGridState() });
       })
     );
 
     // Subscribe to Event Emitter of Sort changed
-    this.subscriptions.push(
+    this._subscriptions.push(
       this.pluginEa.subscribe('sortService:sortChanged', (currentSorters: CurrentSorter[]) => {
-        this.resetRowSelection();
+        this.resetRowSelectionWhenRequired();
         this.pluginEa.publish('gridStateService:changed', { change: { newValues: currentSorters, type: GridStateType.sorter }, gridState: this.getCurrentGridState() });
       })
     );
     // Subscribe to Event Emitter of Sort cleared
-    this.subscriptions.push(
+    this._subscriptions.push(
       this.pluginEa.subscribe('sortService:sortCleared', () => {
-        this.resetRowSelection();
+        this.resetRowSelectionWhenRequired();
         this.pluginEa.publish('gridStateService:changed', { change: { newValues: [], type: GridStateType.sorter }, gridState: this.getCurrentGridState() });
       })
     );
@@ -262,11 +324,16 @@ export class GridStateService {
     this.bindExtensionAddonEventToGridStateChange(ExtensionName.gridMenu, 'onColumnsChanged');
 
     // subscribe to Column Resize & Reordering
-    this.bindSlickGridEventToGridStateChange('onColumnsReordered', grid);
-    this.bindSlickGridEventToGridStateChange('onColumnsResized', grid);
+    this.bindSlickGridColumnChangeEventToGridStateChange('onColumnsReordered', grid);
+    this.bindSlickGridColumnChangeEventToGridStateChange('onColumnsResized', grid);
+
+    // subscribe to Row Selection changes (when enabled)
+    if (this._gridOptions.enableRowSelection || this._gridOptions.enableCheckboxSelector) {
+      this.bindSlickGridRowSelectionToGridStateChange();
+    }
 
     // subscribe to HeaderMenu (hide column)
-    this.subscriptions.push(
+    this._subscriptions.push(
       this.pluginEa.subscribe('headerMenu:onColumnsChanged', (visibleColumns: Column[]) => {
         const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(visibleColumns);
         this.pluginEa.publish('gridStateService:changed', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
@@ -297,18 +364,110 @@ export class GridStateService {
   }
 
   /**
-   * Bind a Grid Event to a Grid State change event
+   * Bind a Grid Event (of Column changes) to a Grid State change event
    * @param event name
    * @param grid
    */
-  bindSlickGridEventToGridStateChange(eventName: string, grid: any) {
+  bindSlickGridColumnChangeEventToGridStateChange(eventName: string, grid: any) {
     const slickGridEvent = grid && grid[eventName];
 
     if (slickGridEvent && typeof slickGridEvent.subscribe === 'function') {
-      this._eventHandler.subscribe(slickGridEvent, (e: Event, args: any) => {
+      this._eventHandler.subscribe(slickGridEvent, () => {
         const columns: Column[] = grid.getColumns();
         const currentColumns: CurrentColumn[] = this.getAssociatedCurrentColumns(columns);
         this.pluginEa.publish('gridStateService:changed', { change: { newValues: currentColumns, type: GridStateType.columns }, gridState: this.getCurrentGridState() });
+      });
+    }
+  }
+
+  /**
+   * Bind a Grid Event of Row Selection change to a Grid State change event
+   * @param event name
+   * @param grid
+   */
+  private bindSlickGridRowSelectionToGridStateChange() {
+    if (this._gridOptions && this._gridOptions.enablePagination) {
+      // when using pagination, the process is much more complex so let's do it in a separate method
+      this.bindSlickGridRowSelectionWithPaginationToGridStateChange();
+    } else {
+      // without Pagination, we can simply get the getSelectedRows() and mapRowsToIds() and we're done
+      this._eventHandler.subscribe(this._grid.onSelectedRowsChanged, () => {
+        const currentSelectedRowIndexes = this._grid.getSelectedRows();
+        this._selectedRowDataContextIds = this._dataView.mapRowsToIds(currentSelectedRowIndexes);
+        const newValues = { gridRowIndexes: currentSelectedRowIndexes, dataContextIds: this._selectedRowDataContextIds } as CurrentRowSelection;
+        this.pluginEa.publish('gridStateService:changed', { change: { newValues, type: GridStateType.rowSelection }, gridState: this.getCurrentGridState() });
+      });
+    }
+  }
+
+  /**
+   * When using Pagination, we can't just use the getSelectedRows() since this will only return the selection in current page which is not enough.
+   * The process is much more complex, what we have to do instead is the following
+   * 1. when changing a row selection, we'll add the new selection if it's not yet in the global array of selected IDs
+   * 2. when deleting a row selection, we'll remove the selection from our global array of selected IDs (unless it came from a page change)
+   * 3. before we change page, we'll keep track with a flag (this flag will be used to skip any deletion when we're changing page)
+   * 4. after the page is changed, we'll do an extra (and delayed) check to make sure that what we have in our global array of selected IDs is displayed on screen
+   */
+  private bindSlickGridRowSelectionWithPaginationToGridStateChange() {
+    if (this._grid && this._gridOptions && this._dataView) {
+      this._eventHandler.subscribe(this._dataView.onBeforePagingInfoChanged, () => {
+        this._wasRecheckedAfterPageChange = false; // reset the page check flag, to skip deletions on page change (used in code below)
+      });
+
+      this._eventHandler.subscribe(this._dataView.onPagingInfoChanged, () => {
+        // when user changes page, the selected row indexes might not show up
+        // we can check to make sure it is but it has to be in a delay so it happens after the first "onSelectedRowsChanged" is triggered
+        setTimeout(() => {
+          const shouldBeSelectedRowIndexes = this._dataView.mapIdsToRows(this._selectedRowDataContextIds || []);
+          const currentSelectedRowIndexes = this._grid.getSelectedRows();
+          if (!isequal(shouldBeSelectedRowIndexes, currentSelectedRowIndexes)) {
+            this._grid.setSelectedRows(shouldBeSelectedRowIndexes);
+          }
+        });
+      });
+
+      this._eventHandler.subscribe(this._grid.onSelectedRowsChanged, (e, args) => {
+        if (Array.isArray(args.rows) && Array.isArray(args.previousSelectedRows)) {
+          const newSelectedRows = args.rows as number[];
+          const prevSelectedRows = args.previousSelectedRows as number[];
+
+          const newSelectedAdditions = newSelectedRows.filter((i) => prevSelectedRows.indexOf(i) < 0);
+          const newSelectedDeletions = prevSelectedRows.filter((i) => newSelectedRows.indexOf(i) < 0);
+
+          // deletion might happen when user is changing page, if that is the case then skip the deletion since it's only a visual deletion (current page)
+          // if it's not a page change (when the flag is true), then proceed with the deletion in our global array of selected IDs
+          if (this._wasRecheckedAfterPageChange && newSelectedDeletions.length > 0) {
+            const toDeleteDataIds: Array<number | string> = this._dataView.mapRowsToIds(newSelectedDeletions) || [];
+            toDeleteDataIds.forEach((removeId: number | string) => {
+              this._selectedRowDataContextIds.splice((this._selectedRowDataContextIds as Array<number | string>).indexOf(removeId), 1);
+            });
+          }
+
+          // if we have newly added selected row(s), let's update our global array of selected IDs
+          if (newSelectedAdditions.length > 0) {
+            const toAddDataIds: Array<number | string> = this._dataView.mapRowsToIds(newSelectedAdditions) || [];
+            toAddDataIds.forEach((dataId: number | string) => {
+              if ((this._selectedRowDataContextIds as Array<number | string>).indexOf(dataId) === -1) {
+                (this._selectedRowDataContextIds as Array<number | string>).push(dataId);
+              }
+            });
+          }
+
+          // we set this flag which will be used on the 2nd time the "onSelectedRowsChanged" event is called
+          // when it's the first time, we skip deletion and this is what this flag is for
+          this._wasRecheckedAfterPageChange = true;
+
+          // form our full selected row IDs, let's make sure these indexes are selected in the grid, if not then let's call a reselect
+          // this could happen if the previous step was a page change
+          const shouldBeSelectedRowIndexes = this._dataView.mapIdsToRows(this._selectedRowDataContextIds || []);
+          const currentSelectedRowIndexes = this._grid.getSelectedRows();
+          if (!isequal(shouldBeSelectedRowIndexes, currentSelectedRowIndexes)) {
+            this._grid.setSelectedRows(shouldBeSelectedRowIndexes);
+          }
+
+          const newValues = { gridRowIndexes: this._grid.getSelectedRows(), dataContextIds: this._selectedRowDataContextIds } as CurrentRowSelection;
+          this.pluginEa.publish('gridStateService:changed', { change: { newValues, type: GridStateType.rowSelection }, gridState: this.getCurrentGridState() });
+        }
       });
     }
   }

--- a/src/aurelia-slickgrid/services/pagination.service.ts
+++ b/src/aurelia-slickgrid/services/pagination.service.ts
@@ -262,6 +262,34 @@ export class PaginationService {
     this.refreshPagination(true, triggerChangedEvent);
   }
 
+  /**
+   * Toggle the Pagination (show/hide), it will use the visible if defined else it will automatically inverse when called without argument
+   *
+   * IMPORTANT NOTE:
+   * The Pagination must be created on initial page load, then only after can you toggle it.
+   * Basically this method WILL NOT WORK to show the Pagination if it was not there from the start.
+   */
+  togglePaginationVisibility(visible?: boolean) {
+    if (this.grid && this.sharedService && this.sharedService.gridOptions) {
+      const isVisible = visible !== undefined ? visible : !this.sharedService.gridOptions.enablePagination;
+      this.sharedService.gridOptions.enablePagination = isVisible;
+      this.pluginEa.publish(`paginationService:onPaginationVisibilityChanged`, { visible: isVisible });
+
+      // make sure to reset the Pagination and go back to first page to avoid any issues with Pagination being offset
+      if (isVisible) {
+        this.goToFirstPage();
+      }
+
+      // when using a local grid, we can reset the DataView pagination by changing its page size
+      // page size of 0 would show all, hence cancel the pagination
+      if (this._isLocalGrid) {
+        const pageSize = visible ? this._itemsPerPage : 0;
+        this.dataView.setPagingOptions({ pageSize, pageNum: 0 });
+      }
+    }
+  }
+
+
   processOnPageChanged(pageNumber: number, event?: Event | undefined): Promise<any> {
     return new Promise((resolve, reject) => {
       this.recalculateFromToIndexes();

--- a/src/examples/slickgrid/example10.html
+++ b/src/examples/slickgrid/example10.html
@@ -4,7 +4,8 @@
        innerhtml.bind="subTitle"></div>
 
   <div class="row">
-    <div class="col-sm-1">
+    <div class="col-sm-4" style="max-width: 170px;">
+      Pagination
       <button class="btn btn-default btn-xs" data-test="goto-first-page" click.delegate="goToGrid1FirstPage()">
         <i class="fa fa-caret-left fa-lg"></i>
       </button>
@@ -28,21 +29,30 @@
                      grid-height="225"
                      grid-width="800"
                      asg-on-aurelia-grid-created.delegate="aureliaGrid1Ready($event.detail)"
+                     asg-on-grid-state-changed.delegate="grid1StateChanged($event.detail)"
                      sg-on-selected-rows-changed.delegate="onGrid1SelectedRowsChanged($event.detail.eventData, $event.detail.args)">
   </aurelia-slickgrid>
 
   <hr>
 
   <div class="row">
-    <div class="col-sm-1">
-      <button class="btn btn-default btn-xs" data-test="goto-first-page" click.delegate="goToGrid2FirstPage()">
-        <i class="fa fa-caret-left fa-lg"></i>
-      </button>
-      <button class="btn btn-default btn-xs" data-test="goto-last-page" click.delegate="goToGrid2LastPage()">
-        <i class="fa fa-caret-right fa-lg"></i>
-      </button>
+    <div class="col-sm-4 col-md-3" style="max-width: 180px;">
+      <label for="enableGrid2Pagination">
+        Pagination:
+        <input type="checkbox" id="enableGrid2Pagination"
+               checked.bind="isGrid2WithPagination"
+               data-test="toggle-pagination-grid2" />
+      </label>
+      <span style="margin-left: 5px" *ngIf="isGrid2WithPagination">
+        <button class="btn btn-default btn-xs" data-test="goto-first-page" click.delegate="goToGrid2FirstPage()">
+          <i class="fa fa-caret-left fa-lg"></i>
+        </button>
+        <button class="btn btn-default btn-xs" data-test="goto-last-page" click.delegate="goToGrid2LastPage()">
+          <i class="fa fa-caret-right fa-lg"></i>
+        </button>
+      </span>
     </div>
-    <div class="col-sm-8">
+    <div class="col-sm-7">
       <div class="alert alert-success">
         <strong>(multi-select) Selected Row(s):</strong>
         <span innerhtml.bind="selectedTitles"
@@ -58,6 +68,6 @@
                      grid-height="255"
                      grid-width="800"
                      asg-on-aurelia-grid-created.delegate="aureliaGrid2Ready($event.detail)"
-                     sg-on-selected-rows-changed.delegate="onGrid2SelectedRowsChanged($event.detail.eventData, $event.detail.args)">
+                     asg-on-grid-state-changed.delegate="grid2StateChanged($event.detail)">
   </aurelia-slickgrid>
 </template>

--- a/src/examples/slickgrid/example10.ts
+++ b/src/examples/slickgrid/example10.ts
@@ -1,5 +1,5 @@
-import { autoinject } from 'aurelia-framework';
-import { AureliaGridInstance, Column, FieldType, Filters, Formatters, GridOption } from '../../aurelia-slickgrid';
+import { autoinject, bindable } from 'aurelia-framework';
+import { AureliaGridInstance, Column, FieldType, Filters, Formatters, GridOption, GridStateChange } from '../../aurelia-slickgrid';
 import './example10.scss'; // provide custom CSS/SASS styling
 
 @autoinject()
@@ -13,7 +13,10 @@ export class Example2 {
       <li>NOTE: Any Row Selection(s) will be reset when using Pagination and changing Page (you will need to set it back manually if you want it back)</li>
     </ul>
   `;
+  @bindable() isGrid2WithPagination = true;
 
+  aureliaGrid1: AureliaGridInstance;
+  aureliaGrid2: AureliaGridInstance;
   columnDefinitions1: Column[];
   columnDefinitions2: Column[];
   gridOptions1: GridOption;
@@ -22,8 +25,7 @@ export class Example2 {
   dataset2: any[];
   selectedTitles: any[];
   selectedTitle = '';
-  aureliaGrid1: AureliaGridInstance;
-  aureliaGrid2: AureliaGridInstance;
+  selectedGrid2IDs: number[];
 
   constructor() {
     // define the grid options & columns and then create the grid itself
@@ -126,6 +128,10 @@ export class Example2 {
         pageSizes: [5, 10, 15, 20, 25, 50, 75, 100],
         pageSize: 5
       },
+      // we can use some Presets, for the example Pagination
+      presets: {
+        pagination: { pageNumber: 2, pageSize: 5 },
+      },
     };
 
     this.gridOptions2 = {
@@ -141,13 +147,25 @@ export class Example2 {
         // True (Single Selection), False (Multiple Selections)
         selectActiveRow: false
       },
-      preselectedRows: [0, 2],
       enableCheckboxSelector: true,
       enableRowSelection: true,
       enablePagination: true,
       pagination: {
         pageSizes: [5, 10, 15, 20, 25, 50, 75, 100],
         pageSize: 5
+      },
+      // 1. pre-select some grid row indexes (less recommended, better use the Presets, see below)
+      // preselectedRows: [0, 2],
+
+      // 2. or use the Presets to pre-select some rows
+      presets: {
+        // you can presets row selection here as well, you can choose 1 of the following 2 ways of setting the selection
+        // by their index position in the grid (UI) or by the object IDs, the default is "dataContextIds" and if provided it will use it and disregard "gridRowIndexes"
+        // the RECOMMENDED is to use "dataContextIds" since that will always work even with Pagination, while "gridRowIndexes" is only good for 1 page
+        rowSelection: {
+          // gridRowIndexes: [2],           // the row position of what you see on the screen (UI)
+          dataContextIds: [3, 12, 13, 522]  // (recommended) select by the your data object IDs
+        }
       },
     };
   }
@@ -191,22 +209,38 @@ export class Example2 {
     this.aureliaGrid2.paginationService.goToLastPage();
   }
 
+  /** Dispatched event of a Grid State Changed event */
+  grid1StateChanged(gridStateChanges: GridStateChange) {
+    console.log('Grid State changed:: ', gridStateChanges);
+    console.log('Grid State changed:: ', gridStateChanges.change);
+  }
+
+  /** Dispatched event of a Grid State Changed event */
+  grid2StateChanged(gridStateChanges: GridStateChange) {
+    console.log('Grid State changed:: ', gridStateChanges);
+    console.log('Grid State changed:: ', gridStateChanges.change);
+
+    if (gridStateChanges.gridState.rowSelection) {
+      this.selectedGrid2IDs = (gridStateChanges.gridState.rowSelection.dataContextIds || []) as number[];
+      this.selectedGrid2IDs = this.selectedGrid2IDs.sort((a, b) => a - b); // sort by ID
+      this.selectedTitles = this.selectedGrid2IDs.map(dataContextId => `Task ${dataContextId}`);
+    }
+  }
+
+  // Toggle the Pagination of Grid2
+  // IMPORTANT, the Pagination MUST BE CREATED on initial page load before you can start toggling it
+  // Basically you cannot toggle a Pagination that doesn't exist (must created at the time as the grid)
+  isGrid2WithPaginationChanged() {
+    // this.isGrid2WithPagination = !this.isGrid2WithPagination;
+    this.aureliaGrid2.paginationService.togglePaginationVisibility(this.isGrid2WithPagination);
+  }
+
   onGrid1SelectedRowsChanged(e, args) {
     const grid = args && args.grid;
     if (Array.isArray(args.rows)) {
       this.selectedTitle = args.rows.map(idx => {
         const item = grid.getDataItem(idx);
-        return item.title || '';
-      });
-    }
-  }
-
-  onGrid2SelectedRowsChanged(e, args) {
-    const grid = args && args.grid;
-    if (grid && Array.isArray(args.rows)) {
-      this.selectedTitles = args.rows.map(idx => {
-        const item = grid.getDataItem(idx);
-        return item.title || '';
+        return item && item.title || '';
       });
     }
   }

--- a/test/cypress/cypress.json
+++ b/test/cypress/cypress.json
@@ -3,7 +3,7 @@
   "baseExampleUrl": "http://localhost:9000/#/slickgrid",
   "video": false,
   "viewportWidth": 1200,
-  "viewportHeight": 800,
+  "viewportHeight": 950,
   "fixturesFolder": "fixtures",
   "integrationFolder": "integration",
   "pluginsFile": "plugins/index.js",

--- a/test/cypress/integration/example10.spec.js
+++ b/test/cypress/integration/example10.spec.js
@@ -3,6 +3,13 @@
 describe('Example 10 - Multiple Grids with Row Selection', () => {
   const titles = ['', 'Title', 'Duration (days)', '% Complete', 'Start', 'Finish', 'Effort Driven'];
 
+  beforeEach(() => {
+    // create a console.log spy for later use
+    cy.window().then((win) => {
+      cy.spy(win.console, "log");
+    });
+  });
+
   it('should display Example title', () => {
     cy.visit(`${Cypress.config('baseExampleUrl')}/example10`);
     cy.get('h2').should('contain', 'Example 10: Multiple Grids with Row Selection');
@@ -33,17 +40,17 @@ describe('Example 10 - Multiple Grids with Row Selection', () => {
       });
   });
 
-  it('should have 2 rows pre-selected in 2nd grid', () => {
-    cy.get('[data-test=grid2-selections]').should('contain', 'Task 0,Task 2');
+  it('should have 1 rows (Task 3) pre-selected in 2nd grid on its first page but 5 rows selected in the entire dataset', () => {
+    cy.get('[data-test=grid2-selections]').should('contain', 'Task 3,Task 12,Task 13,Task 522');
 
     cy.get('#grid2')
       .find('.slick-row')
       .children()
       .filter('.slick-cell-checkboxsel.selected.true')
-      .should('have.length', 2);
+      .should('have.length', 1);
   });
 
-  it('should have 0 rows selected in 2nd grid after typing in a search filter', () => {
+  it('should have 2 rows (Task 12,Task 13) selected in 2nd grid after typing in a search filter', () => {
     cy.get('#grid2')
       .find('.filter-title')
       .type('Task 1');
@@ -58,7 +65,7 @@ describe('Example 10 - Multiple Grids with Row Selection', () => {
       .find('.slick-row')
       .children()
       .filter('.slick-cell-checkboxsel.selected.true')
-      .should('have.length', 0);
+      .should('have.length', 2);
   });
 
   it('should make sure that first column is hidden from the Grid Menu (1st column definition has "excludeFromGridMenu" set) on 1st grid', () => {
@@ -147,7 +154,7 @@ describe('Example 10 - Multiple Grids with Row Selection', () => {
   });
 
   describe('Pagination', () => {
-    it('should Clear all Filters on 2nd Grid and expect the same Pagination defined in both Grids', () => {
+    it('should Clear all Filters on 2nd Grid', () => {
       cy.get('#grid2')
         .find('button.slick-gridmenu-button')
         .trigger('click')
@@ -169,7 +176,7 @@ describe('Example 10 - Multiple Grids with Row Selection', () => {
       cy.get('@grid1')
         .find('[data-test=page-number-input]')
         .invoke('val')
-        .then(pageNumber => expect(pageNumber).to.eq('1'));
+        .then(pageNumber => expect(pageNumber).to.eq('2'));
 
       cy.get('@grid1')
         .find('[data-test=page-count]')
@@ -177,11 +184,11 @@ describe('Example 10 - Multiple Grids with Row Selection', () => {
 
       cy.get('@grid1')
         .find('[data-test=item-from]')
-        .contains('1');
+        .contains('6');
 
       cy.get('@grid1')
         .find('[data-test=item-to]')
-        .contains('5');
+        .contains('10');
 
       cy.get('@grid1')
         .find('[data-test=total-items]')
@@ -342,6 +349,7 @@ describe('Example 10 - Multiple Grids with Row Selection', () => {
 
     it('should also expect Grid2 to be unchanged (after changing Pagination in Grid1 in previous tests)', () => {
       cy.get('#slickGridContainer-grid2').as('grid2');
+
       cy.get('@grid2')
         .find('[data-test=page-count]')
         .contains('7');
@@ -357,6 +365,255 @@ describe('Example 10 - Multiple Grids with Row Selection', () => {
       cy.get('@grid2')
         .find('[data-test=total-items]')
         .contains('525');
+    });
+
+    it('should have 3 rows (Task 12,Task 13,Task 522) selected in the entire 2nd grid BUT 0 selected in current Page 1', () => {
+      cy.get('#slickGridContainer-grid2').as('grid2');
+
+      cy.get('[data-test=grid2-selections]').should('contain', 'Task 12,Task 13,Task 522');
+
+      cy.get('@grid2')
+        .find('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+
+      cy.get('#grid2')
+        .find('.slick-row')
+        .children()
+        .filter('.slick-cell-checkboxsel.selected.true')
+        .should('have.length', 0);
+    });
+
+    it('should go to Page 3 of 2nd Grid and have 2 rows selected in that Page and also have 3 rows (Task 12,Task 13,Task 522) selected in the entire grid', () => {
+      cy.get('#slickGridContainer-grid2').as('grid2');
+
+      cy.get('[data-test=grid2-selections]').should('contain', 'Task 12,Task 13,Task 522');
+
+      cy.get('@grid2')
+        .find('#items-per-page-label').select('5');
+
+      cy.get('@grid2')
+        .find('[data-test=page-number-input]')
+        .clear()
+        .type('3')
+        .type('{enter}');
+
+      cy.get('@grid2')
+        .find('.slick-row')
+        .children()
+        .filter('.slick-cell-checkboxsel.selected.true')
+        .should('have.length', 2);
+    });
+
+    it('should go to last Page of 2nd Grid and have 1 rows selected in that Page and also have 3 rows (Task 12,Task 13,Task 522) selected in the entire grid', () => {
+      cy.get('#slickGridContainer-grid2').as('grid2');
+
+      cy.get('@grid2')
+        .find('.icon-seek-end')
+        .click();
+
+      cy.get('[data-test=grid2-selections]')
+        .should('contain', 'Task 12,Task 13,Task 522');
+
+      cy.get('@grid2')
+        .find('.slick-row')
+        .children()
+        .filter('.slick-cell-checkboxsel.selected.true')
+        .should('have.length', 1);
+    });
+
+    it(`should go to first Page of 2nd Grid and select a new row (Task 1) in that Page and now have 4 rows (Task 1,Task 12,Task 13,Task 522) selected in the entire grid`, () => {
+      cy.get('#slickGridContainer-grid2').as('grid2');
+
+      cy.get('@grid2')
+        .find('.icon-seek-first')
+        .click()
+        .wait(10);
+
+      cy.get('@grid2')
+        .find('.slick-row:nth(1) .slick-cell:nth(0) input[type=checkbox]')
+        .click({ force: true });
+
+      cy.get('[data-test=grid2-selections]')
+        .should('contain', 'Task 1,Task 12,Task 13,Task 522');
+
+      cy.get('@grid2')
+        .find('.slick-row')
+        .children()
+        .filter('.slick-cell-checkboxsel.selected.true')
+        .should('have.length', 1);
+
+      cy.window().then((win) => {
+        expect(win.console.log).to.have.callCount(6);
+        expect(win.console.log).to.be.calledWith("Grid State changed:: ", { newValues: { gridRowIndexes: [1], dataContextIds: [1, 12, 13, 522] }, type: 'rowSelection' });
+      });
+    });
+
+    it('should go back to Page 3 of 2nd Grid and have 2 rows selected in that Page and also have 3 rows (Task 1, Task 12,Task 13,Task 522) selected in the entire grid', () => {
+      cy.get('#slickGridContainer-grid2').as('grid2');
+
+      cy.get('[data-test=grid2-selections]').should('contain', 'Task 1,Task 12,Task 13,Task 522');
+
+      cy.get('@grid2')
+        .find('#items-per-page-label').select('5');
+
+      cy.get('@grid2')
+        .find('[data-test=page-number-input]')
+        .clear()
+        .type('3')
+        .type('{enter}');
+
+      cy.get('@grid2')
+        .find('.slick-row')
+        .children()
+        .filter('.slick-cell-checkboxsel.selected.true')
+        .should('have.length', 2);
+    });
+
+    it('should go to last Page of 2nd Grid and still have 1 rows selected in that Page and also have 3 rows (Task 1, Task 12,Task 13,Task 522) selected in the entire grid', () => {
+      cy.get('#slickGridContainer-grid2').as('grid2');
+
+      cy.get('@grid2')
+        .find('.icon-seek-end')
+        .click();
+
+      cy.get('[data-test=grid2-selections]')
+        .should('contain', 'Task 1,Task 12,Task 13,Task 522');
+
+      cy.get('@grid2')
+        .find('.slick-row')
+        .children()
+        .filter('.slick-cell-checkboxsel.selected.true')
+        .should('have.length', 1);
+    });
+  });
+
+  describe('Row Selection', () => {
+    it('should click on 3rd row and of the Grid1 and expect to see "Task 300" selected', () => {
+      cy.get('#slickGridContainer-grid1').as('grid1');
+
+      cy.get('@grid1')
+      cy.get('.slick-row:nth(2) .slick-cell:nth(0) input[type=checkbox]')
+        .click({ force: true });
+
+      cy.get('[data-test=grid1-selections]')
+        .contains('Task 300');
+
+      cy.window().then((win) => {
+        expect(win.console.log).to.have.callCount(2);
+        expect(win.console.log).to.be.calledWith("Grid State changed:: ", { newValues: { gridRowIndexes: [2], dataContextIds: [300] }, type: 'rowSelection' });
+      });
+    });
+
+    it('should remove the filter from Grid1', () => {
+      cy.get('#slickGridContainer-grid1').as('grid1');
+
+      cy.get('@grid1')
+        .find('.filter-title')
+        .type('{backspace}{backspace}')
+        .invoke('text').then((text => {
+          expect(text.trim()).to.eq('')
+        }));
+    });
+
+    it('should go to Page 61 of Grid1 and expect to find "Task 300" still be selected', () => {
+      cy.get('#slickGridContainer-grid1').as('grid1');
+
+      cy.get('@grid1')
+        .find('[data-test=page-number-input]')
+        .clear()
+        .type('61')
+        .type('{enter}');
+
+      cy.get('[data-test=grid1-selections]')
+        .contains('Task 300');
+
+      cy.get('.slick-cell.l0.r0.slick-cell-checkboxsel.selected.true')
+        .should('exist');
+
+      cy.get('[data-test=grid1-selections]')
+        .contains('Task 300');
+    });
+  });
+
+  describe('Remove Pagination', () => {
+    it('should remove Pagination and not expect any DOM elements of it', () => {
+      cy.get('[data-test=toggle-pagination-grid2]')
+        .click();
+
+      cy.get('#slickPagingContainer-grid2')
+        .should('not.exist');
+
+      cy.window().then((win) => {
+        expect(win.console.log).to.have.callCount(4);
+        expect(win.console.log).to.be.calledWith("Grid State changed:: ", { newValues: { gridRowIndexes: [1, 12, 13, 522], dataContextIds: [1, 12, 13, 522] }, type: 'rowSelection' });
+      });
+    });
+
+    it('should have 4 rows (Task 1,Task 12,Task 13,Task 522) selected in the entire 2nd grid BUT only 1 shown in the DOM on top of the grid (because SlickGrid uses virtual rendering)', () => {
+      cy.get('#slickGridContainer-grid2').as('grid2');
+
+      cy.get('[data-test=grid2-selections]').should('contain', 'Task 1,Task 12,Task 13,Task 522');
+
+      cy.get('@grid2')
+        .find('.slick-row')
+        .children()
+        .filter('.slick-cell-checkboxsel.selected.true')
+        .should('have.length', 1);
+    });
+
+    it('should scroll to the bottom of 2nd Grid and still have 4 rows (Task 1,Task 12,Task 13,Task 522) selected and find 2 row selected because we now have 2 rows that got rendered (first and last)', () => {
+      cy.get('#slickGridContainer-grid2').as('grid2');
+
+      cy.get('[data-test=grid2-selections]').should('contain', 'Task 1,Task 12,Task 13,Task 522');
+
+      cy.get('@grid2')
+        .find('.slick-viewport-top.slick-viewport-left')
+        .scrollTo('bottom')
+        .wait(10);
+
+      cy.get('@grid2')
+        .find('.slick-row')
+        .children()
+        .filter('.slick-cell-checkboxsel.selected.true')
+        .should('have.length', 2);
+    });
+
+    it('should re-enable the Pagination and expect to see it show it again below the grid at Page 1', () => {
+      cy.get('#slickGridContainer-grid2').as('grid2');
+
+      cy.get('[data-test=toggle-pagination-grid2]')
+        .click();
+
+      cy.get('#slickPagingContainer-grid2')
+        .should('exist');
+
+      cy.get('@grid2')
+        .find('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+
+      cy.get('@grid2')
+        .find('[data-test=page-count]')
+        .contains('105');
+
+      cy.get('@grid2')
+        .find('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('@grid2')
+        .find('[data-test=item-to]')
+        .contains('5');
+
+      cy.get('@grid2')
+        .find('[data-test=total-items]')
+        .contains('525');
+
+      cy.window().then((win) => {
+        expect(win.console.log).to.have.callCount(4);
+        expect(win.console.log).to.be.calledWith("Grid State changed:: ", { newValues: { gridRowIndexes: [1], dataContextIds: [1, 12, 13, 522] }, type: 'rowSelection' });
+        expect(win.console.log).to.be.calledWith("Grid State changed:: ", { newValues: { pageNumber: 1, pageSize: 5 }, type: 'pagination' });
+      });
     });
   });
 });

--- a/test/cypress/integration/example15.spec.js
+++ b/test/cypress/integration/example15.spec.js
@@ -201,6 +201,15 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
       .should('contain', '1');
   });
 
+  it('should select row (Task 105)', () => {
+    cy.get('#grid15')
+      .contains('Task 105')
+      .parent()
+      .children('.slick-cell-checkboxsel')
+      .find('input[type=checkbox]')
+      .click({ force: true });
+  });
+
   it('should change Page Size and Page Number then expect the Pagination to have correct values', () => {
     const expectedTasks = ['Task 135', 'Task 136', 'Task 137', 'Task 138', 'Task 139', 'Task 14'];
 
@@ -244,6 +253,15 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
         cy.wrap($row).children('.slick-cell:nth(3)')
           .should('contain', expectedTasks[index]);
       });
+  });
+
+  it('should select row (Task 144)', () => {
+    cy.get('#grid15')
+      .contains('Task 144')
+      .parent()
+      .children('.slick-cell-checkboxsel')
+      .find('input[type=checkbox]')
+      .click({ force: true });
   });
 
   it('should reload the page', () => {
@@ -298,6 +316,17 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
         }
         cy.wrap($row).children('.slick-cell:nth(3)')
           .should('contain', expectedTasks[index]);
+      });
+  });
+
+  it('should expect row selection (Task 144) to be persisted', () => {
+    cy.get('#grid15')
+      .contains('Task 144')
+      .parent()
+      .children()
+      .each($child => {
+        console.log($child)
+        expect($child.attr('class')).to.contain('selected');
       });
   });
 
@@ -420,5 +449,34 @@ describe('Example 15: Grid State & Presets using Local Storage', () => {
       .find('.slick-header-columns')
       .children()
       .each(($child, index) => expect($child.find('.slick-column-name').text()).to.eq(expectedTitles[index]));
+  });
+
+  it('should expect row selection (Task 144) to be persisted', () => {
+    cy.get('#grid15')
+      .contains('Task 144')
+      .parent()
+      .children()
+      .each($child => {
+        console.log($child)
+        expect($child.attr('class')).to.contain('selected');
+      });
+  });
+
+  it('should go back to first page and expect row selection (Task 105) to be persisted', () => {
+    cy.get('#slickGridContainer-grid15').as('grid15');
+
+    cy.get('@grid15')
+      .find('.icon-seek-first')
+      .click()
+      .wait(10);
+
+    cy.get('#grid15')
+      .contains('Task 105')
+      .parent()
+      .children()
+      .each($child => {
+        console.log($child)
+        expect($child.attr('class')).to.contain('selected');
+      });
   });
 });


### PR DESCRIPTION
- with the "syncGridSelection" enabled in the DataView we can now add the Row Selection to the Grid State & Presets (for that the flags "enableCheckboxSelector" or "enableRowSelection" must be enabled)
- the information of the Selected Rows when using Pagination is not available in SlickGrid, it only returns current page selection, so for that we have to implement it ourselve