### PR TITLE
fix(gridMenu): the command "Toggle Filter Row" disappeared

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -280,6 +280,7 @@ export class AureliaSlickgridCustomElement {
     // if that is the case, we need to hide the headerRow ONLY AFTER all filters got created & dataView exist
     if (this._hideHeaderRowAfterPageLoad) {
       this.showHeaderRow(false);
+      this.sharedService.hideHeaderRowAfterPageLoad = this._hideHeaderRowAfterPageLoad;
     }
 
     // publish & dispatch certain events
@@ -508,6 +509,11 @@ export class AureliaSlickgridCustomElement {
     this.subscriptions.push(
       this.globalEa.subscribe('i18n:locale:changed', () => {
         if (gridOptions.enableTranslate) {
+          if (!this._hideHeaderRowAfterPageLoad) {
+            // before translating, make sure the filter row is visible to avoid having other problems,
+            // because if it's not shown prior to translating then the filters won't be recreated after translating
+            this.grid.setHeaderRowVisibility(true);
+          }
           this.extensionService.translateCellMenu();
           this.extensionService.translateColumnHeaders();
           this.extensionService.translateColumnPicker();

--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -757,6 +757,8 @@ export class AureliaSlickgridCustomElement {
     if (!options.enableFiltering && options.enablePagination && this._isLocalGrid) {
       options.enableFiltering = true;
       options.showHeaderRow = false;
+      this._hideHeaderRowAfterPageLoad = true;
+      this.sharedService.hideHeaderRowAfterPageLoad = true;
     }
 
     return options;

--- a/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
@@ -215,7 +215,7 @@ export class GridMenuExtension implements Extension {
     const backendApi = this.sharedService.gridOptions.backendServiceApi || null;
     const gridMenuCustomItems: Array<GridMenuItem | 'divider'> = [];
 
-    if (this.sharedService.gridOptions && (this.sharedService.gridOptions.enableFiltering && this.sharedService.gridOptions.showHeaderRow)) {
+    if (this.sharedService.gridOptions && (this.sharedService.gridOptions.enableFiltering && !this.sharedService.hideHeaderRowAfterPageLoad)) {
       // show grid menu: clear all filters
       if (this.sharedService.gridOptions && this.sharedService.gridOptions.gridMenu && !this.sharedService.gridOptions.gridMenu.hideClearAllFiltersCommand) {
         const commandName = 'clear-filter';

--- a/src/aurelia-slickgrid/services/__tests__/shared.service.spec.ts
+++ b/src/aurelia-slickgrid/services/__tests__/shared.service.spec.ts
@@ -208,4 +208,15 @@ describe('Shared Service', () => {
     expect(setSpy).toHaveBeenCalled();
     expect(columns).toEqual(mockColumns);
   });
+
+
+  it('should call "hideHeaderRowAfterPageLoad" GETTER and expect a boolean value to be returned', () => {
+    const flag = service.hideHeaderRowAfterPageLoad;
+    expect(flag).toEqual(false);
+  });
+
+  it('should call "hideHeaderRowAfterPageLoad" GETTER and SETTER expect same value to be returned', () => {
+    service.hideHeaderRowAfterPageLoad = true;
+    expect(service.hideHeaderRowAfterPageLoad).toEqual(true);
+  });
 });

--- a/src/aurelia-slickgrid/services/shared.service.ts
+++ b/src/aurelia-slickgrid/services/shared.service.ts
@@ -9,6 +9,7 @@ export class SharedService {
   private _groupItemMetadataProvider: any;
   private _grid: any;
   private _gridOptions: GridOption;
+  private _hideHeaderRowAfterPageLoad = false;
   private _visibleColumns: Column[];
 
   // --
@@ -73,6 +74,15 @@ export class SharedService {
   /** Setter for the Grid Options */
   set groupItemMetadataProvider(groupItemMetadataProvider: any) {
     this._groupItemMetadataProvider = groupItemMetadataProvider;
+  }
+
+  /** Getter to know if user want to hide header row after 1st page load */
+  get hideHeaderRowAfterPageLoad(): boolean {
+    return this._hideHeaderRowAfterPageLoad;
+  }
+  /** Setter for knowing if user want to hide header row after 1st page load */
+  set hideHeaderRowAfterPageLoad(hideHeaderRowAfterPageLoad: boolean) {
+    this._hideHeaderRowAfterPageLoad = hideHeaderRowAfterPageLoad;
   }
 
   /** Getter for the Visible Columns in the grid */


### PR DESCRIPTION
- this command "Toggle Filter Row" disappeared if it happens to have the filter row hidden when calling translate. This PR fixes it but while fixing this, it was also found that the Filter row MUST be visible BEFORE calling the translation service else the filters don't get recreated and that is even worst.

The Filters MUST be shown BEFORE calling the translation (the lib will do show the header row by itself internally to counter this issue). If we aren't showing the Filters prior to a language change, this is what happens, filters aren't re-created
![image](https://user-images.githubusercontent.com/643976/81196115-a08cd900-8f8c-11ea-9f42-9e2991476b69.png)


So the fix is to show the Filter row anytime the translation service is called (when switch language) as shown below. We show the header row then we translate
![UG82RuSKHr](https://user-images.githubusercontent.com/643976/81196296-dd58d000-8f8c-11ea-94b2-a29f9e4e0427.gif)
