### PR TITLE
refactor(typings): added new column generic

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "ts-node": "^8.10.2",
     "tslint": "^6.1.3",
     "typedoc": "^0.19.1",
-    "typescript": "^3.9.7",
+    "typescript": "^4.1.0-dev.20201009",
     "uglify-js": "^3.10.0",
     "url-loader": "0.5.8",
     "vinyl-fs": "^3.0.3",

--- a/src/aurelia-slickgrid/models/column.interface.ts
+++ b/src/aurelia-slickgrid/models/column.interface.ts
@@ -11,6 +11,16 @@ import { MenuCommandItem } from './menuCommandItem.interface';
 import { OnEventArgs } from './onEventArgs.interface';
 import { Sorter } from './sorter.interface';
 
+type PathsToStringProps<T> = T extends string | number | boolean | Date ? [] : {
+  [K in Extract<keyof T, string>]: [K, ...PathsToStringProps<T[K]>]
+}[Extract<keyof T, string>];
+
+type Join<T extends any[], D extends string> =
+  T extends [] ? never :
+  T extends [infer F] ? F :
+  T extends [infer F, ...infer R] ?
+  F extends string ? string extends F ? string : `${F}${D}${Join<R, D>}` : never : string;
+
 export interface Column<T = any> {
   /** async background post-rendering formatter */
   asyncPostRender?: (domCellNode: any, row: number, dataContext: T, columnDef: Column) => void;
@@ -67,7 +77,7 @@ export interface Column<T = any> {
    * Export with a Custom Formatter, useful when we want to use a different Formatter for the export.
    * For example, we might have a boolean field with "Formatters.checkmark" but we would like see a translated value for (True/False).
    */
-  exportCustomFormatter?: Formatter;
+  exportCustomFormatter?: Formatter<T>;
 
   /**
    * Export with a Custom Group Total Formatter, useful when we want to use a different Formatter for the export.
@@ -96,7 +106,7 @@ export interface Column<T = any> {
    * NOTE: a field with dot notation (.) will be considered a complex object.
    * For example: { id: 'Users', field: 'user.firstName' }
    */
-  field: string;
+  field: Join<PathsToStringProps<T>, '.'>;
 
   /**
    * Only used by Backend Services since the query is built using the column definitions, this is a way to pass extra properties to the backend query.
@@ -121,7 +131,7 @@ export interface Column<T = any> {
   focusable?: boolean;
 
   /** Formatter function that can be used to change and format certain column(s) in the grid */
-  formatter?: Formatter;
+  formatter?: Formatter<T>;
 
   /** Grouping option used by a Draggable Grouping Column */
   grouping?: Grouping;

--- a/src/aurelia-slickgrid/models/formatter.interface.ts
+++ b/src/aurelia-slickgrid/models/formatter.interface.ts
@@ -1,4 +1,4 @@
 import { Column } from './column.interface';
 import { FormatterResultObject } from './formatterResultObject.interface';
 
-export declare type Formatter = (row: number, cell: number, value: any, columnDef?: Column, dataContext?: any, grid?: any) => string | FormatterResultObject;
+export declare type Formatter<T = any> = (row: number, cell: number, value: any, columnDef?: Column, dataContext?: T, grid?: any) => string | FormatterResultObject;

--- a/src/examples/slickgrid/example1.ts
+++ b/src/examples/slickgrid/example1.ts
@@ -1,23 +1,6 @@
-import { Column, GridOption, Formatters, Formatter } from '../../aurelia-slickgrid';
+import { Column, GridOption, Formatters } from '../../aurelia-slickgrid';
 
 const NB_ITEMS = 995;
-
-interface DataItem {
-  id: number;
-  title: string;
-  duration: string;
-  percentComplete: number;
-  start: Date;
-  finish: Date;
-  effortDriven: boolean;
-  foo: {
-    bar: string;
-  }
-}
-
-const upperCaseFormatter: Formatter<DataItem> = (_, __, value, col, item) => {
-  return `${col.field}, ${item.title}`;
-}
 
 export class Example1 {
   title = 'Example 1: Basic Grids';
@@ -25,7 +8,7 @@ export class Example1 {
 
   gridOptions1: GridOption;
   gridOptions2: GridOption;
-  columnDefinitions1: Column<DataItem>[];
+  columnDefinitions1: Column[];
   columnDefinitions2: Column[];
   dataset1: any[];
   dataset2: any[];
@@ -44,22 +27,12 @@ export class Example1 {
   /* Define grid Options and Columns */
   defineGrids() {
     this.columnDefinitions1 = [
-      { id: 'title', name: 'Title', field: 'title', sortable: true, minWidth: 100, formatter: upperCaseFormatter },
+      { id: 'title', name: 'Title', field: 'title', sortable: true, minWidth: 100 },
       { id: 'duration', name: 'Duration (days)', field: 'duration', sortable: true, minWidth: 100 },
       { id: '%', name: '% Complete', field: 'percentComplete', sortable: true, minWidth: 100 },
       { id: 'start', name: 'Start', field: 'start', formatter: Formatters.dateIso },
       { id: 'finish', name: 'Finish', field: 'finish', formatter: Formatters.dateIso },
-      {
-        id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven', sortable: true, minWidth: 100,
-        formatter: (row: number, cell: number, value: any, columnDef: Column, dataContext, grid) => {
-          return `<span style="margin-left: 5px">
-              ${dataContext.effortDriven} ->
-              <button class="btn btn-xs btn-default">
-                <i class="fa ${value ? 'fa-check-circle' : 'fa-circle-thin'} fa-lg" style="color: ${value ? 'black' : 'lavender'}"></i>
-              </button>
-            </span>`;
-        }
-      }
+      { id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven', sortable: true, minWidth: 100 }
     ];
     this.gridOptions1 = {
       enableAutoResize: false,

--- a/src/examples/slickgrid/example1.ts
+++ b/src/examples/slickgrid/example1.ts
@@ -1,6 +1,23 @@
-import { Column, GridOption, Formatters } from '../../aurelia-slickgrid';
+import { Column, GridOption, Formatters, Formatter } from '../../aurelia-slickgrid';
 
 const NB_ITEMS = 995;
+
+interface DataItem {
+  id: number;
+  title: string;
+  duration: string;
+  percentComplete: number;
+  start: Date;
+  finish: Date;
+  effortDriven: boolean;
+  foo: {
+    bar: string;
+  }
+}
+
+const upperCaseFormatter: Formatter<DataItem> = (_, __, value, col, item) => {
+  return `${col.field}, ${item.title}`;
+}
 
 export class Example1 {
   title = 'Example 1: Basic Grids';
@@ -8,7 +25,7 @@ export class Example1 {
 
   gridOptions1: GridOption;
   gridOptions2: GridOption;
-  columnDefinitions1: Column[];
+  columnDefinitions1: Column<DataItem>[];
   columnDefinitions2: Column[];
   dataset1: any[];
   dataset2: any[];
@@ -27,12 +44,22 @@ export class Example1 {
   /* Define grid Options and Columns */
   defineGrids() {
     this.columnDefinitions1 = [
-      { id: 'title', name: 'Title', field: 'title', sortable: true, minWidth: 100 },
+      { id: 'title', name: 'Title', field: 'title', sortable: true, minWidth: 100, formatter: upperCaseFormatter },
       { id: 'duration', name: 'Duration (days)', field: 'duration', sortable: true, minWidth: 100 },
       { id: '%', name: '% Complete', field: 'percentComplete', sortable: true, minWidth: 100 },
       { id: 'start', name: 'Start', field: 'start', formatter: Formatters.dateIso },
       { id: 'finish', name: 'Finish', field: 'finish', formatter: Formatters.dateIso },
-      { id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven', sortable: true, minWidth: 100 }
+      {
+        id: 'effort-driven', name: 'Effort Driven', field: 'effortDriven', sortable: true, minWidth: 100,
+        formatter: (row: number, cell: number, value: any, columnDef: Column, dataContext, grid) => {
+          return `<span style="margin-left: 5px">
+              ${dataContext.effortDriven} ->
+              <button class="btn btn-xs btn-default">
+                <i class="fa ${value ? 'fa-check-circle' : 'fa-circle-thin'} fa-lg" style="color: ${value ? 'black' : 'lavender'}"></i>
+              </button>
+            </span>`;
+        }
+      }
     ];
     this.gridOptions1 = {
       enableAutoResize: false,

--- a/src/examples/slickgrid/example2.ts
+++ b/src/examples/slickgrid/example2.ts
@@ -8,13 +8,26 @@ import {
   SelectedRange,
 } from '../../aurelia-slickgrid';
 
+interface DataItem {
+  id: number;
+  title: string;
+  duration: string;
+  percentComplete: number;
+  percentComplete2: number;
+  start: Date;
+  finish: Date;
+  effortDriven: boolean;
+  phone: string;
+  completed: number;
+}
+
 // create my custom Formatter with the Formatter type
-const myCustomCheckmarkFormatter: Formatter = (row, cell, value, columnDef, dataContext) => {
+const myCustomCheckmarkFormatter: Formatter<DataItem> = (row, cell, value, columnDef, dataContext) => {
   // you can return a string of a object (of type FormatterResultObject), the 2 types are shown below
   return value ? `<i class="fa fa-fire red" aria-hidden="true"></i>` : { text: '<i class="fa fa-snowflake-o" aria-hidden="true"></i>', addClasses: 'lightblue', toolTip: 'Freezing' };
 };
 
-const customEnableButtonFormatter: Formatter = (row: number, cell: number, value: any, columnDef: Column, dataContext: any, grid: any) => {
+const customEnableButtonFormatter: Formatter<DataItem> = (row: number, cell: number, value: any, columnDef: Column, dataContext, grid) => {
   return `<span style="margin-left: 5px">
       <button class="btn btn-xs btn-default">
         <i class="fa ${value ? 'fa-check-circle' : 'fa-circle-thin'} fa-lg" style="color: ${value ? 'black' : 'lavender'}"></i>
@@ -39,7 +52,7 @@ export class Example2 {
 
   aureliaGrid: AureliaGridInstance;
   gridOptions: GridOption;
-  columnDefinitions: Column[];
+  columnDefinitions: Column<DataItem>[];
   dataset: any[];
   resizerPaused = false;
 
@@ -55,6 +68,7 @@ export class Example2 {
 
   /* Define grid Options and Columns */
   defineGrid() {
+    // the columns field property is type-safe, try to add a different string not representing one of DataItems properties
     this.columnDefinitions = [
       { id: 'title', name: 'Title', field: 'title', sortable: true, type: FieldType.string, width: 70 },
       { id: 'phone', name: 'Phone Number using mask', field: 'phone', sortable: true, type: FieldType.number, minWidth: 100, formatter: Formatters.mask, params: { mask: '(000) 000-0000' } },


### PR DESCRIPTION
Alright this is fantastic, but at the same time requires a feature from current TS nightly. So I wouldn't deem that rdy to merge right now.

Anyways, open up Example1.ts which I've modified as sample (it's just a draft) and try to use intellisense on:

* field property of a column in the definitions array
* the formatters item
* and I'm sure it would work for dataContext of asyncPostRenderer as well

EDIT:
don't forget to check out the dot notation

#### Intellisense in action
![image](https://user-images.githubusercontent.com/643976/95704256-3a347280-0c1e-11eb-95b7-ffb99e51a1b9.png)
![image](https://user-images.githubusercontent.com/643976/95702538-95646600-0c1a-11eb-8f1b-67b12f95acc3.png)
