### PR TITLE
fix(filters): disregard time when filtering date only format

### DIFF
--- a/src/aurelia-slickgrid/filter-conditions/__tests__/dateIsoFilterCondition.spec.ts
+++ b/src/aurelia-slickgrid/filter-conditions/__tests__/dateIsoFilterCondition.spec.ts
@@ -32,6 +32,19 @@ describe('dateIsoFilterCondition method', () => {
     expect(output).toBe(true);
   });
 
+  it('should return True when input value provided is equal to the searchTerms, even when passing Date+Time in cell value, and is called by "executeMappedCondition"', () => {
+    const options = { dataKey: '', operator: 'EQ', fieldType: FieldType.dateIso, cellValue: new Date('1993-12-25T14:02:02.103Z'), searchTerms: ['1993-12-25'] } as FilterConditionOption;
+    const output = executeMappedCondition(options);
+    expect(output).toBe(true);
+  });
+
+  it('should return True when input value provided is equal to the searchTerms, even when passing Date+Time in search value, and is called by "executeMappedCondition"', () => {
+    // @ts-ignore
+    const options = { dataKey: '', operator: 'EQ', fieldType: FieldType.dateIso, cellValue: '1993-12-25', searchTerms: [new Date('1993-12-25T14:02:02.103Z')] } as FilterConditionOption;
+    const output = executeMappedCondition(options);
+    expect(output).toBe(true);
+  });
+
   it('should return False when cell value is not the same value as the searchTerm', () => {
     const options = { dataKey: '', operator: 'EQ', fieldType: FieldType.dateIso, cellValue: '1993-12-25', searchTerms: ['2003-03-14'] } as FilterConditionOption;
     const output = executeMappedCondition(options);

--- a/src/aurelia-slickgrid/filter-conditions/executeMappedCondition.ts
+++ b/src/aurelia-slickgrid/filter-conditions/executeMappedCondition.ts
@@ -83,7 +83,7 @@ function executeAssociatedDateCondition(options: FilterConditionOption): boolean
   // cell value in moment format
   const dateCell = moment(options.cellValue, FORMAT, true);
 
-  if (searchTerms.length === 2 || ((searchTerms[0] as string).indexOf('..') > 0)) {
+  if (searchTerms.length === 2 || (typeof searchTerms[0] === 'string' && (searchTerms[0] as string).indexOf('..') > 0)) {
     isRangeSearch = true;
     const searchValues = (searchTerms.length === 2) ? searchTerms : (searchTerms[0] as string).split('..');
     const searchValue1 = (Array.isArray(searchValues) && searchValues[0] || '') as Date | string;
@@ -105,12 +105,18 @@ function executeAssociatedDateCondition(options: FilterConditionOption): boolean
     dateSearch1 = moment(searchTerms[0] as Date | string, FORMAT, true);
   }
 
+  // when comparing with Dates only (without time), we need to disregard the time portion, we can do so by setting our time to start at midnight
+  // ref, see https://stackoverflow.com/a/19699447/1212166
+  const dateCellTimestamp = FORMAT.toLowerCase().includes('h') ? parseInt(dateCell.format('X'), 10) : parseInt(dateCell.clone().startOf('day').format('X'), 10);
+
   // run the filter condition with date in Unix Timestamp format
   if (isRangeSearch) {
     const isInclusive = options.operator && options.operator === OperatorType.rangeInclusive;
-    const resultCondition1 = testFilterCondition((isInclusive ? '>=' : '>'), parseInt(dateCell.format('X'), 10), parseInt(dateSearch1.format('X'), 10));
-    const resultCondition2 = testFilterCondition((isInclusive ? '<=' : '<'), parseInt(dateCell.format('X'), 10), parseInt(dateSearch2.format('X'), 10));
+    const resultCondition1 = testFilterCondition((isInclusive ? '>=' : '>'), dateCellTimestamp, parseInt(dateSearch1.format('X'), 10));
+    const resultCondition2 = testFilterCondition((isInclusive ? '<=' : '<'), dateCellTimestamp, parseInt(dateSearch2.format('X'), 10));
     return (resultCondition1 && resultCondition2);
   }
-  return testFilterCondition(options.operator || '==', parseInt(dateCell.format('X'), 10), parseInt(dateSearch1.format('X'), 10));
+
+  const dateSearchTimestamp1 = FORMAT.toLowerCase().includes('h') ? parseInt(dateSearch1.format('X'), 10) : parseInt(dateSearch1.clone().startOf('day').format('X'), 10);
+  return testFilterCondition(options.operator || '==', dateCellTimestamp, dateSearchTimestamp1);
 };

--- a/test/tsconfig.spec.json
+++ b/test/tsconfig.spec.json
@@ -1,6 +1,5 @@
 
 {
-  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../out-tsc/spec",
     "baseUrl": "./",


### PR DESCRIPTION
- if we pass a Date object that has time and we use a dateIso format, or any other without time, we should disregard the time portion when using the CompoundDate Filter