### PR TITLE
fix(core): use latest excel-builder-webpacker to fix CLI 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "aurelia-pal": "^1.8.2",
     "aurelia-templating-resources": "^1.13.0",
     "dompurify": "^2.0.12",
-    "excel-builder-webpacker": "^1.0.6",
+    "excel-builder-webpacker": "^2.0.0",
     "flatpickr": "^4.6.6",
     "jquery": "^3.4.1",
     "jquery-ui-dist": "^1.12.1",


### PR DESCRIPTION
- fixes issue found in the `excel-builder-webpacker` npm package with the new Aurelia CLI 2.0 reported here: https://github.com/ghiscoding/aurelia-slickgrid-demos/issues/2
- this new major version was compiled with `ncc` and we now use the compiled `dist/index` instead of the uncompiled `src/index`