### PR TITLE
feat(excel): add some extra styling & width options for Excel export

### DIFF
--- a/src/aurelia-slickgrid/models/column.interface.ts
+++ b/src/aurelia-slickgrid/models/column.interface.ts
@@ -60,11 +60,20 @@ export interface Column {
   /** Defaults to false, which leads to exclude the field from the query (typically a backend service query) */
   excludeFromQuery?: boolean;
 
+  /** If defined this will be set as column width in Excel */
+  exportColumnWidth?: number;
+
   /**
    * Export with a Custom Formatter, useful when we want to use a different Formatter for the export.
    * For example, we might have a boolean field with "Formatters.checkmark" but we would like see a translated value for (True/False).
    */
   exportCustomFormatter?: Formatter;
+
+  /**
+   * Export with a Custom Group Total Formatter, useful when we want to use a different Formatter for the export.
+   * For example, we might have a boolean field with "Formatters.checkmark" but we would like see a translated value for (True/False).
+   */
+  exportCustomGroupTotalsFormatter?: GroupTotalsFormatter;
 
   /**
    * Defaults to false, which leads to Formatters being evaluated on export.

--- a/src/aurelia-slickgrid/models/excelExportOption.interface.ts
+++ b/src/aurelia-slickgrid/models/excelExportOption.interface.ts
@@ -6,6 +6,12 @@ export interface ExcelExportOption {
   /** Defaults to true, when grid is using Grouping, it will show indentation of the text with collapsed/expanded symbol as well */
   addGroupIndentation?: boolean;
 
+  /** If defined apply the style to header columns. Else use the bold style */
+  columnHeaderStyle?: any;
+
+  /** If set then this will be used as column width for all columns */
+  customColumnWidth?: number;
+
   /** Defaults to false, which leads to all Formatters of the grid being evaluated on export. You can also override a column by changing the propery on the column itself */
   exportWithFormatter?: boolean;
 

--- a/src/aurelia-slickgrid/services/__tests__/excelExport.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/excelExport.service.spec.ts
@@ -3,12 +3,13 @@ import { EventAggregator } from 'aurelia-event-aggregator';
 import { BindingSignaler } from 'aurelia-templating-resources';
 import { ExcelExportService } from '../excelExport.service';
 import {
+  Column,
   ExcelExportOption,
+  FieldType,
   FileType,
   Formatter,
   GridOption,
-  Column,
-  FieldType,
+  GroupTotalsFormatter,
   SortDirectionNumber,
 } from '../../models';
 import { GroupTotalFormatters } from '../..';
@@ -27,6 +28,14 @@ const DEFAULT_AURELIA_EVENT_PREFIX = 'asg';
 
 const myBoldHtmlFormatter: Formatter = (row, cell, value, columnDef, dataContext) => value !== null ? { text: `<b>${value}</b>` } : null;
 const myUppercaseFormatter: Formatter = (row, cell, value, columnDef, dataContext) => value ? { text: value.toUpperCase() } : null;
+const myUppercaseGroupTotalFormatter: GroupTotalsFormatter = (totals: any, columnDef: Column) => {
+  const field = columnDef.field || '';
+  const val = totals.sum && totals.sum[field];
+  if (val != null && !isNaN(+val)) {
+    return `Custom: ${val}`;
+  }
+  return '';
+};
 const myCustomObjectFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any) => {
   let textValue = value && value.hasOwnProperty('text') ? value.text : value;
   const toolTip = value && value.hasOwnProperty('toolTip') ? value.toolTip : '';
@@ -430,7 +439,7 @@ describe('ExcelExportService', () => {
         });
       });
 
-      it(`should have the Order without html tags when the grid option has "sanitizeDataExport" enabled`, async () => {
+      it(`should have the Order without html tags when the grid option has "sanitizeDataExport" is enabled`, async () => {
         mockGridOptions.excelExportOptions = { sanitizeDataExport: true };
         mockCollection = [{ id: 1, userId: '2B02', firstName: 'Jane', lastName: 'Doe', position: 'FINANCE_MANAGER', order: 1 }];
         jest.spyOn(dataViewStub, 'getLength').mockReturnValue(mockCollection.length);
@@ -458,6 +467,38 @@ describe('ExcelExportService', () => {
               { metadata: { style: 1, }, value: 'Order', },
             ],
             ['2B02', 'Jane', 'DOE', 'FINANCE_MANAGER', '1'],
+          ]
+        });
+      });
+
+      it(`should have different styling for header titles when the grid option has "columnHeaderStyle" provided with custom styles`, async () => {
+        mockGridOptions.excelExportOptions = { columnHeaderStyle: { font: { bold: true, italic: true } } };
+        mockCollection = [{ id: 1, userId: '2B02', firstName: 'Jane', lastName: 'Doe', position: 'FINANCE_MANAGER', order: 1 }];
+        jest.spyOn(dataViewStub, 'getLength').mockReturnValue(mockCollection.length);
+        jest.spyOn(dataViewStub, 'getItem').mockReturnValue(null).mockReturnValueOnce(mockCollection[0]);
+        const pluginEaSpy = jest.spyOn(pluginEa, 'publish');
+        const globalEaSpy = jest.spyOn(globalEa, 'publish');
+        const spyUrlCreate = jest.spyOn(URL, 'createObjectURL');
+        const spyDownload = jest.spyOn(service, 'startDownloadFile');
+
+        const optionExpectation = { filename: 'export.xlsx', format: 'xlsx' };
+
+        service.init(gridStub, dataViewStub);
+        await service.exportToExcel(mockExportExcelOptions);
+
+        expect(pluginEaSpy).toHaveBeenNthCalledWith(2, `excelExportService:onAfterExportToExcel`, optionExpectation);
+        expect(globalEaSpy).toHaveBeenNthCalledWith(2, `${DEFAULT_AURELIA_EVENT_PREFIX}:onAfterExportToExcel`, optionExpectation);
+        expect(spyUrlCreate).toHaveBeenCalledWith(mockExcelBlob);
+        expect(spyDownload).toHaveBeenCalledWith({
+          ...optionExpectation, blob: new Blob(), data: [
+            [
+              { metadata: { style: 5, }, value: 'User Id', },
+              { metadata: { style: 5, }, value: 'FirstName', },
+              { metadata: { style: 5, }, value: 'LastName', },
+              { metadata: { style: 5, }, value: 'Position', },
+              { metadata: { style: 5, }, value: 'Order', },
+            ],
+            ['2B02', 'Jane', 'DOE', 'FINANCE_MANAGER', '<b>1</b>'],
           ]
         });
       });
@@ -538,7 +579,7 @@ describe('ExcelExportService', () => {
       });
 
 
-      it(`should Date exported correctly when Field Type is provided and we use "exportWithFormatter" set to True & False`, async () => {
+      it(`should expect Date exported correctly when Field Type is provided and we use "exportWithFormatter" set to True & False`, async () => {
         mockCollection = [
           { id: 0, userId: '1E06', firstName: 'John', lastName: 'Z', position: 'SALES_REP', startDate: '2005-12-20T18:19:19.992Z', endDate: null },
           { id: 1, userId: '1E09', firstName: 'Jane', lastName: 'Doe', position: 'HUMAN_RESOURCES', startDate: '2010-10-09T18:19:19.992Z', endDate: '2024-01-02T16:02:02.000Z' },
@@ -694,6 +735,7 @@ describe('ExcelExportService', () => {
             exportWithFormatter: true,
             formatter: Formatters.multiple, params: { formatters: [myBoldHtmlFormatter, myCustomObjectFormatter] },
             groupTotalsFormatter: GroupTotalFormatters.sumTotals,
+            exportCustomGroupTotalsFormatter: myUppercaseGroupTotalFormatter,
           },
         ] as Column[];
 
@@ -761,7 +803,7 @@ describe('ExcelExportService', () => {
             ['▿ Order: 20 (2 items)'],
             ['', '1E06', 'John', 'Z', 'SALES_REP', '10'],
             ['', '2B02', 'Jane', 'DOE', 'FINANCE_MANAGER', '10'],
-            ['', '', '', '', '', '20'],
+            ['', '', '', '', '', 'Custom: 20'],
           ]
         });
       });
@@ -1292,7 +1334,7 @@ describe('ExcelExportService', () => {
       });
 
       it('should return a date time format when using FieldType.date', async () => {
-        const input = new Date('2012-02-28T23:01:52.103Z');
+        const input = new Date(Date.UTC(2012, 1, 28, 23, 1, 52, 103));
         const expectedDate = '2012-02-28';
 
         service.init(gridStub, dataViewStub);

--- a/src/aurelia-slickgrid/services/excelExport.service.ts
+++ b/src/aurelia-slickgrid/services/excelExport.service.ts
@@ -124,6 +124,9 @@ export class ExcelExportService {
             this._gridOptions.excelExportOptions.customExcelHeader(this._workbook, this._sheet);
           }
 
+          const columns = this._grid && this._grid.getColumns && this._grid.getColumns() || [];
+          this._sheet.setColumns(this.getColumnStyles(columns));
+
           const currentSheetData = this._sheet.data;
           let finalOutput = currentSheetData;
           if (Array.isArray(currentSheetData) && Array.isArray(dataOutput)) {
@@ -246,15 +249,44 @@ export class ExcelExportService {
 
     // data variable which will hold all the fields data of a row
     const outputData: Array<string[] | ExcelCellFormat[]> = [];
+    const columnHeaderStyle = this._gridOptions && this._gridOptions.excelExportOptions && this._gridOptions.excelExportOptions.columnHeaderStyle;
+    let columnHeaderStyleId = this._stylesheetFormats.boldFormatter.id;
+    if (columnHeaderStyle) {
+      columnHeaderStyleId = this._stylesheet.createFormat(columnHeaderStyle).id;
+    }
 
     // get all column headers (it might include a "Group by" title at A1 cell)
-    const headers = this.getColumnHeaderData(columns, { style: this._stylesheetFormats.boldFormatter.id });
-    outputData.push(headers);
+    // also style the headers, defaults to Bold but user could pass his own style
+    outputData.push(this.getColumnHeaderData(columns, { style: columnHeaderStyleId }));
 
     // Populate the rest of the Grid Data
     this.pushAllGridRowDataToArray(outputData, columns);
 
     return outputData;
+  }
+
+  /** Get each column style including a style for the width of each column */
+  private getColumnStyles(columns: Column[]): any[] {
+    const grouping = this._dataView && this._dataView.getGrouping && this._dataView.getGrouping();
+    const columnStyles = [];
+    if (grouping) {
+      columnStyles.push({
+        bestFit: true,
+        columnStyles: (this._gridOptions && this._gridOptions.excelExportOptions && this._gridOptions.excelExportOptions.customColumnWidth) || 10
+      });
+    }
+
+    columns.forEach((columnDef: Column) => {
+      const skippedField = columnDef.excludeFromExport || false;
+      // if column width is 0, then we consider that field as a hidden field and should not be part of the export
+      if ((columnDef.width === undefined || columnDef.width > 0) && !skippedField) {
+        columnStyles.push({
+          bestFit: true,
+          width: columnDef.exportColumnWidth || (this._gridOptions && this._gridOptions.excelExportOptions && this._gridOptions.excelExportOptions.customColumnWidth) || 10
+        });
+      }
+    });
+    return columnStyles;
   }
 
   /** Get all column headers and format them in Bold */
@@ -428,9 +460,13 @@ export class ExcelExportService {
 
       const skippedField = columnDef.excludeFromExport || false;
 
-      // if there's a groupTotalsFormatter, we will re-run it to get the exact same output as what is shown in UI
-      if (columnDef.groupTotalsFormatter) {
-        itemData = columnDef.groupTotalsFormatter(itemObj, columnDef);
+      // if there's a exportCustomGroupTotalsFormatter or groupTotalsFormatter, we will re-run it to get the exact same output as what is shown in UI
+      if (columnDef.exportCustomGroupTotalsFormatter) {
+        itemData = columnDef.exportCustomGroupTotalsFormatter(itemObj, columnDef);
+      } else {
+        if (columnDef.groupTotalsFormatter) {
+          itemData = columnDef.groupTotalsFormatter(itemObj, columnDef);
+        }
       }
 
       // does the user want to sanitize the output data (remove HTML tags)?

--- a/src/examples/slickgrid/example24.ts
+++ b/src/examples/slickgrid/example24.ts
@@ -258,7 +258,11 @@ export class Example24 {
       enableSorting: true,
       enableTranslate: true,
       excelExportOptions: {
-        exportWithFormatter: true
+        exportWithFormatter: true,
+        customColumnWidth: 15,
+
+        // you can customize how the header titles will be styled (defaults to Bold)
+        columnHeaderStyle: { font: { bold: true, italic: true } }
       },
       i18n: this.i18n,
 


### PR DESCRIPTION
code referenced from another fork in this particular [commit](https://github.com/drinac/Angular-Slickgrid/commit/275e099c8a55f0eb43935249dbf71e0c02066afe) 

- add the following `excelExportOptions`
  - `customColumnWidth` 
  - `columnHeaderStyle`
- add the following Column options
  - `exportColumnWidth`
  - `exportCustomGroupTotalsFormatter`