### PR TITLE
fix(select): make a collection array copy to avoid change by ref

### DIFF
--- a/src/aurelia-slickgrid/editors/selectEditor.ts
+++ b/src/aurelia-slickgrid/editors/selectEditor.ts
@@ -182,7 +182,7 @@ export class SelectEditor implements Editor {
     const isIncludingPrefixSuffix = this.collectionOptions && this.collectionOptions.includePrefixSuffixToSelectedValues || false;
 
     return this.collection
-      .filter(c => elmValue.indexOf(c.hasOwnProperty(this.valueName) && c[this.valueName].toString()) !== -1)
+      .filter(c => elmValue.indexOf(c.hasOwnProperty(this.valueName) && c[this.valueName] !== null && c[this.valueName].toString()) !== -1)
       .map(c => {
         const labelText = c[this.valueName];
         let prefixText = c[this.labelPrefixName] || '';
@@ -225,7 +225,7 @@ export class SelectEditor implements Editor {
       // collection of label/value pair
       const separatorBetweenLabels = this.collectionOptions && this.collectionOptions.separatorBetweenTextLabels || '';
       const isIncludingPrefixSuffix = this.collectionOptions && this.collectionOptions.includePrefixSuffixToSelectedValues || false;
-      const itemFound = findOrDefault(this.collection, (c: any) => c.hasOwnProperty(this.valueName) && c[this.valueName].toString() === elmValue);
+      const itemFound = findOrDefault(this.collection, (c: any) => c.hasOwnProperty(this.valueName) && c[this.valueName] !== null && c[this.valueName].toString() === elmValue);
 
       // is the field a complex object, "address.streetNumber"
       const isComplexObject = fieldName && fieldName.indexOf('.') > 0;
@@ -495,13 +495,19 @@ export class SelectEditor implements Editor {
     return outputCollection;
   }
 
-  protected renderDomElement(collection: any[]) {
-    if (!Array.isArray(collection) && this.collectionOptions && (this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty)) {
+  protected renderDomElement(inputCollection: any[]) {
+    if (!Array.isArray(inputCollection) && this.collectionOptions && (this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty)) {
       const collectionInsideObjectProperty = this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty;
-      collection = getDescendantProperty(collection, collectionInsideObjectProperty);
+      inputCollection = getDescendantProperty(inputCollection, collectionInsideObjectProperty);
     }
-    if (!Array.isArray(collection)) {
+    if (!Array.isArray(inputCollection)) {
       throw new Error('The "collection" passed to the Select Editor is not a valid array.');
+    }
+
+    // make a copy of the collection so that we don't impact SelectFilter, this could happen when calling "addBlankEntry" or "addCustomFirstEntry"
+    let collection: any[] = [];
+    if (inputCollection.length > 0) {
+      collection = [...inputCollection];
     }
 
     // user can optionally add a blank entry at the beginning of the collection

--- a/src/aurelia-slickgrid/filters/selectFilter.ts
+++ b/src/aurelia-slickgrid/filters/selectFilter.ts
@@ -323,13 +323,19 @@ export class SelectFilter implements Filter {
     }
   }
 
-  renderDomElement(collection: any[]) {
-    if (!Array.isArray(collection) && this.collectionOptions && (this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty)) {
+  protected renderDomElement(inputCollection: any[]) {
+    if (!Array.isArray(inputCollection) && this.collectionOptions && (this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty)) {
       const collectionInsideObjectProperty = this.collectionOptions.collectionInsideObjectProperty || this.collectionOptions.collectionInObjectProperty;
-      collection = getDescendantProperty(collection, collectionInsideObjectProperty || '');
+      inputCollection = getDescendantProperty(inputCollection, collectionInsideObjectProperty);
     }
-    if (!Array.isArray(collection)) {
+    if (!Array.isArray(inputCollection)) {
       throw new Error('The "collection" passed to the Select Filter is not a valid array.');
+    }
+
+    // make a copy of the collection so that we don't impact SelectEditor, this could happen when calling "addBlankEntry" or "addCustomFirstEntry"
+    let collection: any[] = [];
+    if (inputCollection.length > 0) {
+      collection = [...inputCollection];
     }
 
     // user can optionally add a blank entry at the beginning of the collection

--- a/src/examples/slickgrid/example6.ts
+++ b/src/examples/slickgrid/example6.ts
@@ -210,8 +210,7 @@ export class Example6 {
   }
 
   /**
-   * Calling your GraphQL backend server should always return a Promise of type GraphqlPaginatedResult
-   *
+   * Calling your GraphQL backend server should always return a Promise or Observable of type GraphqlPaginatedResult (or GraphqlResult without Pagination)
    * @param query
    * @return Promise<GraphqlPaginatedResult>
    */


### PR DESCRIPTION
- when using "addBlankEntry" or "addCustomFirstEntry", the SelectFilter was affecting SelectEditor (and vice versa) because the collection was used by ref, so to fix this we can just do a copy of the collection before dealing with it