### PR TITLE
feat(extension): add latest slickgrid with RowMove improvements

### DIFF
--- a/src/aurelia-slickgrid/extensions/__tests__/rowMoveManagerExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/rowMoveManagerExtension.spec.ts
@@ -1,5 +1,5 @@
 import { I18N } from 'aurelia-i18n';
-import { GridOption } from '../../models/gridOption.interface';
+import { Column, GridOption } from '../../models';
 import { RowMoveManagerExtension } from '../rowMoveManagerExtension';
 import { ExtensionUtility } from '../extensionUtility';
 import { SharedService } from '../../services/shared.service';
@@ -16,6 +16,7 @@ const gridStub = {
 const mockAddon = jest.fn().mockImplementation(() => ({
   init: jest.fn(),
   destroy: jest.fn(),
+  getColumnDefinition: jest.fn(),
   onBeforeMoveRows: new Slick.Event(),
   onMoveRows: new Slick.Event(),
 }));
@@ -38,6 +39,9 @@ describe('rowMoveManagerExtension', () => {
   const gridOptionsMock = {
     enableRowMoveManager: true,
     rowMoveManager: {
+      cancelEditOnDrag: true,
+      singleRowMove: true,
+      disableRowSelection: true,
       onExtensionRegistered: jest.fn(),
       onBeforeMoveRows: (e, args: { insertBefore: number; rows: number[]; }) => { },
       onMoveRows: (e, args: { insertBefore: number; rows: number[]; }) => { },
@@ -50,13 +54,29 @@ describe('rowMoveManagerExtension', () => {
     extension = new RowMoveManagerExtension(extensionUtility, sharedService);
   });
 
-  it('should return null when either the grid object or the grid options is missing', () => {
+  it('should return null after calling "create" method when either the column definitions or the grid options is missing', () => {
+    const output = extension.create([] as Column[], null);
+    expect(output).toBeNull();
+  });
+
+  it('should return null after calling "loadAddonWhenNotExists" method when either the column definitions or the grid options is missing', () => {
+    const output = extension.loadAddonWhenNotExists([] as Column[], null);
+    expect(output).toBeNull();
+  });
+
+  it('should return null after calling "register" method when either the grid object or the grid options is missing', () => {
     const output = extension.register();
     expect(output).toBeNull();
   });
 
-  describe('registered addon', () => {
+  describe('create method', () => {
+    let columnsMock: Column[];
+
     beforeEach(() => {
+      columnsMock = [
+        { id: 'field1', field: 'field1', width: 100, cssClass: 'red' },
+        { id: 'field2', field: 'field2', width: 50 }
+      ];
       jest.spyOn(SharedService.prototype, 'grid', 'get').mockReturnValue(gridStub);
       jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
     });
@@ -65,16 +85,109 @@ describe('rowMoveManagerExtension', () => {
       jest.clearAllMocks();
     });
 
+    it('should add a reserved column for icons in 1st column index', () => {
+      const instance = extension.loadAddonWhenNotExists(columnsMock, gridOptionsMock);
+      const spy = jest.spyOn(instance, 'getColumnDefinition').mockReturnValue({ id: '_move', field: 'move' });
+      extension.create(columnsMock, gridOptionsMock);
+
+      expect(spy).toHaveBeenCalled();
+      expect(columnsMock).toEqual([
+        {
+          excludeFromColumnPicker: true,
+          excludeFromExport: true,
+          excludeFromGridMenu: true,
+          excludeFromHeaderMenu: true,
+          excludeFromQuery: true,
+          field: 'move',
+          id: '_move'
+        },
+        { id: 'field1', field: 'field1', width: 100, cssClass: 'red' },
+        { id: 'field2', field: 'field2', width: 50 },
+      ]);
+    });
+
+    it('should NOT add the move icon column if it already exist in the column definitions', () => {
+      columnsMock = [{
+        id: '_move', name: '', field: 'move', width: 40,
+        behavior: 'selectAndMove', selectable: false, resizable: false, cssClass: '',
+        formatter: (row, cell, value, columnDef, dataContext, grid) => ({ addClasses: 'cell-reorder dnd' })
+      }, ...columnsMock] as Column[];
+      const instance = extension.loadAddonWhenNotExists(columnsMock, gridOptionsMock);
+      const spy = jest.spyOn(instance, 'getColumnDefinition').mockReturnValue({ id: '_move', field: 'move' });
+      extension.create(columnsMock, gridOptionsMock);
+
+      expect(spy).toHaveBeenCalled();
+      expect(columnsMock).toEqual([
+        {
+          behavior: 'selectAndMove',
+          cssClass: '',
+          field: 'move',
+          formatter: expect.anything(),
+          id: '_move',
+          name: '',
+          resizable: false,
+          selectable: false,
+          width: 40,
+          excludeFromColumnPicker: true,
+          excludeFromExport: true,
+          excludeFromGridMenu: true,
+          excludeFromHeaderMenu: true,
+          excludeFromQuery: true,
+        },
+        { id: 'field1', field: 'field1', width: 100, cssClass: 'red' },
+        { id: 'field2', field: 'field2', width: 50 },
+      ]);
+    });
+
+    it('should expect the column to be at a different column index position when "columnIndexPosition" is defined', () => {
+      gridOptionsMock.rowMoveManager.columnIndexPosition = 2;
+      const instance = extension.loadAddonWhenNotExists(columnsMock, gridOptionsMock);
+      const spy = jest.spyOn(instance, 'getColumnDefinition').mockReturnValue({ id: '_move', field: 'move' });
+      extension.create(columnsMock, gridOptionsMock);
+
+      expect(spy).toHaveBeenCalled();
+      expect(columnsMock).toEqual([
+        { id: 'field1', field: 'field1', width: 100, cssClass: 'red' },
+        { id: 'field2', field: 'field2', width: 50 },
+        {
+          excludeFromColumnPicker: true,
+          excludeFromExport: true,
+          excludeFromGridMenu: true,
+          excludeFromHeaderMenu: true,
+          excludeFromQuery: true,
+          field: 'move',
+          id: '_move'
+        },
+      ]);
+    });
+  });
+
+  describe('registered addon', () => {
+    let columnsMock: Column[];
+
+    beforeEach(() => {
+      columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }];
+      jest.spyOn(SharedService.prototype, 'grid', 'get').mockReturnValue(gridStub);
+      jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
+      jest.clearAllMocks();
+    });
+
     it('should register the addon', () => {
       const onRegisteredSpy = jest.spyOn(SharedService.prototype.gridOptions.rowMoveManager, 'onExtensionRegistered');
       const pluginSpy = jest.spyOn(SharedService.prototype.grid, 'registerPlugin');
 
-      const instance = extension.register();
+      const instance = extension.loadAddonWhenNotExists(columnsMock, gridOptionsMock);
+      extension.create(columnsMock, gridOptionsMock);
+      extension.register();
       const addonInstance = extension.getAddonInstance();
 
       expect(instance).toBeTruthy();
       expect(instance).toEqual(addonInstance);
       expect(mockAddon).toHaveBeenCalledWith({
+        cancelEditOnDrag: true,
+        disableRowSelection: true,
+        singleRowMove: true,
+        columnIndexPosition: 2,
         onExtensionRegistered: expect.anything(),
         onBeforeMoveRows: expect.anything(),
         onMoveRows: expect.anything(),
@@ -84,7 +197,8 @@ describe('rowMoveManagerExtension', () => {
     });
 
     it('should dispose of the addon', () => {
-      const instance = extension.register();
+      const instance = extension.create(columnsMock, gridOptionsMock);
+      extension.register();
       const destroySpy = jest.spyOn(instance, 'destroy');
 
       extension.dispose();
@@ -93,13 +207,14 @@ describe('rowMoveManagerExtension', () => {
     });
 
     it('should provide addon options and expect them to be called in the addon constructor', () => {
-      const optionMock = { cancelEditOnDrag: true };
+      const optionMock = { cancelEditOnDrag: true, singleRowMove: true, disableRowSelection: true };
       const addonOptions = { ...gridOptionsMock, rowMoveManager: optionMock };
       jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(addonOptions);
 
+      const instance = extension.create(columnsMock, gridOptionsMock);
       extension.register();
 
-      expect(mockAddon).toHaveBeenCalledWith(optionMock);
+      expect(mockAddon).toHaveBeenCalledWith(gridOptionsMock.rowMoveManager);
     });
 
     it('should call internal event handler subscribe and expect the "onBeforeMoveRows" option to be called when addon notify is called', () => {
@@ -107,7 +222,8 @@ describe('rowMoveManagerExtension', () => {
       const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.rowMoveManager, 'onBeforeMoveRows');
       const onMoveSpy = jest.spyOn(SharedService.prototype.gridOptions.rowMoveManager, 'onMoveRows');
 
-      const instance = extension.register();
+      const instance = extension.create(columnsMock, gridOptionsMock);
+      extension.register();
       instance.onBeforeMoveRows.notify({ insertBefore: 3, rows: [1] }, new Slick.EventData(), gridStub);
 
       expect(handlerSpy).toHaveBeenCalledTimes(2);
@@ -124,7 +240,8 @@ describe('rowMoveManagerExtension', () => {
       const onBeforeSpy = jest.spyOn(SharedService.prototype.gridOptions.rowMoveManager, 'onBeforeMoveRows');
       const onMoveSpy = jest.spyOn(SharedService.prototype.gridOptions.rowMoveManager, 'onMoveRows');
 
-      const instance = extension.register();
+      const instance = extension.create(columnsMock, gridOptionsMock);
+      extension.register();
       instance.onMoveRows.notify({ insertBefore: 3, rows: [1] }, new Slick.EventData(), gridStub);
 
       expect(handlerSpy).toHaveBeenCalledTimes(2);

--- a/src/aurelia-slickgrid/extensions/rowDetailViewExtension.ts
+++ b/src/aurelia-slickgrid/extensions/rowDetailViewExtension.ts
@@ -158,7 +158,6 @@ export class RowDetailViewExtension implements Extension {
         this.sharedService.grid.setSelectionModel(rowSelectionPlugin);
       }
 
-      // this._extension = this.create(this.sharedService.allColumns, this.sharedService.gridOptions);
       this.sharedService.grid.registerPlugin(this._addon);
 
       // hook all events

--- a/src/aurelia-slickgrid/extensions/rowMoveManagerExtension.ts
+++ b/src/aurelia-slickgrid/extensions/rowMoveManagerExtension.ts
@@ -1,5 +1,5 @@
 import { singleton, inject } from 'aurelia-framework';
-import { CellArgs, Extension, ExtensionName, SlickEventHandler } from '../models/index';
+import { CellArgs, Column, Extension, ExtensionName, GridOption, SlickEventHandler, } from '../models/index';
 import { ExtensionUtility } from './extensionUtility';
 import { SharedService } from '../services/shared.service';
 
@@ -29,6 +29,53 @@ export class RowMoveManagerExtension implements Extension {
     }
   }
 
+  /**
+   * Create the plugin before the Grid creation to avoid having odd behaviors.
+   * Mostly because the column definitions might change after the grid creation, so we want to make sure to add it before then
+   */
+  create(columnDefinitions: Column[], gridOptions: GridOption) {
+    if (Array.isArray(columnDefinitions) && gridOptions) {
+      this._addon = this.loadAddonWhenNotExists(columnDefinitions, gridOptions);
+      const newRowMoveColumn: Column = this._addon.getColumnDefinition();
+      const rowMoveColDef = Array.isArray(columnDefinitions) && columnDefinitions.find((col: Column) => col && col.behavior === 'selectAndMove');
+      const finalRowMoveColumn = rowMoveColDef ? rowMoveColDef : newRowMoveColumn;
+
+      // set some exclusion properties since we don't want this column to be part of the export neither the list of column in the pickers
+      if (typeof finalRowMoveColumn === 'object') {
+        finalRowMoveColumn.excludeFromExport = true;
+        finalRowMoveColumn.excludeFromColumnPicker = true;
+        finalRowMoveColumn.excludeFromGridMenu = true;
+        finalRowMoveColumn.excludeFromQuery = true;
+        finalRowMoveColumn.excludeFromHeaderMenu = true;
+      }
+
+      // only add the new column if it doesn't already exist
+      if (!rowMoveColDef) {
+        // column index position in the grid
+        const columnPosition = gridOptions?.rowMoveManager?.columnIndexPosition || 0;
+        if (columnPosition > 0) {
+          columnDefinitions.splice(columnPosition, 0, finalRowMoveColumn);
+        } else {
+          columnDefinitions.unshift(finalRowMoveColumn);
+        }
+      }
+      return this._addon;
+    }
+    return null;
+  }
+
+  loadAddonWhenNotExists(columnDefinitions: Column[], gridOptions: GridOption): any {
+    if (Array.isArray(columnDefinitions) && gridOptions) {
+      // dynamically import the SlickGrid plugin (addon) with RequireJS
+      this.extensionUtility.loadExtensionDynamically(ExtensionName.rowMoveManager);
+      if (!this._addon) {
+        this._addon = new Slick.RowMoveManager(gridOptions?.rowMoveManager || { cancelEditOnDrag: true });
+      }
+      return this._addon;
+    }
+    return null;
+  }
+
   /** Get the instance of the SlickGrid addon (control or plugin). */
   getAddonInstance() {
     return this._addon;
@@ -46,7 +93,6 @@ export class RowMoveManagerExtension implements Extension {
         this.sharedService.grid.setSelectionModel(rowSelectionPlugin);
       }
 
-      this._addon = new Slick.RowMoveManager(this.sharedService.gridOptions.rowMoveManager || { cancelEditOnDrag: true });
       this.sharedService.grid.registerPlugin(this._addon);
 
       // hook all events

--- a/src/aurelia-slickgrid/extensions/rowMoveManagerExtension.ts
+++ b/src/aurelia-slickgrid/extensions/rowMoveManagerExtension.ts
@@ -52,7 +52,7 @@ export class RowMoveManagerExtension implements Extension {
       // only add the new column if it doesn't already exist
       if (!rowMoveColDef) {
         // column index position in the grid
-        const columnPosition = gridOptions?.rowMoveManager?.columnIndexPosition || 0;
+        const columnPosition = gridOptions && gridOptions.rowMoveManager && gridOptions.rowMoveManager.columnIndexPosition || 0;
         if (columnPosition > 0) {
           columnDefinitions.splice(columnPosition, 0, finalRowMoveColumn);
         } else {
@@ -69,7 +69,7 @@ export class RowMoveManagerExtension implements Extension {
       // dynamically import the SlickGrid plugin (addon) with RequireJS
       this.extensionUtility.loadExtensionDynamically(ExtensionName.rowMoveManager);
       if (!this._addon) {
-        this._addon = new Slick.RowMoveManager(gridOptions?.rowMoveManager || { cancelEditOnDrag: true });
+        this._addon = new Slick.RowMoveManager((gridOptions && gridOptions.rowMoveManager) || { cancelEditOnDrag: true });
       }
       return this._addon;
     }

--- a/src/aurelia-slickgrid/models/rowDetailView.interface.ts
+++ b/src/aurelia-slickgrid/models/rowDetailView.interface.ts
@@ -1,7 +1,4 @@
 export interface RowDetailView {
-  /** A CSS class to be added to the row detail */
-  cssClass?: string;
-
   /** Defaults to true, which will collapse all row detail views when user calls a sort. Unless user implements a sort to deal with padding */
   collapseAllOnSort?: boolean;
 
@@ -14,6 +11,9 @@ export interface RowDetailView {
    * it will add an offset to take into consideration (1.CheckboxSelector, 2.RowDetail, 3.RowMove)
    */
   columnIndexPosition?: number;
+
+  /** A CSS class to be added to the row detail */
+  cssClass?: string;
 
   /** Extra classes to be added to the expanded Toggle */
   expandedClass?: string;

--- a/src/aurelia-slickgrid/models/rowMoveManager.interface.ts
+++ b/src/aurelia-slickgrid/models/rowMoveManager.interface.ts
@@ -22,7 +22,7 @@ export interface RowMoveManager {
   singleRowMove?: boolean;
 
   /**  Width of the column */
-  width?: string;
+  width?: number;
 
   /** Override the logic for showing (or not) the move icon (use case example: only every 2nd row is moveable) */
   usabilityOverride?: (row: number, dataContext: any, grid: any) => boolean;

--- a/src/aurelia-slickgrid/models/rowMoveManager.interface.ts
+++ b/src/aurelia-slickgrid/models/rowMoveManager.interface.ts
@@ -1,4 +1,10 @@
 export interface RowMoveManager {
+  /** Defaults to false, option to cancel editing while dragging a row */
+  cancelEditOnDrag?: boolean;
+
+  /**  Column definition id(defaults to "_move") */
+  columnId?: string;
+
   /**
    * Defaults to 0, the column index position in the grid by default it will show as the first column (index 0).
    * Also note that the index position might vary if you use other extensions, after each extension is created,
@@ -6,11 +12,23 @@ export interface RowMoveManager {
    */
   columnIndexPosition?: number;
 
-  /** defaults to false, option to cancel edit on drag */
-  cancelEditOnDrag?: boolean;
+  /**  A CSS class to be added to the menu item container. */
+  cssClass?: string;
+
+  /**  Defaults to False, do we want to disable the row selection?  */
+  disableRowSelection?: boolean;
+
+  /**  Defaults to False, do we want a single row move? Setting this to false means that 1 or more rows can be selected to move together.  */
+  singleRowMove?: boolean;
+
+  /**  Width of the column */
+  width?: string;
+
+  /** Override the logic for showing (or not) the move icon (use case example: only every 2nd row is moveable) */
+  usabilityOverride?: (row: number, dataContext: any, grid: any) => boolean;
 
   //
-  // Events
+  // SlickGrid Events
 
   /** Fired after extension (plugin) is registered by SlickGrid */
   onExtensionRegistered?: (plugin: any) => void;

--- a/src/aurelia-slickgrid/services/__tests__/extension.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/extension.service.spec.ts
@@ -313,19 +313,26 @@ describe('ExtensionService', () => {
         expect(gridSpy).toHaveBeenCalled();
         expect(extCreateSpy).toHaveBeenCalledWith(columnsMock, gridOptionsMock);
         expect(rowSelectionInstance).not.toBeNull();
-        expect(extRegisterSpy).toHaveBeenCalled(); expect(output).toEqual({ name: ExtensionName.rowDetailView, addon: instanceMock, instance: instanceMock, class: extensionStub } as ExtensionModel);
+        expect(extRegisterSpy).toHaveBeenCalled();
+        expect(output).toEqual({ name: ExtensionName.rowDetailView, addon: instanceMock, instance: instanceMock, class: extensionStub } as ExtensionModel);
       });
 
       it('should register the RowMoveManager addon when "enableRowMoveManager" is set in the grid options', () => {
+        const columnsMock = [{ id: 'field1', field: 'field1', width: 100, cssClass: 'red' }] as Column[];
         const gridOptionsMock = { enableRowMoveManager: true } as GridOption;
-        const extSpy = jest.spyOn(extensionStub, 'register').mockReturnValue(instanceMock);
+        const extCreateSpy = jest.spyOn(extensionStub, 'create').mockReturnValue(instanceMock);
+        const extRegisterSpy = jest.spyOn(extensionStub, 'register');
         const gridSpy = jest.spyOn(SharedService.prototype, 'gridOptions', 'get').mockReturnValue(gridOptionsMock);
 
+        service.createExtensionsBeforeGridCreation(columnsMock, gridOptionsMock);
         service.bindDifferentExtensions();
+        const rowSelectionInstance = service.getExtensionByName(ExtensionName.rowSelection);
         const output = service.getExtensionByName(ExtensionName.rowMoveManager);
 
         expect(gridSpy).toHaveBeenCalled();
-        expect(extSpy).toHaveBeenCalled();
+        expect(extCreateSpy).toHaveBeenCalledWith(columnsMock, gridOptionsMock);
+        expect(rowSelectionInstance).not.toBeNull();
+        expect(extRegisterSpy).toHaveBeenCalled();
         expect(output).toEqual({ name: ExtensionName.rowMoveManager, addon: instanceMock, instance: instanceMock, class: extensionStub } as ExtensionModel);
       });
 

--- a/src/aurelia-slickgrid/services/excelExport.service.ts
+++ b/src/aurelia-slickgrid/services/excelExport.service.ts
@@ -58,7 +58,6 @@ export class ExcelExportService {
   /**
    * Initialize the Export Service
    * @param grid
-   * @param gridOptions
    * @param dataView
    */
   init(grid: any, dataView: any): void {

--- a/src/aurelia-slickgrid/services/extension.service.ts
+++ b/src/aurelia-slickgrid/services/extension.service.ts
@@ -168,8 +168,8 @@ export class ExtensionService {
       }
 
       // Row Selection Plugin
-      // this extension should be registered BEFORE the Checkbox Selector & Row Detail since it can be use by these 2 plugins
-      if (!this.getExtensionByName(ExtensionName.rowSelection) && (this.sharedService.gridOptions.enableRowSelection || this.sharedService.gridOptions.enableCheckboxSelector || this.sharedService.gridOptions.enableRowDetailView)) {
+      // this extension should be registered BEFORE the CheckboxSelector, RowDetail or RowMoveManager since it can be use by these 2 plugins
+      if (!this.getExtensionByName(ExtensionName.rowSelection) && (this.sharedService.gridOptions.enableRowSelection || this.sharedService.gridOptions.enableCheckboxSelector || this.sharedService.gridOptions.enableRowDetailView || this.sharedService.gridOptions.enableRowMoveManager)) {
         if (this.rowSelectionExtension && this.rowSelectionExtension.register) {
           const instance = this.rowSelectionExtension.register();
           this._extensionList.push({ name: ExtensionName.rowSelection, class: this.rowSelectionExtension, addon: instance, instance });
@@ -256,11 +256,12 @@ export class ExtensionService {
       }
 
       // Row Move Manager Plugin
-      if (this.sharedService.gridOptions.enableRowMoveManager) {
-        if (this.rowMoveManagerExtension && this.rowMoveManagerExtension.register) {
-          const instance = this.rowMoveManagerExtension.register();
-          this._extensionList.push({ name: ExtensionName.rowMoveManager, class: this.rowMoveManagerExtension, addon: instance, instance });
-        }
+      if (this.sharedService.gridOptions.enableRowMoveManager && this.rowMoveManagerExtension && this.rowMoveManagerExtension.register) {
+        const rowSelectionExtension = this.getExtensionByName(ExtensionName.rowSelection);
+        this.rowMoveManagerExtension.register(rowSelectionExtension);
+        const createdExtension = this.getCreatedExtensionByName(ExtensionName.rowMoveManager); // get the instance from when it was really created earlier
+        const instance = createdExtension && createdExtension.instance;
+        this._extensionList.push({ name: ExtensionName.rowMoveManager, class: this.rowMoveManagerExtension, addon: instance, instance });
       }
 
       // manually register other plugins
@@ -281,8 +282,8 @@ export class ExtensionService {
   }
 
   /**
-   * Bind/Create certain plugins before the Grid creation, else they might behave oddly.
-   * Mostly because the column definitions might change after the grid creation
+   * Bind/Create certain plugins before the Grid creation to avoid having odd behaviors.
+   * Mostly because the column definitions might change after the grid creation, so we want to make sure to add it before then
    * @param columnDefinitions
    * @param options
    */
@@ -291,6 +292,12 @@ export class ExtensionService {
       if (!this.getCreatedExtensionByName(ExtensionName.checkboxSelector)) {
         const checkboxInstance = this.checkboxSelectorExtension.create(columnDefinitions, options);
         this._extensionCreatedList.push({ name: ExtensionName.checkboxSelector, instance: checkboxInstance });
+      }
+    }
+    if (options.enableRowMoveManager) {
+      if (!this.getCreatedExtensionByName(ExtensionName.rowMoveManager)) {
+        const rowMoveInstance = this.rowMoveManagerExtension.create(columnDefinitions, options);
+        this._extensionCreatedList.push({ name: ExtensionName.rowMoveManager, instance: rowMoveInstance });
       }
     }
     if (options.enableRowDetailView) {

--- a/src/examples/slickgrid/example16.ts
+++ b/src/examples/slickgrid/example16.ts
@@ -1,15 +1,22 @@
 import { autoinject } from 'aurelia-framework';
 import { I18N } from 'aurelia-i18n';
-import { AureliaGridInstance, Column, Formatters, GridOption } from '../../aurelia-slickgrid';
+import { AureliaGridInstance, Column, Formatters, GridOption, ExtensionName } from '../../aurelia-slickgrid';
 
 @autoinject()
 export class Example16 {
-  title = 'Example 16: Row Move Plugin / Row Reordering';
+  title = 'Example 16: Row Move & Checkbox Selector';
   subTitle = `
     This example demonstrates using the <b>Slick.Plugins.RowMoveManager</b> plugin to easily move a row in the grid.<br/>
     <ul>
       <li>Click to select, Ctrl+Click to toggle selection, Shift+Click to select a range.</li>
       <li>Drag one or more rows by the handle (icon) to reorder</li>
+      <li>If you plan to use Row Selection + Row Move, then use "singleRowMove: true" and "disableRowSelection: true"</li>
+      <ul>
+        <li>You will also want to enable the DataView "syncGridSelection: true" to keep row selection even after a row move</li>
+      </ul>
+      <li>If you plan to use only Row Move, then you could keep default values (or omit them completely) of "singleRowMove: false" and "disableRowSelection: false"</li>
+      <ul>
+        <li>SingleRowMove has the name suggest will only move 1 row at a time, by default it will move any row(s) that are selected unless you disable the flag</li>
     </ul>
   `;
 
@@ -28,6 +35,10 @@ export class Example16 {
     this.aureliaGrid = aureliaGrid;
   }
 
+  get rowMoveInstance(): any {
+    return this.aureliaGrid && this.aureliaGrid.extensionService.getSlickgridAddonInstance(ExtensionName.rowMoveManager) || {};
+  }
+
   attached() {
     // populate the dataset once the grid is ready
     this.getData();
@@ -36,16 +47,6 @@ export class Example16 {
   /* Define grid Options and Columns */
   defineGrid() {
     this.columnDefinitions = [
-      {
-        id: '#', field: '', name: '', width: 40,
-        behavior: 'selectAndMove',
-        selectable: false, resizable: false,
-        cssClass: 'cell-reorder dnd',
-        excludeFromExport: true,
-        excludeFromColumnPicker: true,
-        excludeFromHeaderMenu: true,
-        excludeFromGridMenu: true
-      },
       { id: 'title', name: 'Title', field: 'title' },
       { id: 'duration', name: 'Duration', field: 'duration', sortable: true },
       { id: '%', name: '% Complete', field: 'percentComplete', sortable: true },
@@ -60,14 +61,26 @@ export class Example16 {
         containerId: 'demo-container',
         sidePadding: 10
       },
-      enableCellNavigation: true,
-      enableRowMoveManager: true,
-      gridMenu: {
-        iconCssClass: 'fa fa-ellipsis-v',
+      enableCheckboxSelector: true,
+      enableRowSelection: true,
+      rowSelectionOptions: {
+        // True (Single Selection), False (Multiple Selections)
+        selectActiveRow: false
       },
+      dataView: {
+        syncGridSelection: true, // enable this flag so that the row selection follows the row even if we move it to another position
+      },
+      enableRowMoveManager: true,
       rowMoveManager: {
+        // when using Row Move + Row Selection, you want to enable the following 2 flags so it doesn't cancel row selection
+        singleRowMove: true,
+        disableRowSelection: true,
+        cancelEditOnDrag: true,
         onBeforeMoveRows: (e, args) => this.onBeforeMoveRow(e, args),
         onMoveRows: (e, args) => this.onMoveRows(e, args),
+
+        // you can also override the usability of the rows, for example make every 2nd row the only moveable rows,
+        // usabilityOverride: (row, dataContext, grid) => dataContext.id % 2 === 1
       },
       enableTranslate: true,
       i18n: this.i18n
@@ -104,15 +117,11 @@ export class Example16 {
 
   onMoveRows(e, args) {
     const extractedRows = [];
-    let left;
-    let right;
     const rows = args.rows;
     const insertBefore = args.insertBefore;
-    left = this.dataset.slice(0, insertBefore);
-    right = this.dataset.slice(insertBefore, this.dataset.length);
-    rows.sort((a, b) => {
-      return a - b;
-    });
+    const left = this.dataset.slice(0, insertBefore);
+    const right = this.dataset.slice(insertBefore, this.dataset.length);
+    rows.sort((a, b) => a - b);
     for (let i = 0; i < rows.length; i++) {
       extractedRows.push(this.dataset[rows[i]]);
     }
@@ -125,14 +134,13 @@ export class Example16 {
         right.splice(row - insertBefore, 1);
       }
     }
-    this.dataset = left.concat(extractedRows.concat(right));
+    const tmpDataset = left.concat(extractedRows.concat(right));
     const selectedRows = [];
     for (let i = 0; i < rows.length; i++) {
       selectedRows.push(left.length + i);
     }
+
     this.aureliaGrid.slickGrid.resetActiveCell();
-    this.aureliaGrid.slickGrid.setData(this.dataset);
-    this.aureliaGrid.slickGrid.setSelectedRows(selectedRows);
-    this.aureliaGrid.slickGrid.render();
+    this.dataset = tmpDataset;
   }
 }

--- a/src/examples/slickgrid/example16.ts
+++ b/src/examples/slickgrid/example16.ts
@@ -11,12 +11,14 @@ export class Example16 {
       <li>Click to select, Ctrl+Click to toggle selection, Shift+Click to select a range.</li>
       <li>Drag one or more rows by the handle (icon) to reorder</li>
       <li>If you plan to use Row Selection + Row Move, then use "singleRowMove: true" and "disableRowSelection: true"</li>
+      <li>You can change "columnIndexPosition" to move the icon position of any extension (RowMove, RowDetail or RowSelector icon)</li>
       <ul>
         <li>You will also want to enable the DataView "syncGridSelection: true" to keep row selection even after a row move</li>
       </ul>
       <li>If you plan to use only Row Move, then you could keep default values (or omit them completely) of "singleRowMove: false" and "disableRowSelection: false"</li>
       <ul>
         <li>SingleRowMove has the name suggest will only move 1 row at a time, by default it will move any row(s) that are selected unless you disable the flag</li>
+      </ul>
     </ul>
   `;
 
@@ -78,6 +80,11 @@ export class Example16 {
         cancelEditOnDrag: true,
         onBeforeMoveRows: (e, args) => this.onBeforeMoveRow(e, args),
         onMoveRows: (e, args) => this.onMoveRows(e, args),
+
+        // you can change the move icon position of any extension (RowMove, RowDetail or RowSelector icon)
+        // note that you might have to play with the position when using multiple extension
+        // since it really depends on which extension get created first to know what their real position are
+        columnIndexPosition: 1,
 
         // you can also override the usability of the rows, for example make every 2nd row the only moveable rows,
         // usabilityOverride: (row, dataContext, grid) => dataContext.id % 2 === 1

--- a/src/examples/slickgrid/example16.ts
+++ b/src/examples/slickgrid/example16.ts
@@ -84,7 +84,7 @@ export class Example16 {
         // you can change the move icon position of any extension (RowMove, RowDetail or RowSelector icon)
         // note that you might have to play with the position when using multiple extension
         // since it really depends on which extension get created first to know what their real position are
-        columnIndexPosition: 1,
+        // columnIndexPosition: 1,
 
         // you can also override the usability of the rows, for example make every 2nd row the only moveable rows,
         // usabilityOverride: (row, dataContext, grid) => dataContext.id % 2 === 1

--- a/test/cypress/integration/example16.spec.js
+++ b/test/cypress/integration/example16.spec.js
@@ -1,0 +1,90 @@
+/// <reference types="Cypress" />
+
+describe('Example 16 - Row Move & Checkbox Selector Selector Plugins', () => {
+  const fullTitles = ['', '', 'Title', 'Duration', '% Complete', 'Start', 'Finish', 'Completed'];
+
+  beforeEach(() => {
+    // create a console.log spy for later use
+    cy.window().then((win) => {
+      cy.spy(win.console, "log");
+    });
+  });
+
+  it('should display Example title', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example16`);
+    cy.get('h2').should('contain', 'Example 16: Row Move & Checkbox Selector');
+  });
+
+
+  it('should have exact Column Titles in the grid', () => {
+    cy.get('#grid16')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(fullTitles[index]));
+  });
+
+  it('should drag opened Row Detail to another position in the grid', () => {
+    cy.get('[style="top:35px"] > .slick-cell.cell-reorder').as('moveIconTask1');
+    cy.get('[style="top:105px"] > .slick-cell.cell-reorder').as('moveIconTask3');
+
+    cy.get('@moveIconTask3').should('have.length', 1);
+
+    cy.get('@moveIconTask3')
+      .trigger('mousedown', { button: 0, force: true })
+      .trigger('mousemove', 'bottomRight');
+
+    cy.get('@moveIconTask1')
+      .trigger('mousemove', 'bottomRight')
+      .trigger('mouseup', 'bottomRight', { force: true });
+
+    cy.get('input[type="checkbox"]:checked')
+      .should('have.length', 0);
+  });
+
+  it('should expect row to be moved to another row index', () => {
+    cy.get('.slick-viewport-top.slick-viewport-left')
+      .scrollTo('top');
+
+    cy.get('[style="top:0px"] > .slick-cell:nth(2)').should('contain', 'Task 0');
+    cy.get('[style="top:35px"] > .slick-cell:nth(2)').should('contain', 'Task 1');
+    cy.get('[style="top:70px"] > .slick-cell:nth(2)').should('contain', 'Task 3');
+    cy.get('[style="top:105px"] > .slick-cell:nth(2)').should('contain', 'Task 2');
+    cy.get('[style="top:140px"] > .slick-cell:nth(2)').should('contain', 'Task 4');
+
+    cy.get('input[type="checkbox"]:checked')
+      .should('have.length', 0);
+  });
+
+  it('should select 2 rows (Task 3,4), then move row and expect the 2 rows to still be selected without any others', () => {
+    cy.get('[style="top:70px"] > .slick-cell:nth(1)').click();
+    cy.get('[style="top:140px"] > .slick-cell:nth(1)').click();
+
+    cy.get('[style="top:70px"] > .slick-cell.cell-reorder').as('moveIconTask3');
+    cy.get('[style="top:175px"] > .slick-cell.cell-reorder').as('moveIconTask5');
+
+    cy.get('@moveIconTask3').should('have.length', 1);
+
+    cy.get('@moveIconTask3')
+      .trigger('mousedown', { button: 0, force: true })
+      .trigger('mousemove', 'bottomRight');
+
+    cy.get('@moveIconTask5')
+      .trigger('mousemove', 'bottomRight')
+      .trigger('mouseup', 'bottomRight', { force: true });
+
+    cy.get('.slick-viewport-top.slick-viewport-left')
+      .scrollTo('top');
+
+    cy.get('[style="top:0px"] > .slick-cell:nth(2)').should('contain', 'Task 0');
+    cy.get('[style="top:35px"] > .slick-cell:nth(2)').should('contain', 'Task 1');
+    cy.get('[style="top:70px"] > .slick-cell:nth(2)').should('contain', 'Task 2');
+    cy.get('[style="top:105px"] > .slick-cell:nth(2)').should('contain', 'Task 4');
+    cy.get('[style="top:140px"] > .slick-cell:nth(2)').should('contain', 'Task 5');
+    cy.get('[style="top:175px"] > .slick-cell:nth(2)').should('contain', 'Task 3');
+
+    // Task 4 and 3 should be selected
+    cy.get('input[type="checkbox"]:checked').should('have.length', 2);
+    cy.get('[style="top:105px"] > .slick-cell:nth(1) input[type="checkbox"]:checked').should('have.length', 1);
+    cy.get('[style="top:175px"] > .slick-cell:nth(1) input[type="checkbox"]:checked').should('have.length', 1);
+  });
+});

--- a/test/cypress/package.json
+++ b/test/cypress/package.json
@@ -11,7 +11,7 @@
   "author": "Ghislain B.",
   "license": "MIT",
   "devDependencies": {
-    "cypress": "^4.2.0",
+    "cypress": "^4.3.0",
     "mocha": "^5.2.0",
     "mochawesome": "^3.1.2",
     "mochawesome-merge": "^1.0.7",


### PR DESCRIPTION
- now create column definition just by the enableRowMoveManager flag
- also keep row selection with dataview syncGridSelection
- latest slickgrid version also brought the usabilityOverride callback method that was added in RowMoveManager plugin