### PR TITLE
fix(backend): OData/GraphQL pagination should display warning on empty

### DIFF
--- a/src/aurelia-slickgrid/services/pagination.service.ts
+++ b/src/aurelia-slickgrid/services/pagination.service.ts
@@ -93,9 +93,7 @@ export class PaginationService {
     if (this._isLocalGrid && this.dataView) {
       this._eventHandler.subscribe(this.dataView.onPagingInfoChanged, (_e: Event, pagingInfo: { totalRows: number; pageNum: number; }) => {
         if (this._totalItems !== pagingInfo.totalRows) {
-          this._totalItems = pagingInfo.totalRows;
-          this._paginationOptions.totalItems = this._totalItems;
-          this.refreshPagination(false, false);
+          this.updateTotalItems(pagingInfo.totalRows);
         }
       });
       setTimeout(() => {
@@ -358,6 +356,14 @@ export class PaginationService {
   // --
   // private functions
   // --------------------
+
+  updateTotalItems(totalItems: number, triggerChangedEvent = false) {
+    this._totalItems = totalItems;
+    if (this._paginationOptions) {
+      this._paginationOptions.totalItems = totalItems;
+      this.refreshPagination(false, triggerChangedEvent);
+    }
+  }
 
   /**
    * When item is added or removed, we will refresh the numbers on the pagination however we won't trigger a backend change

--- a/src/examples/slickgrid/example5.html
+++ b/src/examples/slickgrid/example5.html
@@ -55,8 +55,12 @@
     </button>
   </div>
 
-  <aurelia-slickgrid grid-id="grid5" column-definitions.bind="columnDefinitions" grid-options.bind="gridOptions"
-                     dataset.bind="dataset" asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
+  <aurelia-slickgrid grid-id="grid5"
+                     column-definitions.bind="columnDefinitions"
+                     grid-options.bind="gridOptions"
+                     pagination-options.bind="paginationOptions"
+                     dataset.bind="dataset"
+                     asg-on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)"
                      asg-on-grid-state-changed.delegate="gridStateChanged($event.detail)">
   </aurelia-slickgrid>
 </template>

--- a/src/examples/slickgrid/example5.ts
+++ b/src/examples/slickgrid/example5.ts
@@ -12,6 +12,7 @@ import {
   OdataOption,
   OdataServiceApi,
   OperatorType,
+  Pagination,
 } from '../../aurelia-slickgrid';
 
 const defaultPageSize = 20;
@@ -41,6 +42,7 @@ export class Example5 {
   gridOptions: GridOption;
   dataset = [];
   metrics: Metrics;
+  paginationOptions: Pagination;
 
   isCountEnabled = true;
   odataVersion = 2;
@@ -140,8 +142,7 @@ export class Example5 {
     if (this.isCountEnabled) {
       countPropName = (this.odataVersion === 4) ? '@odata.count' : 'odata.count';
     }
-    this.gridOptions.pagination.totalItems = data[countPropName];
-    this.gridOptions = { ...{}, ...this.gridOptions };
+    this.paginationOptions = { ...this.gridOptions.pagination, totalItems: data[countPropName] };
     if (this.metrics) {
       this.metrics.totalItemCount = data[countPropName];
     }
@@ -163,7 +164,7 @@ export class Example5 {
    */
   getCustomerDataApiMock(query) {
     // the mock is returning a Promise, just like a WebAPI typically does
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       const queryParams = query.toLowerCase().split('&');
       let top: number;
       let skip = 0;

--- a/test/cypress/integration/example05.spec.js
+++ b/test/cypress/integration/example05.spec.js
@@ -516,6 +516,9 @@ describe('Example 5 - OData Grid', () => {
 
       // wait for the query to finish
       cy.get('[data-test=status]').should('contain', 'done');
+
+      cy.get('.slick-empty-data-warning:visible')
+        .contains('No data to display.');
     });
 
     it('should display page 0 of 0 but hide pagination from/to numbers when filtered data "xy" returns an empty dataset', () => {
@@ -553,6 +556,10 @@ describe('Example 5 - OData Grid', () => {
 
       // wait for the query to finish
       cy.get('[data-test=status]').should('contain', 'done');
+
+      cy.get('.slick-empty-data-warning')
+        .contains('No data to display.')
+        .should('not.be.visible');
 
       cy.window().then((win) => {
         expect(win.console.log).to.have.callCount(2);


### PR DESCRIPTION
- add a new paginationOptions getter/setter to avoid incomplete gridOptions passed by the OData result callback, merging the gridOptions was incomplete because it was only merging with the local gridOptions instead of the local+global gridOptions
- basically we won't be able to see the Empty Dataset Warning with OData unless we modified the code and use the new setter. Keeping the old code will still work but just won't display the warning when dataset is empty