### PR TITLE
feat(core): add custom entry to Select Editor/Filter collections

### DIFF
--- a/src/aurelia-slickgrid/editors/__tests__/selectEditor.spec.ts
+++ b/src/aurelia-slickgrid/editors/__tests__/selectEditor.spec.ts
@@ -278,7 +278,7 @@ describe('SelectEditor', () => {
       expect(editorElm[0].value).toEqual('male');
     });
 
-    it('should create the multi-select filter with a blank entry at the beginning of the collection when "addBlankEntry" is set in the "collectionOptions" property', () => {
+    it('should create the multi-select editor with a blank entry at the beginning of the collection when "addBlankEntry" is set in the "collectionOptions" property', () => {
       mockColumn.internalColumnEditor.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
       mockColumn.internalColumnEditor.collectionOptions = { addBlankEntry: true };
 
@@ -290,7 +290,40 @@ describe('SelectEditor', () => {
       editorOkElm.click();
 
       expect(editorListElm.length).toBe(3);
+      expect(editorListElm[0].value).toBe('');
       expect(editorListElm[1].textContent).toBe('');
+    });
+
+    it('should create the multi-select editor with a custom entry at the beginning of the collection when "addCustomFirstEntry" is provided in the "collectionOptions" property', () => {
+      mockColumn.internalColumnEditor.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn.internalColumnEditor.collectionOptions = { addCustomFirstEntry: { value: null, label: '' } };
+
+      editor = new SelectEditor(bindingEngineStub, collectionService, i18n, editorArguments, true);
+      const editorBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.editor-gender button.ms-choice');
+      const editorListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=editor-gender].ms-drop ul>li input[type=checkbox]`);
+      const editorOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=editor-gender].ms-drop .ms-ok-button`);
+      editorBtnElm.click();
+      editorOkElm.click();
+
+      expect(editorListElm.length).toBe(3);
+      expect(editorListElm[0].value).toBe('');
+      expect(editorListElm[1].textContent).toBe('');
+    });
+
+    it('should create the multi-select editor with a custom entry at the end of the collection when "addCustomFirstEntry" is provided in the "collectionOptions" property', () => {
+      mockColumn.internalColumnEditor.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+      mockColumn.internalColumnEditor.collectionOptions = { addCustomLastEntry: { value: null, label: '' } };
+
+      editor = new SelectEditor(bindingEngineStub, collectionService, i18n, editorArguments, true);
+      const editorBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.editor-gender button.ms-choice');
+      const editorListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=editor-gender].ms-drop ul>li input[type=checkbox]`);
+      const editorOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=editor-gender].ms-drop .ms-ok-button`);
+      editorBtnElm.click();
+      editorOkElm.click();
+
+      expect(editorListElm.length).toBe(3);
+      expect(editorListElm[2].value).toBe('');
+      expect(editorListElm[1].textContent).toBe(''); expect(editorListElm[1].textContent).toBe('');
     });
 
     describe('isValueChanged method', () => {
@@ -530,7 +563,7 @@ describe('SelectEditor', () => {
     });
 
     describe('initialize with collection', () => {
-      it('should create the multi-select filter with a default search term when passed as a filter argument even with collection an array of strings', () => {
+      it('should create the multi-select editor with a default search term when passed as a filter argument even with collection an array of strings', () => {
         mockColumn.internalColumnEditor.collection = ['male', 'female'];
 
         editor = new SelectEditor(bindingEngineStub, collectionService, i18n, editorArguments, true);
@@ -547,7 +580,7 @@ describe('SelectEditor', () => {
     });
 
     describe('collectionSortBy setting', () => {
-      it('should create the multi-select filter and sort the string collection when "collectionSortBy" is set', () => {
+      it('should create the multi-select editor and sort the string collection when "collectionSortBy" is set', () => {
         mockColumn.internalColumnEditor = {
           collection: ['other', 'male', 'female'],
           collectionSortBy: {
@@ -567,7 +600,7 @@ describe('SelectEditor', () => {
         expect(editorListElm[2].value).toBe('female');
       });
 
-      it('should create the multi-select filter and sort the value/label pair collection when "collectionSortBy" is set', () => {
+      it('should create the multi-select editor and sort the value/label pair collection when "collectionSortBy" is set', () => {
         mockColumn.internalColumnEditor = {
           collection: [{ value: 'other', description: 'other' }, { value: 'male', description: 'male' }, { value: 'female', description: 'female' }],
           collectionSortBy: {
@@ -594,7 +627,7 @@ describe('SelectEditor', () => {
     });
 
     describe('collectionFilterBy setting', () => {
-      it('should create the multi-select filter and filter the string collection when "collectionFilterBy" is set', () => {
+      it('should create the multi-select editor and filter the string collection when "collectionFilterBy" is set', () => {
         mockColumn.internalColumnEditor = {
           collection: ['other', 'male', 'female'],
           collectionFilterBy: {
@@ -612,7 +645,7 @@ describe('SelectEditor', () => {
         expect(editorListElm[0].value).toBe('other');
       });
 
-      it('should create the multi-select filter and filter the value/label pair collection when "collectionFilterBy" is set', () => {
+      it('should create the multi-select editor and filter the value/label pair collection when "collectionFilterBy" is set', () => {
         mockColumn.internalColumnEditor = {
           collection: [{ value: 'other', description: 'other' }, { value: 'male', description: 'male' }, { value: 'female', description: 'female' }],
           collectionFilterBy: [
@@ -634,7 +667,7 @@ describe('SelectEditor', () => {
         expect(editorListElm[0].value).toBe('female');
       });
 
-      it('should create the multi-select filter and filter the value/label pair collection when "collectionFilterBy" is set and "filterResultAfterEachPass" is set to "merge"', () => {
+      it('should create the multi-select editor and filter the value/label pair collection when "collectionFilterBy" is set and "filterResultAfterEachPass" is set to "merge"', () => {
         mockColumn.internalColumnEditor = {
           collection: [{ value: 'other', description: 'other' }, { value: 'male', description: 'male' }, { value: 'female', description: 'female' }],
           collectionFilterBy: [
@@ -688,7 +721,7 @@ describe('SelectEditor', () => {
     });
 
     describe('enableRenderHtml property', () => {
-      it('should create the multi-select filter with a default search term and have the HTML rendered when "enableRenderHtml" is set', () => {
+      it('should create the multi-select editor with a default search term and have the HTML rendered when "enableRenderHtml" is set', () => {
         mockColumn.internalColumnEditor = {
           enableRenderHtml: true,
           collection: [{ value: true, label: 'True', labelPrefix: `<i class="fa fa-check"></i> ` }, { value: false, label: 'False' }],
@@ -708,7 +741,7 @@ describe('SelectEditor', () => {
         expect(editorListElm[0].innerHTML).toBe('<i class="fa fa-check"></i> True');
       });
 
-      it('should create the multi-select filter with a default search term and have the HTML rendered and sanitized when "enableRenderHtml" is set and has <script> tag', () => {
+      it('should create the multi-select editor with a default search term and have the HTML rendered and sanitized when "enableRenderHtml" is set and has <script> tag', () => {
         mockColumn.internalColumnEditor = {
           enableRenderHtml: true,
           collection: [{ isEffort: true, label: 'True', labelPrefix: `<script>alert('test')></script><i class="fa fa-check"></i> ` }, { isEffort: false, label: 'False' }],

--- a/src/aurelia-slickgrid/editors/selectEditor.ts
+++ b/src/aurelia-slickgrid/editors/selectEditor.ts
@@ -505,8 +505,22 @@ export class SelectEditor implements Editor {
     }
 
     // user can optionally add a blank entry at the beginning of the collection
-    if (this.collectionOptions && this.collectionOptions.addBlankEntry && Array.isArray(collection) && collection.length > 0 && collection[0][this.labelName] !== '') {
+    // make sure however that it wasn't added more than once
+    if (this.collectionOptions && this.collectionOptions.addBlankEntry && Array.isArray(collection) && collection.length > 0 && collection[0][this.valueName] !== '') {
       collection.unshift(this.createBlankEntry());
+    }
+
+    // user can optionally add his own custom entry at the beginning of the collection
+    if (this.collectionOptions && this.collectionOptions.addCustomFirstEntry && Array.isArray(collection) && collection.length > 0 && collection[0][this.valueName] !== this.collectionOptions.addCustomFirstEntry[this.valueName]) {
+      collection.unshift(this.collectionOptions && this.collectionOptions.addCustomFirstEntry);
+    }
+
+    // user can optionally add his own custom entry at the end of the collection
+    if (this.collectionOptions && this.collectionOptions.addCustomLastEntry && Array.isArray(collection) && collection.length > 0) {
+      const lastCollectionIndex = collection.length - 1;
+      if (collection[lastCollectionIndex][this.valueName] !== this.collectionOptions.addCustomLastEntry[this.valueName]) {
+        collection.push(this.collectionOptions && this.collectionOptions.addCustomLastEntry);
+      }
     }
 
     // assign the collection to a temp variable before filtering/sorting the collection
@@ -550,7 +564,9 @@ export class SelectEditor implements Editor {
         let prefixText = option[this.labelPrefixName] || '';
         let suffixText = option[this.labelSuffixName] || '';
         let optionLabel = option[this.optionLabel] || '';
-        optionLabel = optionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
+        if (optionLabel && optionLabel.toString) {
+          optionLabel = optionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
+        }
 
         // also translate prefix/suffix if enableTranslateLabel is true and text is a string
         prefixText = (this.enableTranslateLabel && prefixText && typeof prefixText === 'string') ? this.i18n.tr(prefixText || ' ') : prefixText;
@@ -570,7 +586,12 @@ export class SelectEditor implements Editor {
           optionText = htmlEncode(sanitizedText);
         }
 
-        options += `<option value="${option[this.valueName]}" label="${optionLabel}">${optionText}</option>`;
+        // html text of each select option
+        let optionValue = option[this.valueName];
+        if (optionValue === undefined || optionValue === null) {
+          optionValue = '';
+        }
+        options += `<option value="${optionValue}" label="${optionLabel}">${optionText}</option>`;
       });
     }
     return `<select id="${this.elementName}" class="ms-filter search-filter editor-${columnId}" ${this.isMultipleSelect ? 'multiple="multiple"' : ''}>${options}</select>`;

--- a/src/aurelia-slickgrid/filters/__tests__/selectFilter.spec.ts
+++ b/src/aurelia-slickgrid/filters/__tests__/selectFilter.spec.ts
@@ -163,12 +163,12 @@ describe('SelectFilter', () => {
   });
 
   it('should throw an error when trying to call init without any arguments', () => {
-    expect(() => filter.init(null, true)).toThrowError('[Aurelia-SlickGrid] A filter must always have an "init()" with valid arguments.');
+    expect(() => filter.init(null)).toThrowError('[Aurelia-SlickGrid] A filter must always have an "init()" with valid arguments.');
   });
 
   it('should throw an error when there is no collection provided in the filter property', (done) => {
     try {
-      filter.init(filterArguments, true);
+      filter.init(filterArguments);
     } catch (e) {
       expect(e.message).toContain(`[Aurelia-SlickGrid] You need to pass a "collection" (or "collectionAsync") for the MultipleSelect/SingleSelect Filter to work correctly.`);
       done();
@@ -179,7 +179,7 @@ describe('SelectFilter', () => {
     try {
       // @ts-ignore
       mockColumn.filter.collection = { hello: 'world' };
-      filter.init(filterArguments, true);
+      filter.init(filterArguments);
     } catch (e) {
       expect(e.message).toContain(`The "collection" passed to the Select Filter is not a valid array.`);
       done();
@@ -189,7 +189,7 @@ describe('SelectFilter', () => {
   it('should throw an error when collection is not a valid value/label pair array', (done) => {
     try {
       mockColumn.filter.collection = [{ hello: 'world' }];
-      filter.init(filterArguments, true);
+      filter.init(filterArguments);
     } catch (e) {
       expect(e.message).toContain(`[select-filter] A collection with value/label (or value/labelKey when using Locale) is required to populate the Select list`);
       done();
@@ -202,7 +202,7 @@ describe('SelectFilter', () => {
       mockColumn.filter.enableTranslateLabel = true;
       mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
       filter = new SelectFilter(bindingEngine, collectionService, i18n);
-      filter.init(filterArguments, true);
+      filter.init(filterArguments);
     } catch (e) {
       expect(e.toString()).toContain(`[select-filter] The i18n Service is required for the Select Filter to work correctly when "enableTranslateLabel" is set.`);
       done();
@@ -211,7 +211,7 @@ describe('SelectFilter', () => {
 
   it('should initialize the filter', () => {
     mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterCount = divContainer.querySelectorAll('select.ms-filter.search-filter.filter-gender').length;
 
     expect(spyGetHeaderRow).toHaveBeenCalled();
@@ -221,7 +221,7 @@ describe('SelectFilter', () => {
   it('should be a multiple-select filter by default when it is not specified in the constructor', () => {
     mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
     filter = new SelectFilter(bindingEngine, collectionService, i18n);
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterCount = divContainer.querySelectorAll('select.ms-filter.search-filter.filter-gender').length;
 
     expect(spyGetHeaderRow).toHaveBeenCalled();
@@ -234,7 +234,7 @@ describe('SelectFilter', () => {
     mockColumn.filter.placeholder = testValue;
     mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterElm = divContainer.querySelector<HTMLSpanElement>('.ms-filter.search-filter.filter-gender .placeholder');
 
     expect(filterElm.innerHTML).toBe(testValue);
@@ -244,7 +244,7 @@ describe('SelectFilter', () => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
     mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
@@ -264,7 +264,7 @@ describe('SelectFilter', () => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     mockColumn.filter.collection = ['male', 'female'];
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
@@ -285,7 +285,7 @@ describe('SelectFilter', () => {
     mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
@@ -302,7 +302,7 @@ describe('SelectFilter', () => {
 
   it('should have same value in "getValues" after being set in "setValues"', () => {
     mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     filter.setValues('female');
     const values = filter.getValues();
 
@@ -312,7 +312,7 @@ describe('SelectFilter', () => {
 
   it('should have empty array returned from "getValues" when nothing is set', () => {
     mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const values = filter.getValues();
 
     expect(values).toEqual([]);
@@ -331,7 +331,7 @@ describe('SelectFilter', () => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     filterArguments.searchTerms = ['female'];
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
@@ -350,7 +350,7 @@ describe('SelectFilter', () => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     filterArguments.searchTerms = [false];
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
@@ -369,7 +369,7 @@ describe('SelectFilter', () => {
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
     filterArguments.searchTerms = [2];
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
@@ -388,7 +388,7 @@ describe('SelectFilter', () => {
     mockColumn.filter.collection = ['male', 'female'];
 
     filterArguments.searchTerms = ['female'];
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
@@ -411,7 +411,7 @@ describe('SelectFilter', () => {
       }
     };
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
@@ -436,7 +436,7 @@ describe('SelectFilter', () => {
       },
     };
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
@@ -453,7 +453,7 @@ describe('SelectFilter', () => {
       collectionFilterBy: { operator: OperatorType.equal, value: 'other' }
     };
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
@@ -472,7 +472,7 @@ describe('SelectFilter', () => {
       customStructure: { value: 'value', label: 'description', },
     };
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
@@ -492,7 +492,7 @@ describe('SelectFilter', () => {
       customStructure: { value: 'value', label: 'description', },
     };
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
@@ -510,7 +510,7 @@ describe('SelectFilter', () => {
       customStructure: { value: 'value', label: 'description', },
     };
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
@@ -529,7 +529,7 @@ describe('SelectFilter', () => {
       customStructure: { value: 'value', label: 'description', },
     };
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
 
     setTimeout(() => {
       const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
@@ -550,7 +550,7 @@ describe('SelectFilter', () => {
     mockColumn.filter.collectionAsync = new Promise((resolve) => setTimeout(() => resolve(mockCollection)));
 
     filterArguments.searchTerms = ['female'];
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
 
     setTimeout(() => {
       const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
@@ -574,7 +574,7 @@ describe('SelectFilter', () => {
     mockColumn.filter.collectionAsync = new Promise((resolve) => setTimeout(() => resolve({ content: mockCollection })));
 
     filterArguments.searchTerms = ['female'];
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
 
     setTimeout(() => {
       const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
@@ -604,7 +604,7 @@ describe('SelectFilter', () => {
     mockColumn.filter.collectionAsync = http.fetch('/api', { method: 'GET' });
 
     filterArguments.searchTerms = ['female'];
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
 
     setTimeout(() => {
       const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
@@ -625,7 +625,7 @@ describe('SelectFilter', () => {
   it('should throw an error when "collectionAsync" Promise does not return a valid array', (done) => {
     const promise = new Promise((resolve) => setTimeout(() => resolve({ hello: 'world' })));
     mockColumn.filter.collectionAsync = promise;
-    filter.init(filterArguments, true).catch((e) => {
+    filter.init(filterArguments).catch((e) => {
       expect(e.toString()).toContain(`Something went wrong while trying to pull the collection from the "collectionAsync" call in the Select Filter, the collection is not a valid array.`);
       done();
     });
@@ -642,7 +642,7 @@ describe('SelectFilter', () => {
       },
     };
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
@@ -662,7 +662,7 @@ describe('SelectFilter', () => {
       },
     };
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLSpanElement>(`[name=filter-gender].ms-drop ul>li span`);
     filterBtnElm.click();
@@ -677,7 +677,7 @@ describe('SelectFilter', () => {
     mockColumn.filter.collectionOptions = { addBlankEntry: true };
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
     const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
@@ -687,7 +687,50 @@ describe('SelectFilter', () => {
 
     expect(filterListElm.length).toBe(3);
     expect(filterFilledElms.length).toBe(1);
+    expect(filterListElm[0].value).toBe('');
     expect(filterListElm[2].checked).toBe(true);
+    expect(spyCallback).toHaveBeenCalledWith(undefined, { columnDef: mockColumn, operator: 'IN', searchTerms: ['female'], shouldTriggerQuery: true });
+  });
+
+  it('should create the multi-select filter with a custom entry at the beginning of the collection when "addCustomFirstEntry" is provided in the "collectionOptions" property', () => {
+    filterArguments.searchTerms = ['female'];
+    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    mockColumn.filter.collectionOptions = { addCustomFirstEntry: { value: null, label: '' } };
+    const spyCallback = jest.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
+    const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
+    const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+    filterBtnElm.click();
+    filterOkElm.click();
+
+    expect(filterListElm.length).toBe(3);
+    expect(filterFilledElms.length).toBe(1);
+    expect(filterListElm[0].value).toBe('');
+    expect(filterListElm[2].checked).toBe(true);
+    expect(spyCallback).toHaveBeenCalledWith(undefined, { columnDef: mockColumn, operator: 'IN', searchTerms: ['female'], shouldTriggerQuery: true });
+  });
+
+  it('should create the multi-select filter with a custom entry at the end of the collection when "addCustomFirstEntry" is provided in the "collectionOptions" property', () => {
+    filterArguments.searchTerms = ['female'];
+    mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
+    mockColumn.filter.collectionOptions = { addCustomLastEntry: { value: null, label: '' } };
+    const spyCallback = jest.spyOn(filterArguments, 'callback');
+
+    filter.init(filterArguments);
+    const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
+    const filterListElm = divContainer.querySelectorAll<HTMLInputElement>(`[name=filter-gender].ms-drop ul>li input[type=checkbox]`);
+    const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
+    const filterOkElm = divContainer.querySelector<HTMLButtonElement>(`[name=filter-gender].ms-drop .ms-ok-button`);
+    filterBtnElm.click();
+    filterOkElm.click();
+
+    expect(filterListElm.length).toBe(3);
+    expect(filterFilledElms.length).toBe(1);
+    expect(filterListElm[2].value).toBe('');
+    expect(filterListElm[1].checked).toBe(true);
     expect(spyCallback).toHaveBeenCalledWith(undefined, { columnDef: mockColumn, operator: 'IN', searchTerms: ['female'], shouldTriggerQuery: true });
   });
 
@@ -696,7 +739,7 @@ describe('SelectFilter', () => {
     mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     filter.clear();
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
 
@@ -710,7 +753,7 @@ describe('SelectFilter', () => {
     mockColumn.filter.collection = [{ value: 'male', label: 'male' }, { value: 'female', label: 'female' }];
     const spyCallback = jest.spyOn(filterArguments, 'callback');
 
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     filter.clear(false);
     const filterFilledElms = divContainer.querySelectorAll<HTMLDivElement>('.ms-parent.ms-filter.search-filter.filter-gender.filled');
 
@@ -733,7 +776,7 @@ describe('SelectFilter', () => {
     };
 
     filterArguments.searchTerms = ['male', 'female'];
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
 
     setTimeout(() => {
       const filterSelectAllElm = divContainer.querySelector<HTMLSpanElement>('.filter-gender .ms-select-all label span');
@@ -768,7 +811,7 @@ describe('SelectFilter', () => {
     };
 
     filterArguments.searchTerms = ['male', 'female'];
-    filter.init(filterArguments, true);
+    filter.init(filterArguments);
     setTimeout(() => {
       const filterSelectAllElm = divContainer.querySelector<HTMLSpanElement>('.filter-gender .ms-select-all label span');
       const filterBtnElm = divContainer.querySelector<HTMLButtonElement>('.ms-parent.ms-filter.search-filter.filter-gender button.ms-choice');
@@ -799,7 +842,7 @@ describe('SelectFilter', () => {
       enableCollectionWatch: true,
     };
 
-    await filter.init(filterArguments, true);
+    await filter.init(filterArguments);
     mockColumn.filter.collection = newCollection;
 
     setTimeout(() => {
@@ -819,7 +862,7 @@ describe('SelectFilter', () => {
       enableCollectionWatch: true,
     };
 
-    await filter.init(filterArguments, true);
+    await filter.init(filterArguments);
     mockColumn.filter.collection.push({ value: 'other', label: 'other' });
 
     setTimeout(() => {

--- a/src/aurelia-slickgrid/filters/selectFilter.ts
+++ b/src/aurelia-slickgrid/filters/selectFilter.ts
@@ -334,8 +334,21 @@ export class SelectFilter implements Filter {
 
     // user can optionally add a blank entry at the beginning of the collection
     // make sure however that it wasn't added more than once
-    if (this.collectionOptions && this.collectionOptions.addBlankEntry && Array.isArray(collection) && collection.length > 0 && collection[0][this.labelName] !== '') {
+    if (this.collectionOptions && this.collectionOptions.addBlankEntry && Array.isArray(collection) && collection.length > 0 && collection[0][this.valueName] !== '') {
       collection.unshift(this.createBlankEntry());
+    }
+
+    // user can optionally add his own custom entry at the beginning of the collection
+    if (this.collectionOptions && this.collectionOptions.addCustomFirstEntry && Array.isArray(collection) && collection.length > 0 && collection[0][this.valueName] !== this.collectionOptions.addCustomFirstEntry[this.valueName]) {
+      collection.unshift(this.collectionOptions.addCustomFirstEntry);
+    }
+
+    // user can optionally add his own custom entry at the end of the collection
+    if (this.collectionOptions && this.collectionOptions.addCustomLastEntry && Array.isArray(collection) && collection.length > 0) {
+      const lastCollectionIndex = collection.length - 1;
+      if (collection[lastCollectionIndex][this.valueName] !== this.collectionOptions.addCustomLastEntry[this.valueName]) {
+        collection.push(this.collectionOptions.addCustomLastEntry);
+      }
     }
 
     // assign the collection to a temp variable before filtering/sorting the collection
@@ -392,7 +405,9 @@ export class SelectFilter implements Filter {
           let prefixText = option[this.labelPrefixName] || '';
           let suffixText = option[this.labelSuffixName] || '';
           let optionLabel = option.hasOwnProperty(this.optionLabel) ? option[this.optionLabel] : '';
-          optionLabel = optionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
+          if (optionLabel && optionLabel.toString) {
+            optionLabel = optionLabel.toString().replace(/\"/g, '\''); // replace double quotes by single quotes to avoid interfering with regular html
+          }
 
           // also translate prefix/suffix if enableTranslateLabel is true and text is a string
           prefixText = (this.enableTranslateLabel && isEnableTranslate && prefixText && typeof prefixText === 'string') ? this.i18n && this.i18n.tr && this.i18n.getLocale && this.i18n.getLocale() && this.i18n.tr(prefixText || ' ') : prefixText;
@@ -412,7 +427,11 @@ export class SelectFilter implements Filter {
           }
 
           // html text of each select option
-          options += `<option value="${option[this.valueName]}" label="${optionLabel}" ${selected}>${optionText}</option>`;
+          let optionValue = option[this.valueName];
+          if (optionValue === undefined || optionValue === null) {
+            optionValue = '';
+          }
+          options += `<option value="${optionValue}" label="${optionLabel}" ${selected}>${optionText}</option>`;
 
           // if there's a search term, we will add the "filled" class for styling purposes
           // on a single select, we'll also make sure the single value is not an empty string to consider this being filled

--- a/src/aurelia-slickgrid/models/collectionOption.interface.ts
+++ b/src/aurelia-slickgrid/models/collectionOption.interface.ts
@@ -3,10 +3,16 @@ import { FilterMultiplePassTypeString } from './filterMultiplePassTypeString';
 
 export interface CollectionOption {
   /**
-   * Optionally add a blank entry to the beginning of the collection.
+   * Optionally add a blank entry to the beginning of the collection (only used by the SingleSelect/MultipleSelect Editor or Filter).
    * Useful when we want to return all data by setting an empty filter that might not exist in the original collection
    */
   addBlankEntry?: boolean;
+
+  /** Optionally add a custom entry at the beginning of the collection (only used by the SingleSelect/MultipleSelect Editor or Filter). */
+  addCustomFirstEntry?: any;
+
+  /** Optionally add a custom entry at the end of the collection (only used by the SingleSelect/MultipleSelect Editor or Filter). */
+  addCustomLastEntry?: any;
 
   /** @deprecated please use "collectionInsideObjectProperty" instead */
   collectionInObjectProperty?: string;


### PR DESCRIPTION
- add 2 new methods (`addCustomFirstEntry`, `addCustomLastEntry`) to optionally add entry on both end of the collection