### PR TITLE
feat(options): hideHeaderFilterRow option

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -277,6 +277,10 @@ export class AureliaSlickgridCustomElement {
       this.sharedService.hideHeaderRowAfterPageLoad = this._hideHeaderRowAfterPageLoad;
     }
 
+    if (this.gridOptions.hideHeaderFilterRow) {
+      this.filterService.toggleHeaderFilterRow();
+    }
+
     // publish & dispatch certain events
     this.globalEa.publish('onGridCreated', this.grid);
     this.dispatchCustomEvent(`${DEFAULT_AURELIA_EVENT_PREFIX}-on-grid-created`, this.grid);

--- a/src/aurelia-slickgrid/global-grid-options.ts
+++ b/src/aurelia-slickgrid/global-grid-options.ts
@@ -162,6 +162,7 @@ export const GlobalGridOptions: Partial<GridOption> = {
     hideSortCommandsDivider: false
   },
   headerRowHeight: 35,
+  hideHeaderFilterRow: false,
   multiColumnSort: true,
   numberedMultiColumnSort: true,
   tristateMultiColumnSort: false,

--- a/src/aurelia-slickgrid/models/gridOption.interface.ts
+++ b/src/aurelia-slickgrid/models/gridOption.interface.ts
@@ -328,6 +328,8 @@ export interface GridOption {
   /** Header menu options */
   headerMenu?: HeaderMenu;
 
+  hideHeaderFilterRow?: boolean;
+
   /** I18N translation service instance */
   i18n?: I18N;
 

--- a/src/examples/slickgrid/example29.ts
+++ b/src/examples/slickgrid/example29.ts
@@ -32,7 +32,9 @@ export class Example29 {
     ];
     this.gridOptions = {
       enableAutoResize: false,
-      enableSorting: true
+      enableSorting: true,
+      enableFiltering: true,
+      hideHeaderFilterRow: true
     };
   }
 


### PR DESCRIPTION
It would be great if we could have an option to automatically hide the filter row in the header if filtering is turned on. I wasn't able to find anything and have implemented the new option via the `filterService.toggleHeaderFilterRow()` method which of course isn't nice since you see the animation right after loading.

But hopefully this Draft gives you an idea what would be wished.