### PR TITLE
fix(editor): shouldn't call cell changed when cell value is undefined

### DIFF
--- a/src/aurelia-slickgrid/editors/__tests__/autoCompleteEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/autoCompleteEditor.spec.ts
@@ -201,6 +201,7 @@ describe('AutoCompleteEditor', () => {
       const event = new (window.window as any).KeyboardEvent('keydown', { keyCode: KEY_CHAR_A, bubbles: true, cancelable: true });
 
       editor = new AutoCompleteEditor(editorArguments);
+      editor.setValue('z');
       const editorElm = divContainer.querySelector<HTMLInputElement>('input.editor-gender');
 
       editorElm.focus();
@@ -363,6 +364,7 @@ describe('AutoCompleteEditor', () => {
         const spy = jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit');
 
         editor = new AutoCompleteEditor(editorArguments);
+        editor.setValue('a');
         editor.save();
 
         expect(spy).toHaveBeenCalled();
@@ -373,6 +375,7 @@ describe('AutoCompleteEditor', () => {
         const spy = jest.spyOn(editorArguments, 'commitChanges');
 
         editor = new AutoCompleteEditor(editorArguments);
+        editor.setValue('a');
         editor.save();
 
         expect(spy).toHaveBeenCalled();

--- a/src/aurelia-slickgrid/editors/__tests__/dualInputEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/dualInputEditor.spec.ts
@@ -224,6 +224,7 @@ describe('DualInputEditor', () => {
         const event = new (window.window as any).KeyboardEvent('keydown', { keyCode: KEY_CHAR_0, bubbles: true, cancelable: true });
 
         editor = new DualInputEditor(editorArguments);
+        editor.setValues(['9', '9']);
         const editorElm = divContainer.querySelector<HTMLInputElement>('input.editor-range');
 
         editor.focus();

--- a/src/aurelia-slickgrid/editors/__tests__/floatEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/floatEditor.spec.ts
@@ -178,6 +178,7 @@ describe('FloatEditor', () => {
         const event = new (window.window as any).KeyboardEvent('keydown', { keyCode: KEY_CHAR_0, bubbles: true, cancelable: true });
 
         editor = new FloatEditor(editorArguments);
+        editor.setValue(9);
         const editorElm = divContainer.querySelector<HTMLInputElement>('input.editor-price');
 
         editor.focus();

--- a/src/aurelia-slickgrid/editors/__tests__/integerEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/integerEditor.spec.ts
@@ -178,6 +178,7 @@ describe('IntegerEditor', () => {
         const event = new (window.window as any).KeyboardEvent('keydown', { keyCode: KEY_CHAR_0, bubbles: true, cancelable: true });
 
         editor = new IntegerEditor(editorArguments);
+        editor.setValue(9);
         const editorElm = divContainer.querySelector<HTMLInputElement>('input.editor-price');
 
         editor.focus();

--- a/src/aurelia-slickgrid/editors/__tests__/longTextEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/longTextEditor.spec.ts
@@ -221,6 +221,7 @@ describe('LongTextEditor', () => {
         const event = new (window.window as any).KeyboardEvent('keydown', { keyCode: KEY_CHAR_A, bubbles: true, cancelable: true });
 
         editor = new LongTextEditor(i18n, editorArguments);
+        editor.setValue('z');
         const editorElm = document.body.querySelector<HTMLTextAreaElement>('.editor-title textarea');
 
         editor.focus();
@@ -246,6 +247,7 @@ describe('LongTextEditor', () => {
         const event = new (window.window as any).KeyboardEvent('keydown', { keyCode: KeyCode.ENTER, bubbles: true, cancelable: true });
 
         editor = new LongTextEditor(i18n, editorArguments);
+        editor.setValue('a');
         const editorElm = document.body.querySelector<HTMLTextAreaElement>('.editor-title textarea');
 
         editor.focus();

--- a/src/aurelia-slickgrid/editors/__tests__/textEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/textEditor.spec.ts
@@ -1,6 +1,6 @@
 import { Editors } from '../index';
 import { TextEditor } from '../textEditor';
-import { Column, EditorArgs, EditorArguments, GridOption, KeyCode } from '../../models';
+import { AutocompleteOption, Column, EditorArgs, EditorArguments, GridOption, KeyCode } from '../../models';
 
 const KEY_CHAR_A = 97;
 const containerId = 'demo-container';
@@ -186,6 +186,7 @@ describe('TextEditor', () => {
         const event = new (window.window as any).KeyboardEvent('keydown', { keyCode: KEY_CHAR_A, bubbles: true, cancelable: true });
 
         editor = new TextEditor(editorArguments);
+        editor.setValue('z');
         const editorElm = divContainer.querySelector<HTMLInputElement>('input.editor-title');
 
         editor.focus();

--- a/src/aurelia-slickgrid/editors/autoCompleteEditor.ts
+++ b/src/aurelia-slickgrid/editors/autoCompleteEditor.ts
@@ -157,11 +157,12 @@ export class AutoCompleteEditor implements Editor {
   }
 
   isValueChanged(): boolean {
-    const lastEvent = this._lastInputEvent && this._lastInputEvent.keyCode;
-    if (this.columnEditor && this.columnEditor.alwaysSaveOnEnterKey && lastEvent === KeyCode.ENTER) {
+    const elmValue = this._$editorElm.val();
+    const lastKeyEvent = this._lastInputEvent && this._lastInputEvent.keyCode;
+    if (this.columnEditor && this.columnEditor.alwaysSaveOnEnterKey && lastKeyEvent === KeyCode.ENTER) {
       return true;
     }
-    return (!(this._$editorElm.val() === '' && this._defaultTextValue === null)) && (this._$editorElm.val() !== this._defaultTextValue);
+    return (!(elmValue === '' && (this._defaultTextValue === null || this._defaultTextValue === undefined))) && (elmValue !== this._defaultTextValue);
   }
 
   loadValue(item: any) {

--- a/src/aurelia-slickgrid/editors/dualInputEditor.ts
+++ b/src/aurelia-slickgrid/editors/dualInputEditor.ts
@@ -237,8 +237,8 @@ export class DualInputEditor implements Editor {
     if ((leftEditorParams && leftEditorParams.alwaysSaveOnEnterKey || rightEditorParams && rightEditorParams.alwaysSaveOnEnterKey) && lastKeyEvent === KeyCode.ENTER) {
       return true;
     }
-    const leftResult = (!(leftElmValue === '' && this.originalLeftValue === null)) && (leftElmValue !== this.originalLeftValue);
-    const rightResult = (!(rightElmValue === '' && this.originalRightValue === null)) && (rightElmValue !== this.originalRightValue);
+    const leftResult = (!(leftElmValue === '' && (this.originalLeftValue === null || this.originalLeftValue === undefined))) && (leftElmValue !== this.originalLeftValue);
+    const rightResult = (!(rightElmValue === '' && (this.originalRightValue === null || this.originalRightValue === undefined))) && (rightElmValue !== this.originalRightValue);
     return leftResult || rightResult;
   }
 

--- a/src/aurelia-slickgrid/editors/floatEditor.ts
+++ b/src/aurelia-slickgrid/editors/floatEditor.ts
@@ -133,11 +133,11 @@ export class FloatEditor implements Editor {
 
   isValueChanged(): boolean {
     const elmValue = this._$input.val();
-    const lastEvent = this._lastInputEvent && this._lastInputEvent.keyCode;
-    if (this.columnEditor && this.columnEditor.alwaysSaveOnEnterKey && lastEvent === KeyCode.ENTER) {
+    const lastKeyEvent = this._lastInputEvent && this._lastInputEvent.keyCode;
+    if (this.columnEditor && this.columnEditor.alwaysSaveOnEnterKey && lastKeyEvent === KeyCode.ENTER) {
       return true;
     }
-    return (!(elmValue === '' && this.originalValue === null)) && (elmValue !== this.originalValue);
+    return (!(elmValue === '' && (this.originalValue === null || this.originalValue === undefined))) && (elmValue !== this.originalValue);
   }
 
   loadValue(item: any) {

--- a/src/aurelia-slickgrid/editors/integerEditor.ts
+++ b/src/aurelia-slickgrid/editors/integerEditor.ts
@@ -106,11 +106,11 @@ export class IntegerEditor implements Editor {
 
   isValueChanged(): boolean {
     const elmValue = this._$input.val();
-    const lastEvent = this._lastInputEvent && this._lastInputEvent.keyCode;
-    if (this.columnEditor && this.columnEditor.alwaysSaveOnEnterKey && lastEvent === KeyCode.ENTER) {
+    const lastKeyEvent = this._lastInputEvent && this._lastInputEvent.keyCode;
+    if (this.columnEditor && this.columnEditor.alwaysSaveOnEnterKey && lastKeyEvent === KeyCode.ENTER) {
       return true;
     }
-    return (!(elmValue === '' && this.originalValue === null)) && (elmValue !== this.originalValue);
+    return (!(elmValue === '' && (this.originalValue === null || this.originalValue === undefined))) && (elmValue !== this.originalValue);
   }
 
   loadValue(item: any) {

--- a/src/aurelia-slickgrid/editors/longTextEditor.ts
+++ b/src/aurelia-slickgrid/editors/longTextEditor.ts
@@ -156,7 +156,8 @@ export class LongTextEditor implements Editor {
   }
 
   isValueChanged(): boolean {
-    return (!(this._$textarea.val() === '' && this.defaultValue === null)) && (this._$textarea.val() !== this.defaultValue);
+    const elmValue = this._$textarea.val();
+    return (!(elmValue === '' && (this.defaultValue === null || this.defaultValue === undefined))) && (elmValue !== this.defaultValue);
   }
 
   loadValue(item: any) {

--- a/src/aurelia-slickgrid/editors/textEditor.ts
+++ b/src/aurelia-slickgrid/editors/textEditor.ts
@@ -106,11 +106,11 @@ export class TextEditor implements Editor {
 
   isValueChanged(): boolean {
     const elmValue = this._$input.val();
-    const lastEvent = this._lastInputEvent && this._lastInputEvent.keyCode;
-    if (this.columnEditor && this.columnEditor.alwaysSaveOnEnterKey && lastEvent === KeyCode.ENTER) {
+    const lastKeyEvent = this._lastInputEvent && this._lastInputEvent.keyCode;
+    if (this.columnEditor && this.columnEditor.alwaysSaveOnEnterKey && lastKeyEvent === KeyCode.ENTER) {
       return true;
     }
-    return (!(elmValue === '' && this.originalValue === null)) && (elmValue !== this.originalValue);
+    return (!(elmValue === '' && (this.originalValue === null || this.originalValue === undefined))) && (elmValue !== this.originalValue);
   }
 
   loadValue(item: any) {


### PR DESCRIPTION
- we were already checking for null value but undefined is another possibility, so now it checks for null/undefined in isValueChanged() method