### PR TITLE
feat(sort): add default sort field as grid option

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "jszip": "^3.2.2",
     "lodash.isequal": "^4.5.0",
     "moment-mini": "^2.24.0",
-    "slickgrid": "^2.4.18",
+    "slickgrid": "^2.4.19",
     "text-encoding-utf-8": "^1.0.2"
   },
   "devDependencies": {

--- a/src/aurelia-slickgrid/global-grid-options.ts
+++ b/src/aurelia-slickgrid/global-grid-options.ts
@@ -72,6 +72,7 @@ export const GlobalGridOptions: Partial<GridOption> = {
     syncGridSelectionWithBackendService: false, // but disable it when using backend services
   },
   datasetIdPropertyName: 'id',
+  defaultColumnSortFieldId: 'id',
   defaultAureliaEventPrefix: 'asg',
   defaultSlickgridEventPrefix: 'sg',
   defaultFilter: Filters.input,

--- a/src/aurelia-slickgrid/models/gridOption.interface.ts
+++ b/src/aurelia-slickgrid/models/gridOption.interface.ts
@@ -133,6 +133,9 @@ export interface GridOption {
   /** Default prefix for Aurelia Event names */
   defaultAureliaEventPrefix?: string;
 
+  /** Defaults to 'id', what is the default column field id to sort when calling clear sorting */
+  defaultColumnSortFieldId?: string;
+
   /** Default column width, is set to 80 when null */
   defaultColumnWidth?: number;
 

--- a/src/aurelia-slickgrid/services/sort.service.ts
+++ b/src/aurelia-slickgrid/services/sort.service.ts
@@ -117,7 +117,9 @@ export class SortService {
           this.onBackendSortChanged(undefined, { grid: this._grid, sortCols: [], clearSortTriggered: true });
         } else {
           if (this._columnDefinitions && Array.isArray(this._columnDefinitions)) {
-            this.onLocalSortChanged(this._grid, this._dataView, new Array({ sortAsc: true, sortCol: this._columnDefinitions[0], clearSortTriggered: true }));
+            const sortColFieldId = this._gridOptions && this._gridOptions.defaultColumnSortFieldId || 'id';
+            const sortCol = { id: sortColFieldId, field: sortColFieldId } as Column;
+            this.onLocalSortChanged(this._grid, this._dataView, new Array({ sortAsc: true, sortCol, clearSortTriggered: true }));
           }
         }
       } else if (this._isBackendGrid) {

--- a/src/examples/slickgrid/example1.ts
+++ b/src/examples/slickgrid/example1.ts
@@ -1,4 +1,4 @@
-import { Column, GridOption } from '../../aurelia-slickgrid';
+import { Column, GridOption, Formatters } from '../../aurelia-slickgrid';
 
 const NB_ITEMS = 995;
 
@@ -30,8 +30,8 @@ export class Example1 {
       { id: 'title', name: 'Title', field: 'title', sortable: true, minWidth: 100 },
       { id: 'duration', name: 'Duration (days)', field: 'duration', sortable: true, minWidth: 100 },
       { id: '%', name: '% Complete', field: 'percentComplete', sortable: true, minWidth: 100 },
-      { id: 'start', name: 'Start', field: 'start', minWidth: 100 },
-      { id: 'finish', name: 'Finish', field: 'finish', minWidth: 100 },
+      { id: 'start', name: 'Start', field: 'start', formatter: Formatters.dateIso },
+      { id: 'finish', name: 'Finish', field: 'finish', formatter: Formatters.dateIso },
       { id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven', sortable: true, minWidth: 100 }
     ];
     this.gridOptions1 = {
@@ -68,8 +68,8 @@ export class Example1 {
         title: 'Task ' + i,
         duration: Math.round(Math.random() * 100) + '',
         percentComplete: randomPercent,
-        start: `${randomMonth}/${randomDay}/${randomYear}`,
-        finish: `${randomMonth}/${randomDay}/${randomYear}`,
+        start: new Date(randomYear, randomMonth + 1, randomDay),
+        finish: new Date(randomYear + 1, randomMonth + 1, randomDay),
         effortDriven: (i % 5 === 0)
       };
     }

--- a/test/cypress/integration/example01.spec.js
+++ b/test/cypress/integration/example01.spec.js
@@ -117,9 +117,9 @@ describe('Example 1 - Basic Grids', () => {
       .click();
   });
 
-  it('should have no sorting in 2nd grid', () => {
+  it('should have no sorting in 2nd grid (back to default sorted by id)', () => {
     let gridUid = '';
-    const grid2Tasks = ['Task 0', 'Task 1', 'Task 10', 'Task 100', 'Task 101'];
+    const grid2Tasks = ['Task 0', 'Task 1', 'Task 2', 'Task 3', 'Task 4'];
 
     cy.get('#grid2')
       .should(($grid) => {

--- a/test/cypress/package.json
+++ b/test/cypress/package.json
@@ -11,7 +11,7 @@
   "author": "Ghislain B.",
   "license": "MIT",
   "devDependencies": {
-    "cypress": "^4.0.2",
+    "cypress": "^4.2.0",
     "mocha": "^5.2.0",
     "mochawesome": "^3.1.2",
     "mochawesome-merge": "^1.0.7",


### PR DESCRIPTION
- when clearing sorting, the default is to use as sort is "id". This new grid option allows to provide another field id.