### PR TITLE
feat(editors): add min/max length options to text editors

### DIFF
--- a/src/aurelia-slickgrid/constants.ts
+++ b/src/aurelia-slickgrid/constants.ts
@@ -59,6 +59,11 @@ export class Constants {
   static readonly VALIDATION_EDITOR_NUMBER_MIN = 'Please enter a valid number that is greater than {{minValue}}';
   static readonly VALIDATION_EDITOR_NUMBER_MIN_INCLUSIVE = 'Please enter a valid number that is greater than or equal to {{minValue}}';
   static readonly VALIDATION_EDITOR_DECIMAL_BETWEEN = 'Please enter a valid number with a maximum of {{maxDecimal}} decimals';
+  static readonly VALIDATION_EDITOR_TEXT_LENGTH_BETWEEN = 'Please make sure your text length is between {{minLength}} and {{maxLength}} characters';
+  static readonly VALIDATION_EDITOR_TEXT_MAX_LENGTH = 'Please make sure your text is less than {{maxLength}} characters';
+  static readonly VALIDATION_EDITOR_TEXT_MAX_LENGTH_INCLUSIVE = 'Please make sure your text is less than or equal to {{maxLength}} characters';
+  static readonly VALIDATION_EDITOR_TEXT_MIN_LENGTH = 'Please make sure your text is more than {{minLength}} character(s)';
+  static readonly VALIDATION_EDITOR_TEXT_MIN_LENGTH_INCLUSIVE = 'Please make sure your text is at least {{minLength}} character(s)';
 
   // some of the Events from the Event Aggregator that are exposed to the outside as dispatch events
   // we define the internal name of the events and their alias used as dispatch events

--- a/src/aurelia-slickgrid/editorValidators/integerValidator.ts
+++ b/src/aurelia-slickgrid/editorValidators/integerValidator.ts
@@ -38,22 +38,20 @@ export function integerValidator(inputValue: any, options: IntegerValidatorOptio
     isValid = false;
     outputMsg = errorMsg || Constants.VALIDATION_EDITOR_VALID_INTEGER;
   } else if (minValue !== undefined && maxValue !== undefined && intNumber !== null && ((operatorConditionalType === 'exclusive' && (intNumber <= minValue || intNumber >= maxValue)) || (operatorConditionalType === 'inclusive' && (intNumber < minValue || intNumber > maxValue)))) {
-    // MIN & MAX Values provided
+    // MIN & MAX Values provided (between)
     // when decimal value is bigger than 0, we only accept the decimal values as that value set
     // for example if we set decimalPlaces to 2, we will only accept numbers between 0 and 2 decimals
     isValid = false;
     outputMsg = errorMsg || Constants.VALIDATION_EDITOR_INTEGER_BETWEEN.replace(/{{minValue}}|{{maxValue}}/gi, (matched) => mapValidation[matched]);
   } else if (minValue !== undefined && intNumber !== null && ((operatorConditionalType === 'exclusive' && intNumber <= minValue) || (operatorConditionalType === 'inclusive' && intNumber !== null && intNumber < minValue))) {
     // MIN VALUE ONLY
-    // when decimal value is bigger than 0, we only accept the decimal values as that value set
-    // for example if we set decimalPlaces to 2, we will only accept numbers between 0 and 2 decimals
+    // when decimal value has to be higher then provided minValue
     isValid = false;
     const defaultErrorMsg = operatorConditionalType === 'inclusive' ? Constants.VALIDATION_EDITOR_INTEGER_MIN_INCLUSIVE : Constants.VALIDATION_EDITOR_INTEGER_MIN;
     outputMsg = errorMsg || defaultErrorMsg.replace(/{{minValue}}/gi, (matched) => mapValidation[matched]);
   } else if (maxValue !== undefined && intNumber !== null && ((operatorConditionalType === 'exclusive' && intNumber >= maxValue) || (operatorConditionalType === 'inclusive' && intNumber !== null && intNumber > maxValue))) {
     // MAX VALUE ONLY
-    // when decimal value is bigger than 0, we only accept the decimal values as that value set
-    // for example if we set decimalPlaces to 2, we will only accept numbers between 0 and 2 decimals
+    // when decimal value has to be lower then provided maxValue
     isValid = false;
     const defaultErrorMsg = operatorConditionalType === 'inclusive' ? Constants.VALIDATION_EDITOR_INTEGER_MAX_INCLUSIVE : Constants.VALIDATION_EDITOR_INTEGER_MAX;
     outputMsg = errorMsg || defaultErrorMsg.replace(/{{maxValue}}/gi, (matched) => mapValidation[matched]);

--- a/src/aurelia-slickgrid/editorValidators/textValidator.ts
+++ b/src/aurelia-slickgrid/editorValidators/textValidator.ts
@@ -5,13 +5,26 @@ import { EditorValidator } from '../models/editorValidator.interface';
 interface TextValidatorOptions {
   editorArgs: any;
   errorMessage?: string;
+  minLength?: number;
+  maxLength?: number;
+  operatorConditionalType?: 'inclusive' | 'exclusive';
   required?: boolean;
   validator?: EditorValidator;
 }
 
 export function textValidator(inputValue: any, options: TextValidatorOptions): EditorValidatorOutput {
-  const isRequired = options.required;
   const errorMsg = options.errorMessage;
+  const isRequired = options.required;
+  const minLength = options.minLength;
+  const maxLength = options.maxLength;
+  const operatorConditionalType = options.operatorConditionalType || 'inclusive';
+  const mapValidation = {
+    '{{minLength}}': minLength,
+    '{{maxLength}}': maxLength
+  };
+  let isValid = true;
+  let outputMsg = '';
+  const inputValueLength = inputValue.length;
 
   if (options.validator) {
     return options.validator(inputValue, options.editorArgs);
@@ -19,11 +32,26 @@ export function textValidator(inputValue: any, options: TextValidatorOptions): E
 
   // by default the editor is almost always valid (except when it's required but not provided)
   if (isRequired && inputValue === '') {
-    return {
-      valid: false,
-      msg: errorMsg || Constants.VALIDATION_REQUIRED_FIELD
-    };
+    isValid = false;
+    outputMsg = errorMsg || Constants.VALIDATION_REQUIRED_FIELD;
+  } else if (minLength !== undefined && maxLength !== undefined && ((operatorConditionalType === 'exclusive' && (inputValueLength <= minLength || inputValueLength >= maxLength)) || (operatorConditionalType === 'inclusive' && (inputValueLength < minLength || inputValueLength > maxLength)))) {
+    // MIN & MAX Length provided
+    // make sure text length is between minLength and maxLength
+    isValid = false;
+    outputMsg = errorMsg || Constants.VALIDATION_EDITOR_TEXT_LENGTH_BETWEEN.replace(/{{minLength}}|{{maxLength}}/gi, (matched) => mapValidation[matched]);
+  } else if (minLength !== undefined && inputValueLength !== null && ((operatorConditionalType === 'exclusive' && inputValueLength <= minLength) || (operatorConditionalType === 'inclusive' && inputValueLength !== null && inputValueLength < minLength))) {
+    // MIN Length ONLY
+    // when text length is shorter than minLength
+    isValid = false;
+    const defaultErrorMsg = operatorConditionalType === 'inclusive' ? Constants.VALIDATION_EDITOR_TEXT_MIN_LENGTH_INCLUSIVE : Constants.VALIDATION_EDITOR_TEXT_MIN_LENGTH;
+    outputMsg = errorMsg || defaultErrorMsg.replace(/{{minLength}}/gi, (matched) => mapValidation[matched]);
+  } else if (maxLength !== undefined && inputValueLength !== null && ((operatorConditionalType === 'exclusive' && inputValueLength >= maxLength) || (operatorConditionalType === 'inclusive' && inputValueLength !== null && inputValueLength > maxLength))) {
+    // MAX Length ONLY
+    // when text length is longer than minLength
+    isValid = false;
+    const defaultErrorMsg = operatorConditionalType === 'inclusive' ? Constants.VALIDATION_EDITOR_TEXT_MAX_LENGTH_INCLUSIVE : Constants.VALIDATION_EDITOR_TEXT_MAX_LENGTH;
+    outputMsg = errorMsg || defaultErrorMsg.replace(/{{maxLength}}/gi, (matched) => mapValidation[matched]);
   }
 
-  return { valid: true, msg: null };
+  return { valid: isValid, msg: outputMsg };
 }

--- a/src/aurelia-slickgrid/editors/__tests__/autoCompleteEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/autoCompleteEditor.spec.ts
@@ -383,7 +383,7 @@ describe('AutoCompleteEditor', () => {
     });
 
     describe('validate method', () => {
-      it('should validate and return False when field is required and field is an empty string', () => {
+      it('should return False when field is required and field is empty', () => {
         mockColumn.internalColumnEditor.required = true;
         editor = new AutoCompleteEditor(editorArguments);
         const validation = editor.validate('');
@@ -391,12 +391,128 @@ describe('AutoCompleteEditor', () => {
         expect(validation).toEqual({ valid: false, msg: 'Field is required' });
       });
 
-      it('should validate and return True when field is required and field is a valid input value', () => {
+      it('should return True when field is required and input is a valid input value', () => {
         mockColumn.internalColumnEditor.required = true;
         editor = new AutoCompleteEditor(editorArguments);
-        const validation = editor.validate('gender');
+        const validation = editor.validate('text');
 
-        expect(validation).toEqual({ valid: true, msg: null });
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return False when field is lower than a minLength defined', () => {
+        mockColumn.internalColumnEditor.minLength = 5;
+        editor = new AutoCompleteEditor(editorArguments);
+        const validation = editor.validate('text');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is at least 5 character(s)' });
+      });
+
+      it('should return False when field is lower than a minLength defined using exclusive operator', () => {
+        mockColumn.internalColumnEditor.minLength = 5;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'exclusive';
+        editor = new AutoCompleteEditor(editorArguments);
+        const validation = editor.validate('text');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is more than 5 character(s)' });
+      });
+
+      it('should return True when field is equal to the minLength defined', () => {
+        mockColumn.internalColumnEditor.minLength = 4;
+        editor = new AutoCompleteEditor(editorArguments);
+        const validation = editor.validate('text');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return False when field is greater than a maxLength defined', () => {
+        mockColumn.internalColumnEditor.maxLength = 10;
+        editor = new AutoCompleteEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
+      });
+
+      it('should return False when field is greater than a maxLength defined using exclusive operator', () => {
+        mockColumn.internalColumnEditor.maxLength = 10;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'exclusive';
+        editor = new AutoCompleteEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 10 characters' });
+      });
+
+      it('should return True when field is equal to the maxLength defined', () => {
+        mockColumn.internalColumnEditor.maxLength = 16;
+        editor = new AutoCompleteEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return True when field is equal to the maxLength defined and "operatorType" is set to "inclusive"', () => {
+        mockColumn.internalColumnEditor.maxLength = 16;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'inclusive';
+        editor = new AutoCompleteEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return False when field is equal to the maxLength defined but "operatorType" is set to "exclusive"', () => {
+        mockColumn.internalColumnEditor.maxLength = 16;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'exclusive';
+        editor = new AutoCompleteEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 16 characters' });
+      });
+
+      it('should return False when field is not between minLength & maxLength defined', () => {
+        mockColumn.internalColumnEditor.minLength = 0;
+        mockColumn.internalColumnEditor.maxLength = 10;
+        editor = new AutoCompleteEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text length is between 0 and 10 characters' });
+      });
+
+      it('should return True when field is is equal to maxLength defined when both min/max values are defined', () => {
+        mockColumn.internalColumnEditor.minLength = 0;
+        mockColumn.internalColumnEditor.maxLength = 16;
+        editor = new AutoCompleteEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return True when field is is equal to minLength defined when "operatorType" is set to "inclusive" and both min/max values are defined', () => {
+        mockColumn.internalColumnEditor.minLength = 4;
+        mockColumn.internalColumnEditor.maxLength = 15;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'inclusive';
+        editor = new AutoCompleteEditor(editorArguments);
+        const validation = editor.validate('text');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return False when field is equal to maxLength but "operatorType" is set to "exclusive" when both min/max lengths are defined', () => {
+        mockColumn.internalColumnEditor.minLength = 4;
+        mockColumn.internalColumnEditor.maxLength = 16;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'exclusive';
+        editor = new AutoCompleteEditor(editorArguments);
+        const validation1 = editor.validate('text is 16 chars');
+        const validation2 = editor.validate('text');
+
+        expect(validation1).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
+        expect(validation2).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
+      });
+
+      it('should return False when field is greater than a maxValue defined', () => {
+        mockColumn.internalColumnEditor.maxLength = 10;
+        editor = new AutoCompleteEditor(editorArguments);
+        const validation = editor.validate('Task is longer than 10 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
       });
     });
 

--- a/src/aurelia-slickgrid/editors/__tests__/longTextEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/longTextEditor.spec.ts
@@ -119,11 +119,17 @@ describe('LongTextEditor', () => {
       gridOptionMock.i18n = i18n;
       editor = new LongTextEditor(i18n, editorArguments);
       const editorCount = document.body.querySelectorAll('.slick-large-editor-text.editor-title textarea').length;
+      const editorTextCounter = document.body.querySelectorAll<HTMLDivElement>('.slick-large-editor-text.editor-title .editor-footer .counter');
+      const currentTextLengthElm = document.body.querySelector<HTMLDivElement>('.editor-footer .text-length');
+      const maxTextLengthElm = document.body.querySelector<HTMLDivElement>('.editor-footer .max-length');
       const editorFooterElm = document.body.querySelector<HTMLDivElement>('.slick-large-editor-text.editor-title .editor-footer');
       const buttonCancelElm = editorFooterElm.querySelector<HTMLButtonElement>('.btn-default');
       const buttonSaveElm = editorFooterElm.querySelector<HTMLButtonElement>('.btn-primary');
 
       expect(editorCount).toBe(1);
+      expect(editorTextCounter.length).toBe(1);
+      expect(currentTextLengthElm.textContent).toBe('0');
+      expect(maxTextLengthElm.textContent).toBe('500');
       expect(buttonCancelElm.textContent).toBe('Annuler');
       expect(buttonSaveElm.textContent).toBe('Sauvegarder');
     });
@@ -190,7 +196,11 @@ describe('LongTextEditor', () => {
       editor = new LongTextEditor(i18n, editorArguments);
       editor.loadValue(mockItemData);
       const editorElm = editor.editorDomElement;
+      const currentTextLengthElm = document.body.querySelector<HTMLDivElement>('.editor-footer .text-length');
+      const maxTextLengthElm = document.body.querySelector<HTMLDivElement>('.editor-footer .max-length');
 
+      expect(currentTextLengthElm.textContent).toBe('6');
+      expect(maxTextLengthElm.textContent).toBe('500');
       expect(editor.getValue()).toBe('task 1');
       expect(editorElm[0].defaultValue).toBe('task 1');
     });
@@ -217,16 +227,22 @@ describe('LongTextEditor', () => {
     });
 
     describe('isValueChanged method', () => {
-      it('should return True when previously dispatched keyboard event is a new char "a"', () => {
-        const event = new (window.window as any).KeyboardEvent('keydown', { keyCode: KEY_CHAR_A, bubbles: true, cancelable: true });
+      it('should return True when previously dispatched keyboard event is a new char "a" and it should also update the text counter accordingly', () => {
+        const eventKeyDown = new (window.window as any).KeyboardEvent('keydown', { keyCode: KEY_CHAR_A, bubbles: true, cancelable: true });
+        const eventKeyUp = new (window.window as any).KeyboardEvent('keyup', { keyCode: KEY_CHAR_A, bubbles: true, cancelable: true });
+        mockColumn.internalColumnEditor.maxLength = 255;
 
         editor = new LongTextEditor(i18n, editorArguments);
         editor.setValue('z');
         const editorElm = document.body.querySelector<HTMLTextAreaElement>('.editor-title textarea');
-
+        const currentTextLengthElm = document.body.querySelector<HTMLDivElement>('.editor-footer .text-length');
+        const maxTextLengthElm = document.body.querySelector<HTMLDivElement>('.editor-footer .max-length');
         editor.focus();
-        editorElm.dispatchEvent(event);
+        editorElm.dispatchEvent(eventKeyDown);
+        editorElm.dispatchEvent(eventKeyUp);
 
+        expect(currentTextLengthElm.textContent).toBe('1');
+        expect(maxTextLengthElm.textContent).toBe('255');
         expect(editor.isValueChanged()).toBe(true);
       });
 
@@ -520,7 +536,123 @@ describe('LongTextEditor', () => {
         editor = new LongTextEditor(i18n, editorArguments);
         const validation = editor.validate('text');
 
-        expect(validation).toEqual({ valid: true, msg: null });
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return False when field is lower than a minLength defined', () => {
+        mockColumn.internalColumnEditor.minLength = 5;
+        editor = new LongTextEditor(i18n, editorArguments);
+        const validation = editor.validate('text');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is at least 5 character(s)' });
+      });
+
+      it('should return False when field is lower than a minLength defined using exclusive operator', () => {
+        mockColumn.internalColumnEditor.minLength = 5;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'exclusive';
+        editor = new LongTextEditor(i18n, editorArguments);
+        const validation = editor.validate('text');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is more than 5 character(s)' });
+      });
+
+      it('should return True when field is equal to the minLength defined', () => {
+        mockColumn.internalColumnEditor.minLength = 4;
+        editor = new LongTextEditor(i18n, editorArguments);
+        const validation = editor.validate('text');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return False when field is greater than a maxLength defined', () => {
+        mockColumn.internalColumnEditor.maxLength = 10;
+        editor = new LongTextEditor(i18n, editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
+      });
+
+      it('should return False when field is greater than a maxLength defined using exclusive operator', () => {
+        mockColumn.internalColumnEditor.maxLength = 10;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'exclusive';
+        editor = new LongTextEditor(i18n, editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 10 characters' });
+      });
+
+      it('should return True when field is equal to the maxLength defined', () => {
+        mockColumn.internalColumnEditor.maxLength = 16;
+        editor = new LongTextEditor(i18n, editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return True when field is equal to the maxLength defined and "operatorType" is set to "inclusive"', () => {
+        mockColumn.internalColumnEditor.maxLength = 16;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'inclusive';
+        editor = new LongTextEditor(i18n, editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return False when field is equal to the maxLength defined but "operatorType" is set to "exclusive"', () => {
+        mockColumn.internalColumnEditor.maxLength = 16;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'exclusive';
+        editor = new LongTextEditor(i18n, editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 16 characters' });
+      });
+
+      it('should return False when field is not between minLength & maxLength defined', () => {
+        mockColumn.internalColumnEditor.minLength = 0;
+        mockColumn.internalColumnEditor.maxLength = 10;
+        editor = new LongTextEditor(i18n, editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text length is between 0 and 10 characters' });
+      });
+
+      it('should return True when field is is equal to maxLength defined when both min/max values are defined', () => {
+        mockColumn.internalColumnEditor.minLength = 0;
+        mockColumn.internalColumnEditor.maxLength = 16;
+        editor = new LongTextEditor(i18n, editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return True when field is is equal to minLength defined when "operatorType" is set to "inclusive" and both min/max values are defined', () => {
+        mockColumn.internalColumnEditor.minLength = 4;
+        mockColumn.internalColumnEditor.maxLength = 15;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'inclusive';
+        editor = new LongTextEditor(i18n, editorArguments);
+        const validation = editor.validate('text');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return False when field is equal to maxLength but "operatorType" is set to "exclusive" when both min/max lengths are defined', () => {
+        mockColumn.internalColumnEditor.minLength = 4;
+        mockColumn.internalColumnEditor.maxLength = 16;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'exclusive';
+        editor = new LongTextEditor(i18n, editorArguments);
+        const validation1 = editor.validate('text is 16 chars');
+        const validation2 = editor.validate('text');
+
+        expect(validation1).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
+        expect(validation2).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
+      });
+
+      it('should return False when field is greater than a maxValue defined', () => {
+        mockColumn.internalColumnEditor.maxLength = 10;
+        editor = new LongTextEditor(i18n, editorArguments);
+        const validation = editor.validate('Task is longer than 10 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
       });
     });
   });

--- a/src/aurelia-slickgrid/editors/__tests__/textEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/textEditor.spec.ts
@@ -384,7 +384,123 @@ describe('TextEditor', () => {
         editor = new TextEditor(editorArguments);
         const validation = editor.validate('text');
 
-        expect(validation).toEqual({ valid: true, msg: null });
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return False when field is lower than a minLength defined', () => {
+        mockColumn.internalColumnEditor.minLength = 5;
+        editor = new TextEditor(editorArguments);
+        const validation = editor.validate('text');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is at least 5 character(s)' });
+      });
+
+      it('should return False when field is lower than a minLength defined using exclusive operator', () => {
+        mockColumn.internalColumnEditor.minLength = 5;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'exclusive';
+        editor = new TextEditor(editorArguments);
+        const validation = editor.validate('text');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is more than 5 character(s)' });
+      });
+
+      it('should return True when field is equal to the minLength defined', () => {
+        mockColumn.internalColumnEditor.minLength = 4;
+        editor = new TextEditor(editorArguments);
+        const validation = editor.validate('text');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return False when field is greater than a maxLength defined', () => {
+        mockColumn.internalColumnEditor.maxLength = 10;
+        editor = new TextEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
+      });
+
+      it('should return False when field is greater than a maxLength defined using exclusive operator', () => {
+        mockColumn.internalColumnEditor.maxLength = 10;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'exclusive';
+        editor = new TextEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 10 characters' });
+      });
+
+      it('should return True when field is equal to the maxLength defined', () => {
+        mockColumn.internalColumnEditor.maxLength = 16;
+        editor = new TextEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return True when field is equal to the maxLength defined and "operatorType" is set to "inclusive"', () => {
+        mockColumn.internalColumnEditor.maxLength = 16;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'inclusive';
+        editor = new TextEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return False when field is equal to the maxLength defined but "operatorType" is set to "exclusive"', () => {
+        mockColumn.internalColumnEditor.maxLength = 16;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'exclusive';
+        editor = new TextEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than 16 characters' });
+      });
+
+      it('should return False when field is not between minLength & maxLength defined', () => {
+        mockColumn.internalColumnEditor.minLength = 0;
+        mockColumn.internalColumnEditor.maxLength = 10;
+        editor = new TextEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text length is between 0 and 10 characters' });
+      });
+
+      it('should return True when field is is equal to maxLength defined when both min/max values are defined', () => {
+        mockColumn.internalColumnEditor.minLength = 0;
+        mockColumn.internalColumnEditor.maxLength = 16;
+        editor = new TextEditor(editorArguments);
+        const validation = editor.validate('text is 16 chars');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return True when field is is equal to minLength defined when "operatorType" is set to "inclusive" and both min/max values are defined', () => {
+        mockColumn.internalColumnEditor.minLength = 4;
+        mockColumn.internalColumnEditor.maxLength = 15;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'inclusive';
+        editor = new TextEditor(editorArguments);
+        const validation = editor.validate('text');
+
+        expect(validation).toEqual({ valid: true, msg: '' });
+      });
+
+      it('should return False when field is equal to maxLength but "operatorType" is set to "exclusive" when both min/max lengths are defined', () => {
+        mockColumn.internalColumnEditor.minLength = 4;
+        mockColumn.internalColumnEditor.maxLength = 16;
+        mockColumn.internalColumnEditor.operatorConditionalType = 'exclusive';
+        editor = new TextEditor(editorArguments);
+        const validation1 = editor.validate('text is 16 chars');
+        const validation2 = editor.validate('text');
+
+        expect(validation1).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
+        expect(validation2).toEqual({ valid: false, msg: 'Please make sure your text length is between 4 and 16 characters' });
+      });
+
+      it('should return False when field is greater than a maxValue defined', () => {
+        mockColumn.internalColumnEditor.maxLength = 10;
+        editor = new TextEditor(editorArguments);
+        const validation = editor.validate('Task is longer than 10 chars');
+
+        expect(validation).toEqual({ valid: false, msg: 'Please make sure your text is less than or equal to 10 characters' });
       });
     });
   });

--- a/src/aurelia-slickgrid/editors/autoCompleteEditor.ts
+++ b/src/aurelia-slickgrid/editors/autoCompleteEditor.ts
@@ -217,6 +217,9 @@ export class AutoCompleteEditor implements Editor {
     return textValidator(val, {
       editorArgs: this.args,
       errorMessage: this.columnEditor.errorMessage,
+      minLength: this.columnEditor.minLength,
+      maxLength: this.columnEditor.maxLength,
+      operatorConditionalType: this.columnEditor.operatorConditionalType,
       required: this.columnEditor.required,
       validator: this.validator,
     });

--- a/src/aurelia-slickgrid/editors/longTextEditor.ts
+++ b/src/aurelia-slickgrid/editors/longTextEditor.ts
@@ -17,6 +17,8 @@ import { getDescendantProperty, getHtmlElementOffset, getTranslationPrefix, setD
 import { textValidator } from '../editorValidators/textValidator';
 import * as $ from 'jquery';
 
+const DEFAULT_MAX_LENGTH = 500;
+
 /*
  * An example of a 'detached' editor.
  * The UI is added onto document BODY and .position(), .show() and .hide() are implemented.
@@ -26,6 +28,7 @@ import * as $ from 'jquery';
 export class LongTextEditor implements Editor {
   private _locales: Locale;
   private _$textarea: any;
+  private _$currentLengthElm: any;
   private _$wrapper: any;
   defaultValue: any;
 
@@ -88,26 +91,40 @@ export class LongTextEditor implements Editor {
     const columnId = this.columnDef && this.columnDef.id;
     const placeholder = this.columnEditor && this.columnEditor.placeholder || '';
     const title = this.columnEditor && this.columnEditor.title || '';
+    const maxLength = this.columnEditor && this.columnEditor.maxLength || DEFAULT_MAX_LENGTH;
+    const textAreaRows = this.columnEditor && this.columnEditor.params && this.columnEditor.params.textAreaRows || 6;
+
     const $container = $('body');
-
     this._$wrapper = $(`<div class="slick-large-editor-text editor-${columnId}" />`).appendTo($container);
-    this._$textarea = $(`<textarea hidefocus rows="5" placeholder="${placeholder}" title="${title}">`).appendTo(this._$wrapper);
+    this._$textarea = $(`<textarea hidefocus rows="${textAreaRows}" placeholder="${placeholder}" title="${title}">`).appendTo(this._$wrapper);
 
-    $(`<div class="editor-footer">
-          <button class="btn btn-save btn-primary btn-xs">${saveText}</button>
-          <button class="btn btn-cancel btn-default btn-xs">${cancelText}</button>
-      </div>`).appendTo(this._$wrapper);
+    const editorFooterElm = $(`<div class="editor-footer"/>`);
+    const countContainerElm = $(`<span class="counter"/>`);
+    this._$currentLengthElm = $(`<span class="text-length">0</span>`);
+    const textMaxLengthElm = $(`<span>/</span><span class="max-length">${maxLength}</span>`);
+    this._$currentLengthElm.appendTo(countContainerElm);
+    textMaxLengthElm.appendTo(countContainerElm);
+
+    const cancelBtnElm = $(`<button class="btn btn-cancel btn-default btn-xs">${cancelText}</button>`);
+    const saveBtnElm = $(`<button class="btn btn-save btn-primary btn-xs">${saveText}</button>`);
+    countContainerElm.appendTo(editorFooterElm);
+    cancelBtnElm.appendTo(editorFooterElm);
+    saveBtnElm.appendTo(editorFooterElm);
+    editorFooterElm.appendTo(this._$wrapper);
 
     this._$wrapper.find('.btn-save').on('click', () => this.save());
     this._$wrapper.find('.btn-cancel').on('click', () => this.cancel());
     this._$textarea.on('keydown', this.handleKeyDown.bind(this));
+    this._$textarea.on('keyup', this.handleKeyUp.bind(this));
 
     this.position(this.args && this.args.position);
     this._$textarea.focus().select();
   }
 
   cancel() {
-    this._$textarea.val(this.defaultValue);
+    const value = this.defaultValue || '';
+    this._$textarea.val(value);
+    this._$currentLengthElm.text(value.length);
     if (this.args && this.args.cancelChanges) {
       this.args.cancelChanges();
     }
@@ -135,6 +152,7 @@ export class LongTextEditor implements Editor {
 
   setValue(val: string) {
     this._$textarea.val(val);
+    this._$currentLengthElm.text(val.length);
   }
 
   applyValue(item: any, state: any) {
@@ -168,8 +186,9 @@ export class LongTextEditor implements Editor {
       const isComplexObject = fieldName && fieldName.indexOf('.') > 0;
       const value = (isComplexObject) ? getDescendantProperty(item, fieldName) : item[fieldName];
 
-      this.defaultValue = value;
+      this.defaultValue = value || '';
       this._$textarea.val(this.defaultValue);
+      this._$currentLengthElm.text(this.defaultValue.length);
       this._$textarea[0].defaultValue = this.defaultValue;
       this._$textarea.select();
     }
@@ -203,6 +222,9 @@ export class LongTextEditor implements Editor {
     return textValidator(elmValue, {
       editorArgs: this.args,
       errorMessage: this.columnEditor.errorMessage,
+      minLength: this.columnEditor.minLength,
+      maxLength: this.columnEditor.maxLength,
+      operatorConditionalType: this.columnEditor.operatorConditionalType,
       required: this.columnEditor.required,
       validator: this.validator,
     });
@@ -230,5 +252,11 @@ export class LongTextEditor implements Editor {
         this.grid.navigateNext();
       }
     }
+  }
+
+  /** On every keyup event, we'll update the current text length counter */
+  private handleKeyUp(event: KeyboardEvent & { target: HTMLTextAreaElement }) {
+    const textLength = event.target.value.length;
+    this._$currentLengthElm.text(textLength);
   }
 }

--- a/src/aurelia-slickgrid/editors/textEditor.ts
+++ b/src/aurelia-slickgrid/editors/textEditor.ts
@@ -147,6 +147,9 @@ export class TextEditor implements Editor {
     return textValidator(elmValue, {
       editorArgs: this.args,
       errorMessage: this.columnEditor.errorMessage,
+      minLength: this.columnEditor.minLength,
+      maxLength: this.columnEditor.maxLength,
+      operatorConditionalType: this.columnEditor.operatorConditionalType,
       required: this.columnEditor.required,
       validator: this.validator,
     });

--- a/src/aurelia-slickgrid/models/columnEditor.interface.ts
+++ b/src/aurelia-slickgrid/models/columnEditor.interface.ts
@@ -26,7 +26,7 @@ export interface ColumnEditor {
   /** Options to change the behavior of the "collection" */
   collectionOptions?: CollectionOption;
 
-  /** We could filter some 1 or more items from the collection */
+  /** We could filter 1 or more items from the collection */
   collectionFilterBy?: CollectionFilterBy | CollectionFilterBy[];
 
   /** We could sort the collection by 1 or more properties, or by translated value(s) when enableTranslateLabel is True */
@@ -46,7 +46,7 @@ export interface ColumnEditor {
   decimal?: number;
 
   /**
-   * Defaults to false, when enable it will add collection observers and re-render the Filter DOM element
+   * Defaults to false, when enable it will add collection observers and re-render the editor DOM element
    * with the new collection when changes are detected. Also note that using "collectionAsync" automatically watch for changes,
    * in consequence, there's no need to enable this flag in that particular case.
    */
@@ -68,7 +68,7 @@ export interface ColumnEditor {
 
   /**
    * Defaults to false, when set it will render any HTML code instead of removing it (sanitized)
-   * Only used so far in the MultipleSelect & SingleSelect Filters will support it
+   * Only used so far in the MultipleSelect & SingleSelect Editors will support it
    */
   enableRenderHtml?: boolean;
 
@@ -78,10 +78,16 @@ export interface ColumnEditor {
   /** Error message to display when validation fails */
   errorMessage?: string;
 
-  /** Maximum value of the filter, works only with Filters supporting it (text, number, float, slider) */
+  /** Maximum length of the text value, works only with Editors supporting it (autoComplete, text, longText) */
+  maxLength?: number;
+
+  /** Maximum value of the editor, works only with Editors supporting it (number, float, slider) */
   maxValue?: number | string;
 
-  /** Minimum value of the filter, works only with Filters supporting it (text, number, float, slider) */
+  /** Minimum length of the text value, works only with Editors supporting it (autoComplete, text, longText) */
+  minLength?: number;
+
+  /** Minimum value of the editor, works only with Editors supporting it (number, float, slider) */
   minValue?: number | string;
 
   /** Any inline editor function that implements Editor for the cell */
@@ -114,13 +120,13 @@ export interface ColumnEditor {
   /** Editor Validator */
   validator?: EditorValidator;
 
-  /** Step value of the filter, works only with Filters supporting it (input text, number, float, range, slider) */
+  /** Step value of the editor, works only with Editors supporting it (input text, number, float, range, slider) */
   valueStep?: number | string;
 
   /**
    * Use "params" to pass any type of arguments to your Custom Editor
    * or regular Editor like the Editors.float
-   * for example, to pass the option collection to a select Filter we can type this:
+   * for example, to pass the option collection to a select Editor we can type this:
    * params: { decimalPlaces: 2 }
    */
   params?: any;

--- a/src/aurelia-slickgrid/styles/_variables.scss
+++ b/src/aurelia-slickgrid/styles/_variables.scss
@@ -423,6 +423,8 @@ $large-editor-textarea-height:                  80px !default;
 $large-editor-textarea-width:                   250px !default;
 $large-editor-button-text-align:                right !default;
 $large-editor-footer-spacing:                   2px !default;
+$large-editor-count-font-size:                  11px !default;
+$large-editor-count-margin-top:                 8px !default;
 $text-editor-border:                            1px solid #e2e2e2 !default;
 $text-editor-border-radius:                     3px !default;
 $text-editor-background:                        #ffffff !default;

--- a/src/aurelia-slickgrid/styles/slick-editors.scss
+++ b/src/aurelia-slickgrid/styles/slick-editors.scss
@@ -59,17 +59,25 @@
   padding: $large-editor-text-padding;
   border: $large-editor-border;
   border-radius: $large-editor-border-radius;
-}
-.slick-large-editor-text textarea {
-  background: $large-editor-background-color;
-  height: $large-editor-textarea-height;
-  width: $large-editor-textarea-width;
-  border: 0;
-  outline: 0;
-}
-.slick-large-editor-text .editor-footer {
-  text-align: $large-editor-button-text-align;
-}
-.slick-large-editor-text .editor-footer > button {
-  margin-left: $large-editor-footer-spacing;
+
+  .editor-footer {
+    text-align: $large-editor-button-text-align;
+    button {
+      margin-left: $large-editor-footer-spacing;
+    }
+  }
+
+  textarea {
+    background: $large-editor-background-color;
+    height: $large-editor-textarea-height;
+    width: $large-editor-textarea-width;
+    border: 0;
+    outline: 0;
+  }
+
+  .counter {
+    float: left;
+    font-size: $large-editor-count-font-size;
+    margin-top: $large-editor-count-margin-top;
+  }
 }

--- a/src/examples/slickgrid/example26.ts
+++ b/src/examples/slickgrid/example26.ts
@@ -86,7 +86,9 @@ export class Example26 {
         sortable: true,
         type: FieldType.string,
         editor: {
-          model: Editors.longText
+          model: Editors.longText,
+          minLength: 5,
+          maxLength: 255,
         },
         minWidth: 100,
         onCellChange: (e: Event, args: OnEventArgs) => {


### PR DESCRIPTION
- add a text length counter (currentTextLength/maxLength) to the LongText Editor
- the new `minLenght`, `maxLength` options can be used by the following Editors (autoComplete, longText, text)
- also flip the position of the Cancel/Save buttons, Cancel should be on the left and Save on the right