### PR TITLE
fix(extensions): draggable grouping called wrong check

### DIFF
--- a/src/aurelia-slickgrid/services/extension.service.ts
+++ b/src/aurelia-slickgrid/services/extension.service.ts
@@ -311,7 +311,7 @@ export class ExtensionService {
       }
     }
     if (options.enableDraggableGrouping) {
-      if (!this.getCreatedExtensionByName(ExtensionName.rowDetailView)) {
+      if (!this.getCreatedExtensionByName(ExtensionName.draggableGrouping)) {
         const draggableInstance = this.draggableGroupingExtension.create(options);
         options.enableColumnReorder = draggableInstance.getSetupColumnReorder;
         this._extensionCreatedList.push({ name: ExtensionName.draggableGrouping, instance: draggableInstance });


### PR DESCRIPTION
- On line 314, instead of checking for ExtensionName.draggableGrouping, code is checking for ExtensionName.rowDetailView, due to which if the rowDetailVIew is on then draggableGrouping can't be on. This is causing the issue when we enable both.