### PR TITLE
fix(editors): all Editors should call commitChanges even when invalid

### DIFF
--- a/src/aurelia-slickgrid/editors/__tests__/floatEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/floatEditor.spec.ts
@@ -405,7 +405,7 @@ describe('FloatEditor', () => {
         expect(spy).toHaveBeenCalled();
       });
 
-      it('should not call anything when the input value is not a valid float number', () => {
+      it('should call "commitCurrentEdit" even when the input value is not a valid float number', () => {
         mockItemData = { id: 1, price: null, isActive: true };
         gridOptionMock.autoCommitEdit = true;
         const spy = jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit');
@@ -415,7 +415,7 @@ describe('FloatEditor', () => {
         editor.setValue('-.');
         editor.save();
 
-        expect(spy).not.toHaveBeenCalled();
+        expect(spy).toHaveBeenCalled();
       });
 
       it('should call "getEditorLock" and "save" methods when "hasAutoCommitEdit" is enabled and the event "focusout" is triggered', (done) => {

--- a/src/aurelia-slickgrid/editors/__tests__/selectEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/selectEditor.spec.ts
@@ -501,15 +501,13 @@ describe('SelectEditor', () => {
         mockItemData = { id: 1, gender: '', isActive: true };
         mockColumn.internalColumnEditor.required = true;
         gridOptionMock.autoCommitEdit = true;
-        const commitEditSpy = jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit');
-        const commitChangeSpy = jest.spyOn(editorArguments, 'commitChanges');
+        const spy = jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit');
 
         editor = new SelectEditor(bindingEngineStub, collectionService, i18n, editorArguments, true);
         editor.loadValue(mockItemData);
         editor.save();
 
-        expect(commitEditSpy).not.toHaveBeenCalled();
-        expect(commitChangeSpy).not.toHaveBeenCalled();
+        expect(spy).not.toHaveBeenCalled();
       });
     });
 

--- a/src/aurelia-slickgrid/editors/__tests__/sliderEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/sliderEditor.spec.ts
@@ -388,7 +388,7 @@ describe('SliderEditor', () => {
         expect(spy).toHaveBeenCalled();
       });
 
-      it('should not call anything when the input value is the same as the default value', () => {
+      it('should call "commitCurrentEdit" even when the input value is the same as the default value', () => {
         mockItemData = { id: 1, price: 0, isActive: true };
         gridOptionMock.autoCommitEdit = true;
         const spy = jest.spyOn(gridStub.getEditorLock(), 'commitCurrentEdit');
@@ -397,7 +397,7 @@ describe('SliderEditor', () => {
         editor.loadValue(mockItemData);
         editor.save();
 
-        expect(spy).not.toHaveBeenCalled();
+        expect(spy).toHaveBeenCalled();
       });
 
       it('should call "getEditorLock" and "save" methods when "hasAutoCommitEdit" is enabled and the event "focusout" is triggered', (done) => {

--- a/src/aurelia-slickgrid/editors/autoCompleteEditor.ts
+++ b/src/aurelia-slickgrid/editors/autoCompleteEditor.ts
@@ -211,12 +211,14 @@ export class AutoCompleteEditor implements Editor {
 
   save() {
     const validation = this.validate();
-    if (validation && validation.valid && this.isValueChanged()) {
-      if (this.hasAutoCommitEdit) {
-        this.grid.getEditorLock().commitCurrentEdit();
-      } else {
-        this.args.commitChanges();
-      }
+    const isValid = (validation && validation.valid) || false;
+
+    if (this.hasAutoCommitEdit && isValid) {
+      // do not use args.commitChanges() as this sets the focus to the next row.
+      // also the select list will stay shown when clicking off the grid
+      this.grid.getEditorLock().commitCurrentEdit();
+    } else {
+      this.args.commitChanges();
     }
   }
 

--- a/src/aurelia-slickgrid/editors/checkboxEditor.ts
+++ b/src/aurelia-slickgrid/editors/checkboxEditor.ts
@@ -125,8 +125,14 @@ export class CheckboxEditor implements Editor {
 
   save() {
     const validation = this.validate();
-    if (validation && validation.valid && this.isValueChanged() && this.hasAutoCommitEdit) {
+    const isValid = (validation && validation.valid) || false;
+
+    if (this.hasAutoCommitEdit && isValid) {
+      // do not use args.commitChanges() as this sets the focus to the next row.
+      // also the select list will stay shown when clicking off the grid
       this.grid.getEditorLock().commitCurrentEdit();
+    } else {
+      this.args.commitChanges();
     }
   }
 

--- a/src/aurelia-slickgrid/editors/dateEditor.ts
+++ b/src/aurelia-slickgrid/editors/dateEditor.ts
@@ -211,14 +211,15 @@ export class DateEditor implements Editor {
   }
 
   save() {
-    // autocommit will not focus the next editor
     const validation = this.validate();
-    if (validation && validation.valid && this.isValueChanged()) {
-      if (this.hasAutoCommitEdit) {
-        this.grid.getEditorLock().commitCurrentEdit();
-      } else {
-        this.args.commitChanges();
-      }
+    const isValid = (validation && validation.valid) || false;
+
+    if (this.hasAutoCommitEdit && isValid) {
+      // do not use args.commitChanges() as this sets the focus to the next row.
+      // also the select list will stay shown when clicking off the grid
+      this.grid.getEditorLock().commitCurrentEdit();
+    } else {
+      this.args.commitChanges();
     }
   }
 

--- a/src/aurelia-slickgrid/editors/floatEditor.ts
+++ b/src/aurelia-slickgrid/editors/floatEditor.ts
@@ -160,12 +160,14 @@ export class FloatEditor implements Editor {
 
   save() {
     const validation = this.validate();
-    if (validation && validation.valid && this.isValueChanged()) {
-      if (this.hasAutoCommitEdit) {
-        this.grid.getEditorLock().commitCurrentEdit();
-      } else {
-        this.args.commitChanges();
-      }
+    const isValid = (validation && validation.valid) || false;
+
+    if (this.hasAutoCommitEdit && isValid) {
+      // do not use args.commitChanges() as this sets the focus to the next row.
+      // also the select list will stay shown when clicking off the grid
+      this.grid.getEditorLock().commitCurrentEdit();
+    } else {
+      this.args.commitChanges();
     }
   }
 

--- a/src/aurelia-slickgrid/editors/integerEditor.ts
+++ b/src/aurelia-slickgrid/editors/integerEditor.ts
@@ -129,12 +129,14 @@ export class IntegerEditor implements Editor {
 
   save() {
     const validation = this.validate();
-    if (validation && validation.valid && this.isValueChanged()) {
-      if (this.hasAutoCommitEdit) {
-        this.grid.getEditorLock().commitCurrentEdit();
-      } else {
-        this.args.commitChanges();
-      }
+    const isValid = (validation && validation.valid) || false;
+
+    if (this.hasAutoCommitEdit && isValid) {
+      // do not use args.commitChanges() as this sets the focus to the next row.
+      // also the select list will stay shown when clicking off the grid
+      this.grid.getEditorLock().commitCurrentEdit();
+    } else {
+      this.args.commitChanges();
     }
   }
 

--- a/src/aurelia-slickgrid/editors/longTextEditor.ts
+++ b/src/aurelia-slickgrid/editors/longTextEditor.ts
@@ -207,6 +207,8 @@ export class LongTextEditor implements Editor {
     const isValid = (validation && validation.valid) || false;
 
     if (this.hasAutoCommitEdit && isValid) {
+      // do not use args.commitChanges() as this sets the focus to the next row.
+      // also the select list will stay shown when clicking off the grid
       this.grid.getEditorLock().commitCurrentEdit();
     } else {
       this.args.commitChanges();

--- a/src/aurelia-slickgrid/editors/selectEditor.ts
+++ b/src/aurelia-slickgrid/editors/selectEditor.ts
@@ -403,16 +403,15 @@ export class SelectEditor implements Editor {
   }
 
   save() {
-    // autocommit will not focus the next editor
     const validation = this.validate();
-    if (validation && validation.valid && this.isValueChanged()) {
-      if (!this._destroying && this.hasAutoCommitEdit) {
-        // do not use args.commitChanges() as this sets the focus to the next row.
-        // also the select list will stay shown when clicking off the grid
-        this.grid.getEditorLock().commitCurrentEdit();
-      } else {
-        this.args.commitChanges();
-      }
+    const isValid = (validation && validation.valid) || false;
+
+    if (!this._destroying && this.hasAutoCommitEdit && isValid) {
+      // do not use args.commitChanges() as this sets the focus to the next row.
+      // also the select list will stay shown when clicking off the grid
+      this.grid.getEditorLock().commitCurrentEdit();
+    } else {
+      this.args.commitChanges();
     }
   }
 

--- a/src/aurelia-slickgrid/editors/sliderEditor.ts
+++ b/src/aurelia-slickgrid/editors/sliderEditor.ts
@@ -162,12 +162,14 @@ export class SliderEditor implements Editor {
 
   save() {
     const validation = this.validate();
-    if (validation && validation.valid && this.isValueChanged()) {
-      if (this.hasAutoCommitEdit) {
-        this.args.grid.getEditorLock().commitCurrentEdit();
-      } else {
-        this.args.commitChanges();
-      }
+    const isValid = (validation && validation.valid) || false;
+
+    if (this.hasAutoCommitEdit && isValid) {
+      // do not use args.commitChanges() as this sets the focus to the next row.
+      // also the select list will stay shown when clicking off the grid
+      this.grid.getEditorLock().commitCurrentEdit();
+    } else {
+      this.args.commitChanges();
     }
   }
 

--- a/src/aurelia-slickgrid/editors/textEditor.ts
+++ b/src/aurelia-slickgrid/editors/textEditor.ts
@@ -129,12 +129,14 @@ export class TextEditor implements Editor {
 
   save() {
     const validation = this.validate();
-    if (validation && validation.valid && this.isValueChanged()) {
-      if (this.hasAutoCommitEdit) {
-        this.grid.getEditorLock().commitCurrentEdit();
-      } else {
-        this.args.commitChanges();
-      }
+    const isValid = (validation && validation.valid) || false;
+
+    if (this.hasAutoCommitEdit && isValid) {
+      // do not use args.commitChanges() as this sets the focus to the next row.
+      // also the select list will stay shown when clicking off the grid
+      this.grid.getEditorLock().commitCurrentEdit();
+    } else {
+      this.args.commitChanges();
     }
   }
 

--- a/src/aurelia-slickgrid/models/locale.interface.ts
+++ b/src/aurelia-slickgrid/models/locale.interface.ts
@@ -92,7 +92,7 @@ export interface Locale {
   /** Text "Remove Sort" shown in Header Menu */
   TEXT_REMOVE_SORT: string;
 
-  /** Text "Cancel" shown in the Long Text Editor dialog */
+  /** Text "Save" shown in the Long Text Editor dialog */
   TEXT_SAVE: string;
 
   /** Text "Select All" displayed in the Multiple Select Editor/Filter */

--- a/src/examples/slickgrid/example3.ts
+++ b/src/examples/slickgrid/example3.ts
@@ -222,6 +222,12 @@ export class Example3 {
             operator: OperatorType.notEqual
           },
           model: Editors.singleSelect,
+          // validator: (value, args) => {
+          //   if (value < 50) {
+          //     return { valid: false, msg: 'Please use at least 50%' };
+          //   }
+          //   return { valid: true, msg: '' };
+          // }
         },
         minWidth: 100,
         params: {
@@ -560,7 +566,9 @@ export class Example3 {
   }
 
   onCellValidationError(e, args) {
-    alert(args.validationResults.msg);
+    if (args.validationResults) {
+      alert(args.validationResults.msg);
+    }
   }
 
   changeAutoCommit() {


### PR DESCRIPTION
- for the Editor validators to work properly it needs to call the commitChanges() at all time even when potentially invalid or value is unchanged so that the validator can be executed at all time