### PR TITLE
refactor(core): rename DataView interface to SlickDataView

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -21,7 +21,7 @@ import {
   BackendServiceOption,
   Column,
   CustomFooterOption,
-  DataView,
+  SlickDataView,
   ExtensionName,
   GraphqlResult,
   GraphqlPaginatedResult,
@@ -115,7 +115,7 @@ export class AureliaSlickgridCustomElement {
 
   @bindable({ defaultBindingMode: bindingMode.twoWay }) columnDefinitions: Column[] = [];
   @bindable({ defaultBindingMode: bindingMode.twoWay }) element: Element;
-  @bindable({ defaultBindingMode: bindingMode.twoWay }) dataview: DataView;
+  @bindable({ defaultBindingMode: bindingMode.twoWay }) dataview: SlickDataView;
   @bindable({ defaultBindingMode: bindingMode.twoWay }) grid: SlickGrid;
   @bindable({ defaultBindingMode: bindingMode.twoWay }) paginationOptions: Pagination | undefined;
   @bindable({ defaultBindingMode: bindingMode.twoWay }) totalItems: number;
@@ -509,7 +509,7 @@ export class AureliaSlickgridCustomElement {
     }
   }
 
-  bindDifferentHooks(grid: SlickGrid, gridOptions: GridOption, dataView: DataView) {
+  bindDifferentHooks(grid: SlickGrid, gridOptions: GridOption, dataView: SlickDataView) {
     // translate some of them on first load, then on each language change
     if (gridOptions.enableTranslate) {
       this.translateColumnHeaderTitleKeys();
@@ -743,7 +743,7 @@ export class AureliaSlickgridCustomElement {
     }
   }
 
-  executeAfterDataviewCreated(grid: SlickGrid, gridOptions: GridOption, dataView: DataView) {
+  executeAfterDataviewCreated(grid: SlickGrid, gridOptions: GridOption, dataView: SlickDataView) {
     // if user entered some Sort "presets", we need to reflect them all in the DOM
     if (gridOptions.enableSorting) {
       if (gridOptions.presets && Array.isArray(gridOptions.presets.sorters) && gridOptions.presets.sorters.length > 0) {

--- a/src/aurelia-slickgrid/models/aureliaGridInstance.interface.ts
+++ b/src/aurelia-slickgrid/models/aureliaGridInstance.interface.ts
@@ -1,4 +1,4 @@
-import { BackendService, DataView, SlickGrid } from './index';
+import { BackendService, SlickDataView, SlickGrid } from './index';
 import {
   ExcelExportService,
   ExportService,
@@ -16,7 +16,7 @@ import {
 
 export interface AureliaGridInstance {
   /** Slick DataView object */
-  dataView: DataView;
+  dataView: SlickDataView;
 
   /** Slick Grid object */
   slickGrid: SlickGrid;

--- a/src/aurelia-slickgrid/models/editorArguments.interface.ts
+++ b/src/aurelia-slickgrid/models/editorArguments.interface.ts
@@ -1,10 +1,10 @@
-import { Column, DataView, ElementPosition, SlickGrid } from './index';
+import { Column, SlickDataView, ElementPosition, SlickGrid } from './index';
 
 export interface EditorArguments {
   column: Column;
   columnMetaData: any;
   container: HTMLDivElement;
-  dataView: DataView;
+  dataView: SlickDataView;
   event: Event;
   grid: SlickGrid;
   gridPosition: ElementPosition;

--- a/src/aurelia-slickgrid/models/index.ts
+++ b/src/aurelia-slickgrid/models/index.ts
@@ -29,7 +29,7 @@ export * from './currentPagination.interface';
 export * from './currentRowSelection.interface';
 export * from './currentSorter.interface';
 export * from './customFooterOption.interface';
-export * from './dataView.interface';
+export * from './slickDataView.interface';
 export * from './delimiterType.enum';
 export * from './draggableGrouping.interface';
 export * from './editCommand.interface';

--- a/src/aurelia-slickgrid/models/onEventArgs.interface.ts
+++ b/src/aurelia-slickgrid/models/onEventArgs.interface.ts
@@ -1,5 +1,5 @@
 import { Column } from './column.interface';
-import { DataView } from './dataView.interface';
+import { SlickDataView } from './slickDataView.interface';
 import { SlickGrid } from './slickGrid.interface';
 
 export interface OnEventArgs {
@@ -7,6 +7,6 @@ export interface OnEventArgs {
   cell: number;
   columnDef: Column;
   dataContext: any;
-  dataView: DataView;
+  dataView: SlickDataView;
   grid: SlickGrid;
 }

--- a/src/aurelia-slickgrid/models/pagingInfo.interface.ts
+++ b/src/aurelia-slickgrid/models/pagingInfo.interface.ts
@@ -1,9 +1,9 @@
-import { DataView } from './dataView.interface';
+import { SlickDataView } from './slickDataView.interface';
 
 export interface PagingInfo {
   pageSize: number;
   pageNum: number;
   totalRows?: number;
   totalPages?: number;
-  dataView?: DataView;
+  dataView?: SlickDataView;
 }

--- a/src/aurelia-slickgrid/models/slickDataView.interface.ts
+++ b/src/aurelia-slickgrid/models/slickDataView.interface.ts
@@ -3,7 +3,7 @@ import { PagingInfo } from './pagingInfo.interface';
 import { SlickEvent } from './slickEvent.interface';
 import { SlickGrid } from './slickGrid.interface';
 
-export interface DataView {
+export interface SlickDataView {
   // --
   // Available Methods
 

--- a/src/aurelia-slickgrid/models/viewModelBindableData.interface.ts
+++ b/src/aurelia-slickgrid/models/viewModelBindableData.interface.ts
@@ -1,4 +1,4 @@
-import { DataView } from './dataView.interface';
+import { SlickDataView } from './slickDataView.interface';
 import { SlickGrid } from './slickGrid.interface';
 
 export interface ViewModelBindableData {
@@ -6,6 +6,6 @@ export interface ViewModelBindableData {
   model: any;
   addon: any;
   grid: SlickGrid;
-  dataView: DataView;
+  dataView: SlickDataView;
   parent?: any;
 }

--- a/src/aurelia-slickgrid/models/viewModelBindableInputData.interface.ts
+++ b/src/aurelia-slickgrid/models/viewModelBindableInputData.interface.ts
@@ -1,10 +1,10 @@
-import { DataView } from './dataView.interface';
+import { SlickDataView } from './slickDataView.interface';
 import { SlickGrid } from './slickGrid.interface';
 
 export interface ViewModelBindableInputData {
   model: any;
   addon: any;
   grid: SlickGrid;
-  dataView: DataView;
+  dataView: SlickDataView;
   parent?: any;
 }

--- a/src/aurelia-slickgrid/services/excelExport.service.ts
+++ b/src/aurelia-slickgrid/services/excelExport.service.ts
@@ -8,7 +8,7 @@ import * as moment from 'moment-mini';
 
 import {
   Column,
-  DataView,
+  SlickDataView,
   ExcelCellFormat,
   ExcelExportOption,
   ExcelMetadata,
@@ -34,7 +34,7 @@ const DEFAULT_AURELIA_EVENT_PREFIX = 'asg';
 export class ExcelExportService {
   private _aureliaEventPrefix: string;
   private _fileFormat = FileType.xlsx;
-  private _dataView: DataView;
+  private _dataView: SlickDataView;
   private _grid: SlickGrid;
   private _locales: Locale;
   private _columnHeaders: Array<KeyTitlePair>;
@@ -62,7 +62,7 @@ export class ExcelExportService {
    * @param grid
    * @param dataView
    */
-  init(grid: SlickGrid, dataView: DataView): void {
+  init(grid: SlickGrid, dataView: SlickDataView): void {
     this._grid = grid;
     this._dataView = dataView;
     this._aureliaEventPrefix = (this._gridOptions && this._gridOptions.defaultAureliaEventPrefix) ? this._gridOptions.defaultAureliaEventPrefix : DEFAULT_AURELIA_EVENT_PREFIX;

--- a/src/aurelia-slickgrid/services/export.service.ts
+++ b/src/aurelia-slickgrid/services/export.service.ts
@@ -8,7 +8,7 @@ import { Constants } from './../constants';
 import { exportWithFormatterWhenDefined } from './export-utilities';
 import {
   Column,
-  DataView,
+  SlickDataView,
   ExportOption,
   FileType,
   GridOption,
@@ -30,7 +30,7 @@ export class ExportService {
   private _exportOptions: ExportOption;
   private _fileFormat = FileType.csv;
   private _lineCarriageReturn = '\n';
-  private _dataView: DataView;
+  private _dataView: SlickDataView;
   private _grid: SlickGrid;
   private _columnHeaders: KeyTitlePair[];
   private _groupedColumnHeaders: KeyTitlePair[];
@@ -53,7 +53,7 @@ export class ExportService {
    * @param grid
    * @param dataView
    */
-  init(grid: SlickGrid, dataView: DataView): void {
+  init(grid: SlickGrid, dataView: SlickDataView): void {
     this._grid = grid;
     this._dataView = dataView;
     this._aureliaEventPrefix = (this._gridOptions && this._gridOptions.defaultAureliaEventPrefix) ? this._gridOptions.defaultAureliaEventPrefix : DEFAULT_AURELIA_EVENT_PREFIX;

--- a/src/aurelia-slickgrid/services/filter.service.ts
+++ b/src/aurelia-slickgrid/services/filter.service.ts
@@ -9,7 +9,7 @@ import {
   ColumnFilter,
   ColumnFilters,
   CurrentFilter,
-  DataView,
+  SlickDataView,
   EmitterType,
   FieldType,
   Filter,
@@ -46,7 +46,7 @@ export class FilterService {
   private _firstColumnIdRendered = '';
   private _filtersMetadata: any[] = [];
   private _columnFilters: ColumnFilters = {};
-  private _dataView: DataView;
+  private _dataView: SlickDataView;
   private _grid: SlickGrid;
   private _onSearchChange: SlickEvent;
   private _tmpPreFilteredData: number[];
@@ -144,7 +144,7 @@ export class FilterService {
    * Bind a backend filter hook to the grid
    * @param grid SlickGrid Grid object
    */
-  bindBackendOnFilter(grid: SlickGrid, dataView: DataView) {
+  bindBackendOnFilter(grid: SlickGrid, dataView: SlickDataView) {
     this._dataView = dataView;
     this._filtersMetadata = [];
 
@@ -171,7 +171,7 @@ export class FilterService {
    * @param gridOptions Grid Options object
    * @param dataView
    */
-  bindLocalOnFilter(grid: SlickGrid, dataView: DataView) {
+  bindLocalOnFilter(grid: SlickGrid, dataView: SlickDataView) {
     this._filtersMetadata = [];
     this._dataView = dataView;
 
@@ -329,7 +329,7 @@ export class FilterService {
     return true;
   }
 
-  getFilterConditionOptionsOrBoolean(item: any, columnFilter: ColumnFilter, columnId: string | number, grid: SlickGrid, dataView: DataView): FilterConditionOption | boolean {
+  getFilterConditionOptionsOrBoolean(item: any, columnFilter: ColumnFilter, columnId: string | number, grid: SlickGrid, dataView: SlickDataView): FilterConditionOption | boolean {
     let columnIndex = grid.getColumnIndex(columnId) as number;
     let columnDef = grid.getColumns()[columnIndex] as Column;
 

--- a/src/aurelia-slickgrid/services/grid.service.ts
+++ b/src/aurelia-slickgrid/services/grid.service.ts
@@ -4,7 +4,7 @@ import { EventAggregator } from 'aurelia-event-aggregator';
 import {
   CellArgs,
   Column,
-  DataView,
+  SlickDataView,
   GridOption,
   GridServiceDeleteOption,
   GridServiceInsertOption,
@@ -32,7 +32,7 @@ const GridServiceUpdateOptionDefaults: GridServiceUpdateOption = { highlightRow:
 @inject(EventAggregator, SlickgridEventAggregator, ExtensionService, FilterService, GridStateService, SharedService, SortService)
 export class GridService {
   private _aureliaEventPrefix = DEFAULT_AURELIA_EVENT_PREFIX;
-  private _dataView: DataView;
+  private _dataView: SlickDataView;
   private _grid: SlickGrid;
 
   constructor(
@@ -55,7 +55,7 @@ export class GridService {
    * @param grid
    * @param dataView
    */
-  init(grid: SlickGrid, dataView: DataView): void {
+  init(grid: SlickGrid, dataView: SlickDataView): void {
     this._grid = grid;
     this._dataView = dataView;
     this._aureliaEventPrefix = (this._gridOptions && this._gridOptions.defaultAureliaEventPrefix) ? this._gridOptions.defaultAureliaEventPrefix : DEFAULT_AURELIA_EVENT_PREFIX;

--- a/src/aurelia-slickgrid/services/gridEvent.service.ts
+++ b/src/aurelia-slickgrid/services/gridEvent.service.ts
@@ -1,5 +1,5 @@
 import { singleton } from 'aurelia-framework';
-import { CellArgs, Column, DataView, GridOption, OnEventArgs, SlickEventHandler, SlickGrid } from './../models/index';
+import { CellArgs, Column, SlickDataView, GridOption, OnEventArgs, SlickEventHandler, SlickGrid } from './../models/index';
 
 // using external non-typed js libraries
 declare const Slick: any;
@@ -17,7 +17,7 @@ export class GridEventService {
   }
 
   /* OnCellChange Event */
-  bindOnCellChange(grid: SlickGrid, dataView: DataView) {
+  bindOnCellChange(grid: SlickGrid, dataView: SlickDataView) {
     // subscribe to this Slickgrid event of onCellChange
     this._eventHandler.subscribe(grid.onCellChange, (e: KeyboardEvent | MouseEvent, args: CellArgs) => {
       if (!e || !args || !grid || args.cell === undefined || !grid.getColumns || !grid.getDataItem) {
@@ -44,7 +44,7 @@ export class GridEventService {
   }
 
   /* OnClick Event */
-  bindOnClick(grid: SlickGrid, dataView: DataView) {
+  bindOnClick(grid: SlickGrid, dataView: SlickDataView) {
     this._eventHandler.subscribe(grid.onClick, (e: KeyboardEvent | MouseEvent, args: CellArgs) => {
       if (!e || !args || !grid || args.cell === undefined || !grid.getColumns || !grid.getDataItem) {
         return;

--- a/src/aurelia-slickgrid/services/gridState.service.ts
+++ b/src/aurelia-slickgrid/services/gridState.service.ts
@@ -9,7 +9,7 @@ import {
   CurrentPagination,
   CurrentRowSelection,
   CurrentSorter,
-  DataView,
+  SlickDataView,
   ExtensionName,
   GridOption,
   GridState,
@@ -32,7 +32,7 @@ export class GridStateService {
   private _eventHandler = new Slick.EventHandler();
   private _columns: Column[] = [];
   private _currentColumns: CurrentColumn[] = [];
-  private _dataView: DataView;
+  private _dataView: SlickDataView;
   private _grid: SlickGrid;
   private _subscriptions: Subscription[] = [];
   private _selectedRowDataContextIds: Array<number | string> | undefined = []; // used with row selection
@@ -73,7 +73,7 @@ export class GridStateService {
    * Initialize the Service
    * @param grid
    */
-  init(grid: SlickGrid, dataView: DataView): void {
+  init(grid: SlickGrid, dataView: SlickDataView): void {
     this._grid = grid;
     this._dataView = dataView;
     this.subscribeToAllGridChanges(grid);

--- a/src/aurelia-slickgrid/services/groupingAndColspan.service.ts
+++ b/src/aurelia-slickgrid/services/groupingAndColspan.service.ts
@@ -3,7 +3,7 @@ import * as $ from 'jquery';
 
 import {
   Column,
-  DataView,
+  SlickDataView,
   GridOption,
   SlickEventHandler,
   SlickGrid,
@@ -45,7 +45,7 @@ export class GroupingAndColspanService {
    * @param grid
    * @param dataView
    */
-  init(grid: SlickGrid, dataView: DataView) {
+  init(grid: SlickGrid, dataView: SlickDataView) {
     this._grid = grid;
     this._aureliaEventPrefix = (this._gridOptions && this._gridOptions.defaultAureliaEventPrefix) ? this._gridOptions.defaultAureliaEventPrefix : 'asg';
 

--- a/src/aurelia-slickgrid/services/pagination.service.ts
+++ b/src/aurelia-slickgrid/services/pagination.service.ts
@@ -2,7 +2,7 @@ import { inject, singleton } from 'aurelia-framework';
 import { Subscription } from 'aurelia-event-aggregator';
 import * as isequal from 'lodash.isequal';
 
-import { BackendServiceApi, CurrentPagination, DataView, GraphqlResult, GraphqlPaginatedResult, Pagination, ServicePagination, SlickGrid } from '../models/index';
+import { BackendServiceApi, CurrentPagination, SlickDataView, GraphqlResult, GraphqlPaginatedResult, Pagination, ServicePagination, SlickGrid } from '../models/index';
 import { executeBackendProcessesCallback, onBackendError } from './backend-utilities';
 import { SharedService } from './shared.service';
 import { disposeAllSubscriptions } from './utilities';
@@ -28,7 +28,7 @@ export class PaginationService {
   private _paginationOptions: Pagination;
   private _subscriptions: Subscription[] = [];
 
-  dataView: DataView;
+  dataView: SlickDataView;
   grid: SlickGrid;
 
   /** Constructor */
@@ -77,7 +77,7 @@ export class PaginationService {
     }
   }
 
-  init(grid: SlickGrid, dataView: DataView, paginationOptions: Pagination, backendServiceApi?: BackendServiceApi) {
+  init(grid: SlickGrid, dataView: SlickDataView, paginationOptions: Pagination, backendServiceApi?: BackendServiceApi) {
     this._availablePageSizes = paginationOptions.pageSizes;
     this.dataView = dataView;
     this.grid = grid;

--- a/src/aurelia-slickgrid/services/shared.service.ts
+++ b/src/aurelia-slickgrid/services/shared.service.ts
@@ -1,11 +1,11 @@
 import { singleton } from 'aurelia-framework';
-import { Column, CurrentPagination, DataView, GridOption, SlickGrid } from '../models/index';
+import { Column, CurrentPagination, SlickDataView, GridOption, SlickGrid } from '../models/index';
 
 @singleton(true)
 export class SharedService {
   private _allColumns: Column[];
   private _currentPagination: CurrentPagination | null;
-  private _dataView: DataView;
+  private _dataView: SlickDataView;
   private _groupItemMetadataProvider: any;
   private _grid: SlickGrid;
   private _gridOptions: GridOption;
@@ -41,11 +41,11 @@ export class SharedService {
   }
 
   /** Getter for SlickGrid DataView object */
-  get dataView(): DataView {
+  get dataView(): SlickDataView {
     return this._dataView;
   }
   /** Setter for SlickGrid DataView object */
-  set dataView(dataView: DataView) {
+  set dataView(dataView: SlickDataView) {
     this._dataView = dataView;
   }
 

--- a/src/aurelia-slickgrid/services/sort.service.ts
+++ b/src/aurelia-slickgrid/services/sort.service.ts
@@ -3,7 +3,7 @@ import { inject, singleton } from 'aurelia-framework';
 import {
   Column,
   ColumnSort,
-  DataView,
+  SlickDataView,
   EmitterType,
   FieldType,
   GridOption,
@@ -29,7 +29,7 @@ declare const Slick: any;
 export class SortService {
   private _currentLocalSorters: CurrentSorter[] = [];
   private _eventHandler: SlickEventHandler;
-  private _dataView: DataView;
+  private _dataView: SlickDataView;
   private _grid: SlickGrid;
   private _isBackendGrid = false;
 
@@ -57,7 +57,7 @@ export class SortService {
    * @param grid SlickGrid Grid object
    * @param dataView SlickGrid DataView object
    */
-  bindBackendOnSort(grid: SlickGrid, dataView: DataView) {
+  bindBackendOnSort(grid: SlickGrid, dataView: SlickDataView) {
     this._isBackendGrid = true;
     this._grid = grid;
     this._dataView = dataView;
@@ -72,7 +72,7 @@ export class SortService {
    * @param gridOptions Grid Options object
    * @param dataView
    */
-  bindLocalOnSort(grid: SlickGrid, dataView: DataView) {
+  bindLocalOnSort(grid: SlickGrid, dataView: SlickDataView) {
     this._isBackendGrid = false;
     this._grid = grid;
     this._dataView = dataView;
@@ -282,7 +282,7 @@ export class SortService {
   }
 
   /** When a Sort Changes on a Local grid (JSON dataset) */
-  onLocalSortChanged(grid: SlickGrid, dataView: DataView, sortColumns: ColumnSort[], forceReSort = false) {
+  onLocalSortChanged(grid: SlickGrid, dataView: SlickDataView, sortColumns: ColumnSort[], forceReSort = false) {
     const isTreeDataEnabled = this._gridOptions && this._gridOptions.enableTreeData || false;
 
     if (grid && dataView) {

--- a/src/examples/slickgrid/example11.ts
+++ b/src/examples/slickgrid/example11.ts
@@ -2,7 +2,7 @@ import { autoinject } from 'aurelia-framework';
 import {
   AureliaGridInstance,
   Column,
-  DataView,
+  SlickDataView,
   Editors,
   FieldType,
   Formatters,
@@ -38,7 +38,7 @@ export class Example11 {
   aureliaGrid: AureliaGridInstance;
   grid: SlickGrid;
   gridService: GridService;
-  dataView: DataView;
+  dataView: SlickDataView;
   columnDefinitions: Column[];
   gridOptions: GridOption;
   dataset: any[];

--- a/src/examples/slickgrid/example13.ts
+++ b/src/examples/slickgrid/example13.ts
@@ -3,7 +3,7 @@ import {
   Aggregators,
   AureliaGridInstance,
   Column,
-  DataView,
+  SlickDataView,
   DelimiterType,
   FieldType,
   FileType,
@@ -33,7 +33,7 @@ export class Example13 {
   columnDefinitions: Column[];
   gridOptions: GridOption;
   dataset: any[];
-  dataviewObj: DataView;
+  dataviewObj: SlickDataView;
   gridObj: SlickGrid;
   processing = false;
 

--- a/src/examples/slickgrid/example18.ts
+++ b/src/examples/slickgrid/example18.ts
@@ -3,7 +3,7 @@ import {
   Aggregators,
   AureliaGridInstance,
   Column,
-  DataView,
+  SlickDataView,
   DelimiterType,
   FieldType,
   FileType,
@@ -39,7 +39,7 @@ export class Example18 {
   aureliaGrid: AureliaGridInstance;
   columnDefinitions: Column[];
   dataset: any[];
-  dataviewObj: DataView;
+  dataviewObj: SlickDataView;
   draggableGroupingPlugin: any;
   durationOrderByCount = false;
   gridObj: SlickGrid;

--- a/src/examples/slickgrid/example19-detail-view.ts
+++ b/src/examples/slickgrid/example19-detail-view.ts
@@ -1,6 +1,6 @@
 import { bindable } from 'aurelia-framework';
 import { Example19 } from './example19';
-import { DataView, SlickGrid, ViewModelBindableData } from '../../aurelia-slickgrid';
+import { SlickDataView, SlickGrid, ViewModelBindableData } from '../../aurelia-slickgrid';
 
 export class DetailViewCustomElement {
   @bindable() model: {
@@ -17,7 +17,7 @@ export class DetailViewCustomElement {
   // you also have access to the following objects (it must match the exact property names shown below)
   addon: any; // row detail addon instance
   grid: SlickGrid;
-  dataView: DataView;
+  dataView: SlickDataView;
 
   // you can also optionally use the Parent Component reference
   // NOTE that you MUST provide it through the "parent" property in your "rowDetail" grid options

--- a/src/examples/slickgrid/example21.ts
+++ b/src/examples/slickgrid/example21.ts
@@ -2,7 +2,7 @@ import { bindable } from 'aurelia-framework';
 import {
   AureliaGridInstance,
   Column,
-  DataView,
+  SlickDataView,
   FieldType,
   FilterCallbackArg,
   Formatters,
@@ -28,7 +28,7 @@ export class Example21 {
 
   aureliaGrid: AureliaGridInstance;
   grid: SlickGrid;
-  dataView: DataView;
+  dataView: SlickDataView;
   columnDefinitions: Column[];
   gridOptions: GridOption;
   dataset: any[];

--- a/src/examples/slickgrid/example27.ts
+++ b/src/examples/slickgrid/example27.ts
@@ -2,7 +2,7 @@ import { autoinject } from 'aurelia-framework';
 import {
   AureliaGridInstance,
   Column,
-  DataView,
+  SlickDataView,
   FieldType,
   Filters,
   Formatters,
@@ -30,7 +30,7 @@ export class Example27 {
     </ul>
   </ul>`;
   aureliaGrid: AureliaGridInstance;
-  dataViewObj: DataView;
+  dataViewObj: SlickDataView;
   gridObj: SlickGrid;
   gridOptions: GridOption;
   columnDefinitions: Column[];

--- a/src/examples/slickgrid/example28.ts
+++ b/src/examples/slickgrid/example28.ts
@@ -2,7 +2,7 @@ import { autoinject, bindable } from 'aurelia-framework';
 import {
   AureliaGridInstance,
   Column,
-  DataView,
+  SlickDataView,
   FieldType,
   Filters,
   Formatters,
@@ -26,7 +26,7 @@ export class Example28 {
     </ul>
   `;
   aureliaGrid: AureliaGridInstance;
-  dataViewObj: DataView;
+  dataViewObj: SlickDataView;
   gridObj: SlickGrid;
   gridOptions: GridOption;
   columnDefinitions: Column[];

--- a/src/examples/slickgrid/example8.ts
+++ b/src/examples/slickgrid/example8.ts
@@ -1,6 +1,6 @@
 import { I18N } from 'aurelia-i18n';
 import { autoinject } from 'aurelia-framework';
-import { AureliaGridInstance, Column, DataView, Formatters, GridOption, SlickGrid } from '../../aurelia-slickgrid';
+import { AureliaGridInstance, Column, SlickDataView, Formatters, GridOption, SlickGrid } from '../../aurelia-slickgrid';
 import './example8.scss'; // provide custom CSS/SASS styling
 
 @autoinject()
@@ -30,7 +30,7 @@ export class Example8 {
   columnDefinitions: Column[];
   gridOptions: GridOption;
   dataset = [];
-  dataView: DataView;
+  dataView: SlickDataView;
   gridObj: SlickGrid;
   selectedLanguage: string;
   visibleColumns;

--- a/src/examples/slickgrid/example9.ts
+++ b/src/examples/slickgrid/example9.ts
@@ -3,7 +3,7 @@ import { autoinject } from 'aurelia-framework';
 import {
   AureliaGridInstance,
   Column,
-  DataView,
+  SlickDataView,
   ExtensionName,
   FieldType,
   Filters,
@@ -33,7 +33,7 @@ export class Example9 {
   columnDefinitions: Column[];
   gridOptions: GridOption;
   dataset = [];
-  dataView: DataView;
+  dataView: SlickDataView;
   gridObj: SlickGrid;
   selectedLanguage: string;
 


### PR DESCRIPTION
- to easily identify the interfaces of SlickGrid components and classes, we'll name them all with the Slick prefix (SlickGrid, SlickDataView, SlickGridMenu, ...)