### PR TITLE
feat(slots):adds named slots for header and footer 

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.html
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.html
@@ -1,6 +1,6 @@
 <template>
   <div id="slickGridContainer-${gridId}" class="gridPane" css="width: ${gridWidth}px">
-    <!-- Header slot if you need to create a complex custom footer -->
+    <!-- Header slot if you need to create a complex custom header -->
     <slot name="slickgrid-header"></slot>
 
     <div id.bind="gridId" class="slickgrid-container" style="width: 100%" css="height: ${gridHeight}px"

--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.html
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.html
@@ -1,5 +1,8 @@
 <template>
   <div id="slickGridContainer-${gridId}" class="gridPane" css="width: ${gridWidth}px">
+    <!-- Header slot if you need to create a complex custom footer -->
+    <slot name="slickgrid-header"></slot>
+
     <div id.bind="gridId" class="slickgrid-container" style="width: 100%" css="height: ${gridHeight}px"
       focusout.delegate="commitEdit($event.target)">
     </div>
@@ -33,5 +36,8 @@
         ${customFooterOptions.metricTexts.items}
       </div>
     </div>
+
+    <!-- Footer slot if you need to create a complex custom footer -->
+    <slot name="slickgrid-footer"></slot>
   </div>
 </template>

--- a/src/examples/slickgrid/custom-footer.ts
+++ b/src/examples/slickgrid/custom-footer.ts
@@ -1,0 +1,13 @@
+import { inlineView } from 'aurelia-framework';
+
+@inlineView(`<template>
+  <button click.delegate="clickMe()">I'm a button from an Aurelia custom element</button>
+  <div if.bind="clickedTimes">You've clicked me \${clickedTimes} time(s)</div>
+</template>`)
+export class CustomFooter {
+  clickedTimes = 0;
+
+  clickMe() {
+    this.clickedTimes++;
+  }
+}

--- a/src/examples/slickgrid/example29.html
+++ b/src/examples/slickgrid/example29.html
@@ -1,0 +1,21 @@
+<template>
+  <require from="./custom-footer"></require>
+  <h2>${title}</h2>
+  <div class="subtitle"
+       innerhtml.bind="subTitle"></div>
+
+
+  <aurelia-slickgrid grid-id="grid"
+                     column-definitions.bind="columnDefinitions"
+                     grid-options.bind="gridOptions"
+                     dataset.bind="dataset"
+                     grid-height="225"
+                     grid-width="800">
+    <div slot="slickgrid-header">
+      <h3>Grid with header and footer slot</h3>
+    </div>
+    <custom-footer class="slick-custom-footer"
+                   slot="slickgrid-footer">
+    </custom-footer>
+  </aurelia-slickgrid>
+</template>

--- a/src/examples/slickgrid/example29.ts
+++ b/src/examples/slickgrid/example29.ts
@@ -1,0 +1,61 @@
+import { Column, GridOption, Formatters } from '../../aurelia-slickgrid';
+
+const NB_ITEMS = 995;
+
+export class Example29 {
+  title = 'Example 29: Grid with Header and Footer slot';
+  subTitle = `Simple Grids with a custom header and footer via named slots`;
+
+  gridOptions: GridOption;
+  columnDefinitions: Column[];
+  dataset: any[];
+
+  constructor() {
+    // define the grid options & columns and then create the grid itself
+    this.defineGrids();
+  }
+
+  attached() {
+    // mock some data (different in each dataset)
+    this.dataset = this.mockData(NB_ITEMS);
+  }
+
+  /* Define grid Options and Columns */
+  defineGrids() {
+    this.columnDefinitions = [
+      { id: 'title', name: 'Title', field: 'title', sortable: true, minWidth: 100 },
+      { id: 'duration', name: 'Duration (days)', field: 'duration', sortable: true, minWidth: 100 },
+      { id: '%', name: '% Complete', field: 'percentComplete', sortable: true, minWidth: 100 },
+      { id: 'start', name: 'Start', field: 'start', formatter: Formatters.dateIso },
+      { id: 'finish', name: 'Finish', field: 'finish', formatter: Formatters.dateIso },
+      { id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven', sortable: true, minWidth: 100 }
+    ];
+    this.gridOptions = {
+      enableAutoResize: false,
+      enableSorting: true
+    };
+  }
+
+  mockData(count: number) {
+    // mock a dataset
+    const mockDataset = [];
+    for (let i = 0; i < count; i++) {
+      const randomYear = 2000 + Math.floor(Math.random() * 10);
+      const randomMonth = Math.floor(Math.random() * 11);
+      const randomDay = Math.floor((Math.random() * 29));
+      const randomPercent = Math.round(Math.random() * 100);
+
+      mockDataset[i] = {
+        id: i,
+        title: 'Task ' + i,
+        duration: Math.round(Math.random() * 100) + '',
+        percentComplete: randomPercent,
+        start: new Date(randomYear, randomMonth + 1, randomDay),
+        finish: new Date(randomYear + 1, randomMonth + 1, randomDay),
+        effortDriven: (i % 5 === 0)
+      };
+    }
+
+    return mockDataset;
+  }
+}

--- a/src/examples/slickgrid/index.ts
+++ b/src/examples/slickgrid/index.ts
@@ -35,6 +35,7 @@ export class Index {
       { route: 'example26', moduleId: PLATFORM.moduleName('./example26'), name: 'example26', nav: true, title: '26- Use of Aurelia Components' },
       { route: 'example27', moduleId: PLATFORM.moduleName('./example27'), name: 'example27', nav: true, title: '27- Tree Data (Parent/Child)' },
       { route: 'example28', moduleId: PLATFORM.moduleName('./example28'), name: 'example28', nav: true, title: '28- Tree Data (Hierarchical set)' },
+      { route: 'example29', moduleId: PLATFORM.moduleName('./example29'), name: 'example29', nav: true, title: '29- Grid with header and footer slots' },
     ];
 
     config.map(mapping);

--- a/test/cypress/integration/example29.spec.js
+++ b/test/cypress/integration/example29.spec.js
@@ -1,0 +1,25 @@
+/// <reference types="cypress" />
+
+describe('Example 29 - Header and Footer slots', () => {
+  it('should display a custom header as slot', () => {
+    cy.visit(`${Cypress.config('baseExampleUrl')}/example29`);
+    cy.get("div[slot='slickgrid-header']")
+      .find('h3')
+      .contains('Grid with header and footer slot');
+  });
+
+  it('should render a footer slot', () => {
+    cy.get("custom-footer[slot='slickgrid-footer']")
+      .should('exist');
+  });
+
+  it('should render a custom element inside footer slot', () => {
+    cy.get("custom-footer[slot='slickgrid-footer']")
+      .find("button")
+      .click()
+      .click()
+      .click()
+      .siblings("div")
+      .should("contain", "3 time(s)");
+  });
+});


### PR DESCRIPTION
this adds named slots for a custom header and footer so that more complex scenarios can be injected as part of the aurelia-slickgrid custom element

related issue https://github.com/ghiscoding/aurelia-slickgrid/issues/424