### PR TITLE
fix(pagination): disabled page buttons should not be clickable

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/slick-pagination.html
+++ b/src/aurelia-slickgrid/custom-elements/slick-pagination.html
@@ -4,14 +4,14 @@
       <div class="slick-pagination-nav">
         <nav aria-label="Page navigation">
           <ul class="pagination">
-            <li class="page-item" class.bind="(pageNumber === 1 || totalItems === 0) ? 'disabled' : ''">
+            <li class="page-item" class.bind="isLeftPaginationDisabled ? 'disabled' : ''">
               <a class="page-link icon-seek-first fa fa-angle-double-left" href="" aria-label="First"
-                 click.delegate="changeToFirstPage($event)">
+                click.delegate="changeToFirstPage($event)">
               </a>
             </li>
-            <li class="page-item" class.bind="(pageNumber === 1 || totalItems === 0) ? 'disabled' : ''">
+            <li class="page-item" class.bind="isLeftPaginationDisabled ? 'disabled' : ''">
               <a class="page-link icon-seek-prev fa fa-angle-left" href="" aria-label="Previous"
-                 click.delegate="changeToPreviousPage($event)">
+                click.delegate="changeToPreviousPage($event)">
               </a>
             </li>
           </ul>
@@ -20,9 +20,9 @@
         <div class="slick-page-number">
           <span>${textPage}</span>
           <input type="text" class="form-control" data-test="page-number-input"
-                 value.bind="pageNumber | asgNumber" size="1"
-                 readonly.bind="totalItems === 0"
-                 change.delegate="changeToCurrentPage($event)">
+            value.bind="pageNumber | asgNumber" size="1"
+            readonly.bind="totalItems === 0"
+            change.delegate="changeToCurrentPage($event)">
           <span>${textOf}</span>
           <span data-test="page-count"> ${pageCount}</span>
         </div>
@@ -30,15 +30,15 @@
         <nav aria-label="Page navigation">
           <ul class="pagination">
             <li class="page-item"
-                class.bind="(pageNumber === pageCount || totalItems === 0) ? 'disabled' : ''">
+              class.bind="(pageNumber === pageCount || totalItems === 0) ? 'disabled' : ''">
               <a class="page-link icon-seek-next fa fa-angle-right" href="" aria-label="Next"
-                 click.delegate="changeToNextPage($event)">
+                click.delegate="changeToNextPage($event)">
               </a>
             </li>
             <li class="page-item"
-                class.bind="(pageNumber === pageCount || totalItems === 0) ? 'disabled' : ''">
+              class.bind="(pageNumber === pageCount || totalItems === 0) ? 'disabled' : ''">
               <a class="page-link icon-seek-end fa fa-angle-double-right" href="" aria-label="Last"
-                 click.delegate="changeToLastPage($event)">
+                click.delegate="changeToLastPage($event)">
               </a>
             </li>
           </ul>

--- a/src/aurelia-slickgrid/custom-elements/slick-pagination.ts
+++ b/src/aurelia-slickgrid/custom-elements/slick-pagination.ts
@@ -38,6 +38,16 @@ export class SlickPaginationCustomElement {
     return this.paginationService.dataTo;
   }
 
+  /** is the left side pagination disabled? */
+  get isLeftPaginationDisabled(): boolean {
+    return this.pageNumber === 1 || this.totalItems === 0;
+  }
+
+  /** is the right side pagination disabled? */
+  get isRightPaginationDisabled(): boolean {
+    return this.pageNumber === this.pageCount || this.totalItems === 0;
+  }
+
   get itemsPerPage(): number {
     return this.paginationService.itemsPerPage;
   }
@@ -81,20 +91,28 @@ export class SlickPaginationCustomElement {
     this.dispose();
   }
 
-  changeToFirstPage(event: any) {
-    this.paginationService.goToFirstPage(event);
+  changeToFirstPage(event: MouseEvent) {
+    if (!this.isLeftPaginationDisabled) {
+      this.paginationService.goToFirstPage(event);
+    }
   }
 
-  changeToLastPage(event: any) {
-    this.paginationService.goToLastPage(event);
+  changeToLastPage(event: MouseEvent) {
+    if (!this.isRightPaginationDisabled) {
+      this.paginationService.goToLastPage(event);
+    }
   }
 
-  changeToNextPage(event: any) {
-    this.paginationService.goToNextPage(event);
+  changeToNextPage(event: MouseEvent) {
+    if (!this.isRightPaginationDisabled) {
+      this.paginationService.goToNextPage(event);
+    }
   }
 
-  changeToPreviousPage(event: any) {
-    this.paginationService.goToPreviousPage(event);
+  changeToPreviousPage(event: MouseEvent) {
+    if (!this.isLeftPaginationDisabled) {
+      this.paginationService.goToPreviousPage(event);
+    }
   }
 
   changeToCurrentPage(event: any) {

--- a/test/cypress/package.json
+++ b/test/cypress/package.json
@@ -11,7 +11,7 @@
   "author": "Ghislain B.",
   "license": "MIT",
   "devDependencies": {
-    "cypress": "^4.7.0",
+    "cypress": "^4.8.0",
     "mocha": "^5.2.0",
     "mochawesome": "^3.1.2",
     "mochawesome-merge": "^1.0.7",


### PR DESCRIPTION
- I found out that the Bootstrap styling applied to the DOM element does not block clicks from it, the reason is because they are in fact `href` links which cannot by disabled (according to w3c specs), so it's better to check if action is enabled before proceeding with clicks