### PR TITLE
fix(rowDetail): use latest SlickGrid version to fix issue with id

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "jquery-ui-dist": "^1.12.1",
     "lodash.isequal": "^4.5.0",
     "moment-mini": "^2.24.0",
-    "slickgrid": "2.4.20",
+    "slickgrid": "2.4.22",
     "text-encoding-utf-8": "^1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "jquery-ui-dist": "^1.12.1",
     "lodash.isequal": "^4.5.0",
     "moment-mini": "^2.24.0",
-    "slickgrid": "2.4.22",
+    "slickgrid": "^2.4.22",
     "text-encoding-utf-8": "^1.0.2"
   },
   "devDependencies": {

--- a/src/aurelia-slickgrid/global-grid-options.ts
+++ b/src/aurelia-slickgrid/global-grid-options.ts
@@ -163,13 +163,13 @@ export const GlobalGridOptions: Partial<GridOption> = {
     pageSize: 25,
     totalItems: 0
   },
-  // @ts-ignore
   // technically speaking the Row Detail requires the process & viewComponent but we'll ignore it just to set certain options
+  // @ts-ignore
   rowDetailView: {
     cssClass: 'detail-view-toggle',
     panelRows: 1,
     keyPrefix: '__',
-    useRowClick: true,
+    useRowClick: false,
     useSimpleViewportCalc: true,
     saveDetailViewOnScroll: false,
     viewModel: '',


### PR DESCRIPTION
- there was a small issue in core lib when using "datasetIdPropertyName" other than "id" so update to latest SlickGrid version which has the fix
- change default grid options of Row Detail "useRowClick" property to false