### PR TITLE
refactor(core): rename DataView interface to SlickDataView

### DIFF
--- a/src/aurelia-slickgrid/models/index.ts
+++ b/src/aurelia-slickgrid/models/index.ts
@@ -29,7 +29,7 @@ export * from './currentPagination.interface';
 export * from './currentRowSelection.interface';
 export * from './currentSorter.interface';
 export * from './customFooterOption.interface';
-export * from './dataView.interface';
+export * from './slickDataView.interface';
 export * from './delimiterType.enum';
 export * from './draggableGrouping.interface';
 export * from './editCommand.interface';

--- a/src/aurelia-slickgrid/models/pagingInfo.interface.ts
+++ b/src/aurelia-slickgrid/models/pagingInfo.interface.ts
@@ -1,9 +1,9 @@
-import { DataView } from './dataView.interface';
+import { SlickDataView } from './slickDataView.interface';
 
 export interface PagingInfo {
   pageSize: number;
   pageNum: number;
   totalRows?: number;
   totalPages?: number;
-  dataView?: DataView;
+  dataView?: SlickDataView;
 }

--- a/src/aurelia-slickgrid/models/slickDataView.interface.ts
+++ b/src/aurelia-slickgrid/models/slickDataView.interface.ts
@@ -3,7 +3,7 @@ import { PagingInfo } from './pagingInfo.interface';
 import { SlickEvent } from './slickEvent.interface';
 import { SlickGrid } from './slickGrid.interface';
 
-export interface DataView {
+export interface SlickDataView {
   // --
   // Available Methods
 


### PR DESCRIPTION
- to easily identify the interfaces of SlickGrid components and classes, we'll name them all with the Slick prefix (SlickGrid, SlickDataView, SlickGridMenu, ...)