### PR TITLE
fix(styling): cell/context menus get re-position below the grid

### DIFF
--- a/src/aurelia-slickgrid/styles/slick-plugins.scss
+++ b/src/aurelia-slickgrid/styles/slick-plugins.scss
@@ -19,6 +19,13 @@
   overflow: auto;
   resize: both;
 
+  /* make sure that other UI frameworks aren't overriding our properties (Bulma was one of them affecting this) */
+  &.dropdown,
+  &.dropup {
+    display: inline-block;
+    position: absolute;
+  }
+
   > .close {
     float: right;
     cursor: pointer;
@@ -129,6 +136,13 @@
   display: inline-block;
   overflow: auto;
   resize: both;
+
+  /* make sure that other UI frameworks aren't overriding our properties (Bulma was one of them affecting this) */
+  &.dropdown,
+  &.dropup {
+    display: inline-block;
+    position: absolute;
+  }
 
   > .close {
     float: right;


### PR DESCRIPTION
- not an issue with Bootstrap but other frameworks like Bulma had this issue which it was overriding the SlickGrid cell-menu/context-menu styling because of these menus use generic css dropdown/dropup classes