### PR TITLE
fix(export): remove unsupported file type

### DIFF
--- a/src/aurelia-slickgrid/models/fileType.enum.ts
+++ b/src/aurelia-slickgrid/models/fileType.enum.ts
@@ -1,8 +1,5 @@
 export enum FileType {
   csv = 'csv',
-  doc = 'doc',
-  docx = 'docx',
-  pdf = 'pdf',
   txt = 'txt',
   xls = 'xls',
   xlsx = 'xlsx'


### PR DESCRIPTION
- PDF and DOC are unsupported file type since there are no Exporter Services that exist for them, so they should be removed from acceptable file type formats