### PR TITLE
fix(pagination): on filter change pagination should reset to 1st page

### DIFF
--- a/src/aurelia-slickgrid/services/__tests__/pagination.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/pagination.service.spec.ts
@@ -513,6 +513,18 @@ describe('PaginationService', () => {
 
       expect(spy).toHaveBeenCalledWith(true, false);
     });
+
+    it('should reset the DataView when using local grid by calling "setPagingOptions" with page 0 and also call "refreshPagination" method', () => {
+      const spy = jest.spyOn(service, 'refreshPagination');
+      const setPagingSpy = jest.spyOn(dataviewStub, 'setPagingOptions');
+
+      mockGridOption.backendServiceApi = null;
+      service.init(gridStub, dataviewStub, mockGridOption.pagination, null);
+      service.resetPagination();
+
+      expect(setPagingSpy).toHaveBeenCalledWith({ pageSize: 25, pageNum: 0 });
+      expect(spy).toHaveBeenCalledWith(true, true);
+    });
   });
 
   // processOnItemAddedOrRemoved is private but we can spy on recalculateFromToIndexes

--- a/src/aurelia-slickgrid/services/pagination.service.ts
+++ b/src/aurelia-slickgrid/services/pagination.service.ts
@@ -259,6 +259,10 @@ export class PaginationService {
 
   /** Reset the Pagination to first page and recalculate necessary numbers */
   resetPagination(triggerChangedEvent = true) {
+    if (this._isLocalGrid) {
+      // on a local grid we also need to reset the DataView paging to 1st page
+      this.dataView.setPagingOptions({ pageSize: this._itemsPerPage, pageNum: 0 });
+    }
     this.refreshPagination(true, triggerChangedEvent);
   }
 


### PR DESCRIPTION
- when using local grid, the DataView should be reset to page 0