### PR TITLE
feat(examples): display "No Data" when filtered dataset is empty

### DIFF
--- a/src/examples/slickgrid/example4.ts
+++ b/src/examples/slickgrid/example4.ts
@@ -299,5 +299,41 @@ export class Example4 {
         };
       });
     }
+
+    // display warning when there's no filtered data
+    this.showEmptyDataMessage('#grid4', 'No data to display', args.current === 0 /*, { color: 'red' } */);
+  }
+
+  /**
+    this.angularGrid.destroy();	   * Display a warning of empty data when the filtered dataset is empty
+   * NOTE: to make this code reusable, you could (should) move this code into a utility service
+   * @param gridSelector - HTML Selector of the grid <div>
+   * @param emptyMessage - empty data message to display in the <span>
+   * @param isShowing - are we showing the message?
+   * @param options - any styling options you'd like to pass like the text color
+   */
+  showEmptyDataMessage(gridSelector: string, emptyMessage: string, isShowing = true, options?: { color: string; class: 'empty-data' }) {
+    const emptyDataClassName = options && options.class || 'empty-data';
+    let emptyDataElm = document.querySelector<HTMLSpanElement>(`.${emptyDataClassName}`);
+    const gridElm = document.querySelector<HTMLDivElement>(gridSelector);
+
+    if (!emptyDataElm) {
+      emptyDataElm = document.createElement('span');
+      emptyDataElm.className = emptyDataClassName;
+      emptyDataElm.textContent = emptyMessage;
+      document.body.appendChild(emptyDataElm);
+    }
+
+    if (gridElm && emptyDataElm) {
+      if (isShowing) {
+        const gridPosition = gridElm.getBoundingClientRect();
+        emptyDataElm.style.top = `${gridPosition.top + 90}px`;
+        emptyDataElm.style.left = `${gridPosition.left + 10}px`;
+        emptyDataElm.style.color = options && options.color || 'lightsalmon';
+        emptyDataElm.style.zIndex = '9999';
+        emptyDataElm.style.position = 'absolute';
+      }
+      emptyDataElm.style.display = isShowing ? 'inline' : 'none';
+    }
   }
 }


### PR DESCRIPTION
- a quick demo on how to display an empty data message when there's no data to display
- ref SO [question](https://stackoverflow.com/questions/64663148/when-searching-the-data-in-the-filter-i-want-to-show-no-data-to-display-when-s)

![image](https://user-images.githubusercontent.com/643976/98015307-a42ddb00-1dca-11eb-95d2-15f56378a5f7.png)
