### PR TITLE
fix(resizer): remove scrollbar measure compensate patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "jszip": "^3.2.2",
     "lodash.isequal": "^4.5.0",
     "moment-mini": "^2.24.0",
-    "slickgrid": "^2.4.19",
+    "slickgrid": "2.4.20",
     "text-encoding-utf-8": "^1.0.2"
   },
   "devDependencies": {

--- a/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid-constructor.spec.ts
+++ b/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid-constructor.spec.ts
@@ -151,7 +151,6 @@ const resizerServiceStub = {
   init: jest.fn(),
   dispose: jest.fn(),
   bindAutoResizeDataGrid: jest.fn(),
-  compensateHorizontalScroll: jest.fn(),
   resizeGrid: jest.fn(),
 } as unknown as ResizerService;
 

--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -695,9 +695,6 @@ export class AureliaSlickgridCustomElement {
     // expand/autofit columns on first page load
     if (grid && options.autoFitColumnsOnFirstLoad && options.enableAutoSizeColumns && typeof grid.autosizeColumns === 'function') {
       this.grid.autosizeColumns();
-
-      // compensate anytime SlickGrid measureScrollbar is incorrect (only seems to happen in Chrome 1/5 computers)
-      this.resizerService.compensateHorizontalScroll(this.grid, this.gridOptions);
     }
 
     // auto-resize grid on browser resize

--- a/src/aurelia-slickgrid/services/__tests__/resizer.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/resizer.service.spec.ts
@@ -21,7 +21,7 @@ const gridOptionMock = {
     containerId,
     maxHeight: 800,
     maxWidth: 1200,
-    sidePadding: 15,
+    sidePadding: 10,
   },
   enableAutoResize: true
 } as GridOption;

--- a/src/aurelia-slickgrid/services/resizer.service.ts
+++ b/src/aurelia-slickgrid/services/resizer.service.ts
@@ -175,25 +175,6 @@ export class ResizerService {
     return this._lastDimensions;
   }
 
-  /**
-   * For some reason this only seems to happen in Chrome and is sometime miscalculated by SlickGrid measureSrollbar() method
-   * When that happens we will compensate and resize the Grid Viewport to avoid seeing horizontal scrollbar
-   * Most of the time it happens, it's a tiny offset calculation of usually 3px (enough to show scrollbar)
-   * GitHub issue reference: https://github.com/6pac/SlickGrid/issues/275
-   */
-  compensateHorizontalScroll(grid: any, gridOptions: GridOption) {
-    const scrollbarDimensions = grid && grid.getScrollbarDimensions();
-    const slickGridScrollbarWidth = scrollbarDimensions && scrollbarDimensions.width;
-    const calculatedScrollbarWidth = getScrollBarWidth();
-
-    // if scrollbar width is different from SlickGrid calculation to our custom calculation
-    // then resize the grid with the missing pixels to remove scroll (usually only 3px)
-    if (slickGridScrollbarWidth < calculatedScrollbarWidth && this._gridDomElm && this._gridDomElm.width) {
-      const oldWidth = this._gridDomElm && this._gridDomElm.width && this._gridDomElm.width() || 0;
-      this._gridDomElm.width(oldWidth + (calculatedScrollbarWidth - slickGridScrollbarWidth));
-    }
-  }
-
   /** Provide the possibility to pause the resizer for some time, until user decides to re-enabled it later if he wish to. */
   pauseResizer(isResizePaused: boolean) {
     this._resizePaused = isResizePaused;
@@ -254,8 +235,6 @@ export class ResizerService {
         if (this._gridUid && $(`.${this._gridUid}`).length > 0) {
           this._grid.autosizeColumns();
         }
-        // compensate anytime SlickGrid measureScrollbar is incorrect
-        this.compensateHorizontalScroll(this._grid, this._gridOptions);
       }
 
       // keep last resized dimensions & resolve them to the Promise

--- a/src/aurelia-slickgrid/services/resizer.service.ts
+++ b/src/aurelia-slickgrid/services/resizer.service.ts
@@ -3,7 +3,6 @@ import { EventAggregator } from 'aurelia-event-aggregator';
 import * as $ from 'jquery';
 
 import { GridOption } from './../models/index';
-import { getScrollBarWidth } from './utilities';
 import { SlickgridEventAggregator } from '../custom-elements/slickgridEventAggregator';
 
 // global constants, height/width are in pixels

--- a/src/aurelia-slickgrid/services/utilities.ts
+++ b/src/aurelia-slickgrid/services/utilities.ts
@@ -722,14 +722,6 @@ export function getHtmlElementOffset(element: HTMLElement): { top: number; left:
   return { top, left };
 }
 
-/** Get the browser's scrollbar width, this is different to each browser */
-export function getScrollBarWidth(): number {
-  const $outer = $('<div>').css({ visibility: 'hidden', width: 100, overflow: 'scroll' }).appendTo('body');
-  const widthWithScroll = $('<div>').css({ width: '100%' }).appendTo($outer).outerWidth() || 0;
-  $outer.remove();
-  return Math.ceil(100 - widthWithScroll);
-}
-
 /**
  * Converts a string from camelCase to snake_case (underscore) case
  * @param str the string to convert

--- a/src/examples/slickgrid/example11.ts
+++ b/src/examples/slickgrid/example11.ts
@@ -138,7 +138,7 @@ export class Example11 {
       asyncEditorLoading: false,
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       editable: true,
       enableColumnPicker: true,

--- a/src/examples/slickgrid/example12.ts
+++ b/src/examples/slickgrid/example12.ts
@@ -136,7 +136,7 @@ export class Example12 {
     this.gridOptions = {
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableAutoResize: true,
       enableExcelCopyBuffer: true,

--- a/src/examples/slickgrid/example13.ts
+++ b/src/examples/slickgrid/example13.ts
@@ -146,7 +146,7 @@ export class Example13 {
     this.gridOptions = {
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableExcelExport: true,
       enableFiltering: true,

--- a/src/examples/slickgrid/example15.ts
+++ b/src/examples/slickgrid/example15.ts
@@ -140,7 +140,7 @@ export class Example15 {
     this.gridOptions = {
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableCheckboxSelector: true,
       enableFiltering: true,

--- a/src/examples/slickgrid/example16.ts
+++ b/src/examples/slickgrid/example16.ts
@@ -58,7 +58,7 @@ export class Example16 {
       enableAutoResize: true,
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableCellNavigation: true,
       enableRowMoveManager: true,

--- a/src/examples/slickgrid/example17.ts
+++ b/src/examples/slickgrid/example17.ts
@@ -91,7 +91,7 @@ export class Example17 {
       enableAutoResize: true,
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableCellNavigation: true,
       enableColumnReorder: false,

--- a/src/examples/slickgrid/example18.ts
+++ b/src/examples/slickgrid/example18.ts
@@ -199,7 +199,7 @@ export class Example18 {
     this.gridOptions = {
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableDraggableGrouping: true,
       createPreHeaderPanel: true,

--- a/src/examples/slickgrid/example19.ts
+++ b/src/examples/slickgrid/example19.ts
@@ -72,7 +72,7 @@ export class Example19 {
     this.gridOptions = {
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableFiltering: true,
       enableRowDetailView: true,

--- a/src/examples/slickgrid/example2.ts
+++ b/src/examples/slickgrid/example2.ts
@@ -80,7 +80,7 @@ export class Example2 {
     this.gridOptions = {
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableCellNavigation: true,
       showCustomFooter: true, // display some metrics in the bottom custom footer

--- a/src/examples/slickgrid/example20.ts
+++ b/src/examples/slickgrid/example20.ts
@@ -138,7 +138,7 @@ export class Example20 {
     this.gridOptions = {
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       alwaysShowVerticalScroll: false, // disable scroll since we don't want it to show on the left pinned columns
       enableCellNavigation: true,

--- a/src/examples/slickgrid/example21.ts
+++ b/src/examples/slickgrid/example21.ts
@@ -97,7 +97,7 @@ export class Example21 {
       autoHeight: true,
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
 
       // enable the filtering but hide the user filter row since we use our own single filter

--- a/src/examples/slickgrid/example22.ts
+++ b/src/examples/slickgrid/example22.ts
@@ -54,7 +54,7 @@ export class Example22 {
       enableAutoResize: true,
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableSorting: true
     };
@@ -79,7 +79,7 @@ export class Example22 {
       enableAutoResize: true,
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableFiltering: true,
       enableSorting: true

--- a/src/examples/slickgrid/example23.ts
+++ b/src/examples/slickgrid/example23.ts
@@ -160,7 +160,7 @@ export class Example23 {
     this.gridOptions = {
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableExcelCopyBuffer: true,
       enableFiltering: true,

--- a/src/examples/slickgrid/example24.ts
+++ b/src/examples/slickgrid/example24.ts
@@ -251,7 +251,7 @@ export class Example24 {
     this.gridOptions = {
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableCellNavigation: true,
       enableFiltering: true,

--- a/src/examples/slickgrid/example25.ts
+++ b/src/examples/slickgrid/example25.ts
@@ -143,7 +143,7 @@ export class Example25 {
     this.gridOptions = {
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableFiltering: true,
       enableCellNavigation: true,

--- a/src/examples/slickgrid/example26.ts
+++ b/src/examples/slickgrid/example26.ts
@@ -256,7 +256,7 @@ export class Example26 {
       autoCommitEdit: false,
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       rowHeight: 45, // increase row height so that the custom elements fits in the cell
       editable: true,

--- a/src/examples/slickgrid/example3.ts
+++ b/src/examples/slickgrid/example3.ts
@@ -437,7 +437,7 @@ export class Example3 {
       autoCommitEdit: false,
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       editable: true,
       enableCellNavigation: true,

--- a/src/examples/slickgrid/example4.ts
+++ b/src/examples/slickgrid/example4.ts
@@ -200,7 +200,7 @@ export class Example4 {
     this.gridOptions = {
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableExcelExport: true,
       enableExcelCopyBuffer: true,

--- a/src/examples/slickgrid/example5.ts
+++ b/src/examples/slickgrid/example5.ts
@@ -81,7 +81,7 @@ export class Example5 {
       enableAutoResize: true,
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       checkboxSelector: {
         // you can toggle these 2 properties to show the "select all" checkbox in different location

--- a/src/examples/slickgrid/example7.ts
+++ b/src/examples/slickgrid/example7.ts
@@ -63,7 +63,7 @@ export class Example7 {
       enableHeaderMenu: false,
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableFiltering: false,
       enableCellNavigation: true,

--- a/src/examples/slickgrid/example8.ts
+++ b/src/examples/slickgrid/example8.ts
@@ -118,7 +118,7 @@ export class Example8 {
       enableHeaderMenu: true,
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableFiltering: false,
       enableCellNavigation: true,

--- a/src/examples/slickgrid/example9.ts
+++ b/src/examples/slickgrid/example9.ts
@@ -93,7 +93,7 @@ export class Example9 {
       enableGridMenu: true,
       autoResize: {
         containerId: 'demo-container',
-        sidePadding: 15
+        sidePadding: 10
       },
       enableFiltering: true,
       enableCellNavigation: true,


### PR DESCRIPTION
- that was a temporary patch that was put in place to compensate for incorrect scrollbar measure happening in some browser like Chrome. This patch is no longer necessary since the bug was fixed in SlickGrid (core)