### PR TITLE
fix(pagination): passing custom pagination sizes should work

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -740,10 +740,8 @@ export class AureliaSlickgridCustomElement {
     // using jQuery extend to do a deep clone has an unwanted side on objects and pageSizes but ES6 spread has other worst side effects
     // so we will just overwrite the pageSizes when needed, this is the only one causing issues so far.
     // jQuery wrote this on their docs:: On a deep extend, Object and Array are extended, but object wrappers on primitive types such as String, Boolean, and Number are not.
-    if (options && gridOptions && gridOptions.backendServiceApi) {
-      if (options.pagination && gridOptions.pagination && Array.isArray(gridOptions.pagination.pageSizes) && gridOptions.pagination.pageSizes.length > 0) {
-        options.pagination.pageSizes = gridOptions.pagination.pageSizes;
-      }
+    if (gridOptions.enablePagination && gridOptions.pagination && Array.isArray(gridOptions.pagination.pageSizes)) {
+      options.pagination.pageSizes = gridOptions.pagination.pageSizes;
     }
 
     // also make sure to show the header row if user have enabled filtering

--- a/src/examples/slickgrid/example1.ts
+++ b/src/examples/slickgrid/example1.ts
@@ -47,7 +47,7 @@ export class Example1 {
       ...{
         enablePagination: true,
         pagination: {
-          pageSizes: [5, 10, 15, 20, 25, 50, 75, 100],
+          pageSizes: [5, 10, 20, 25, 50],
           pageSize: 5
         },
       }


### PR DESCRIPTION
- ref, this bug was mentioned in this Stack Overflow [question](https://stackoverflow.com/questions/61750596/angular-slickgrid-paginators-item-per-page-is-not-displayed-according-to-config) 