### PR TITLE
feat(core): add enableMouseWheelScrollHandler grid option

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "jquery-ui-dist": "^1.12.1",
     "lodash.isequal": "^4.5.0",
     "moment-mini": "^2.24.0",
-    "slickgrid": "^2.4.31",
+    "slickgrid": "^2.4.32",
     "text-encoding-utf-8": "^1.0.2"
   },
   "devDependencies": {

--- a/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid-constructor.spec.ts
+++ b/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid-constructor.spec.ts
@@ -407,13 +407,13 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
     expect(spy).toHaveBeenNthCalledWith(5, 'onAfterGridDestroyed', true);
   });
 
-  it('should load jQuery mousewheel when using a frozen grid', () => {
-    const loadSpy = jest.spyOn(customElement, 'loadJqueryMousewheelDynamically');
+  it('should load enable jquery mousewheel scrolling when using a frozen grid', () => {
+    customElement.gridOptions.enableMouseWheelScrollHandler = undefined;
     customElement.gridOptions.frozenRow = 3;
 
     customElement.attached();
 
-    expect(loadSpy).toHaveBeenCalled();
+    expect(customElement.gridOptions.enableMouseWheelScrollHandler).toBeTrue();
   });
 
   describe('initialization method', () => {
@@ -702,7 +702,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
           },
           dataView: { syncGridSelection: true, syncGridSelectionWithBackendService: true },
           enableRowSelection: true
-        } as GridOption;
+        } as unknown as GridOption;
         customElement.bind();
         customElement.attached();
 
@@ -720,7 +720,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
           },
           dataView: { syncGridSelection: false, syncGridSelectionWithBackendService: true },
           enableRowSelection: true
-        } as GridOption;
+        } as unknown as GridOption;
         customElement.bind();
         customElement.attached();
 
@@ -738,7 +738,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
           },
           dataView: { syncGridSelection: true, syncGridSelectionWithBackendService: false },
           enableRowSelection: true
-        } as GridOption;
+        } as unknown as GridOption;
         customElement.bind();
         customElement.attached();
 
@@ -901,7 +901,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
         customElement.gridOptions = {
           backendServiceApi: {
             onInit: jest.fn(),
-            service: mockGraphqlService as BackendService,
+            service: mockGraphqlService as unknown as BackendService,
             preProcess: jest.fn(),
             postProcess: jest.fn(),
             process: jest.fn(),
@@ -1268,7 +1268,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
             process: () => new Promise((resolve) => resolve({ data: { users: { nodes: [], totalCount: 100 } } })),
           } as GraphqlServiceApi,
           pagination: mockPagination,
-        } as GridOption;
+        } as unknown as GridOption;
         customElement.bind();
         customElement.attached();
 
@@ -1286,7 +1286,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
             preProcess: () => jest.fn(),
             process: () => new Promise((resolve) => resolve('process resolved')),
           }
-        } as GridOption;
+        } as unknown as GridOption;
         customElement.bind();
         customElement.attached();
 
@@ -1304,7 +1304,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
             preProcess: () => jest.fn(),
             process: () => new Promise((resolve) => resolve('process resolved')),
           }
-        } as GridOption;
+        } as unknown as GridOption;
         customElement.bind();
         customElement.attached();
 
@@ -1336,7 +1336,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
             preProcess: () => jest.fn(),
             process: () => new Promise((resolve) => resolve('process resolved')),
           }
-        } as GridOption;
+        } as unknown as GridOption;
         customElement.bind();
         customElement.attached();
 
@@ -1355,7 +1355,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
             preProcess: () => jest.fn(),
             process: () => new Promise((resolve) => resolve('process resolved')),
           }
-        } as GridOption;
+        } as unknown as GridOption;
         customElement.bind();
         customElement.attached();
 
@@ -1716,7 +1716,7 @@ describe('Aurelia-Slickgrid Custom Component instantiated via Constructor', () =
       it('should call the backend service API to refresh the dataset', (done) => {
         customElement.gridOptions.enablePagination = true;
         customElement.gridOptions.backendServiceApi = {
-          service: mockGraphqlService as BackendService,
+          service: mockGraphqlService as unknown as BackendService,
           process: jest.fn(),
         };
 

--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -3,6 +3,7 @@
 import * as $ from 'jquery';
 import 'jquery-ui-dist/jquery-ui';
 import 'slickgrid/lib/jquery.event.drag-2.3.0';
+import 'slickgrid/lib/jquery.mousewheel';
 import 'slickgrid/slick.core';
 import 'slickgrid/slick.dataview';
 import 'slickgrid/slick.grid';
@@ -181,8 +182,9 @@ export class AureliaSlickgridCustomElement {
   }
 
   initialization() {
-    if (this.gridOptions && (this.gridOptions.frozenColumn !== undefined && this.gridOptions.frozenColumn >= 0) || (this.gridOptions.frozenRow !== undefined && this.gridOptions.frozenRow >= 0)) {
-      this.loadJqueryMousewheelDynamically();
+    // when detecting a frozen grid, we'll automatically enable the mousewheel scroll handler so that we can scroll from both left/right frozen containers
+    if (this.gridOptions && ((this.gridOptions.frozenRow !== undefined && this.gridOptions.frozenRow >= 0) || this.gridOptions.frozenColumn !== undefined && this.gridOptions.frozenColumn >= 0) && this.gridOptions.enableMouseWheelScrollHandler === undefined) {
+      this.gridOptions.enableMouseWheelScrollHandler = true;
     }
 
     this.dispatchCustomEvent(`${DEFAULT_AURELIA_EVENT_PREFIX}-on-before-grid-create`);
@@ -816,15 +818,6 @@ export class AureliaSlickgridCustomElement {
     }
 
     return options;
-  }
-
-
-  /**
-   *  load jQuery mousewheel only when using a frozen grid (this will make the mousewheel work on any side of the frozen container).
-   * DO NOT USE with Row Detail
-   */
-  loadJqueryMousewheelDynamically() {
-    require('slickgrid/lib/jquery.mousewheel');
   }
 
   /**

--- a/src/aurelia-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/gridMenuExtension.spec.ts
@@ -613,7 +613,7 @@ describe('gridMenuExtension', () => {
 
         expect(onCommandSpy).toHaveBeenCalled();
         expect(setColumnsSpy).toHaveBeenCalled();
-        expect(setOptionsSpy).toHaveBeenCalledWith({ frozenColumn: -1 });
+        expect(setOptionsSpy).toHaveBeenCalledWith({ frozenColumn: -1, enableMouseWheelScrollHandler: false });
       });
 
       it('should call "clearFilters" and dataview refresh when the command triggered is "clear-filter"', () => {

--- a/src/aurelia-slickgrid/extensions/__tests__/headerMenuExtension.spec.ts
+++ b/src/aurelia-slickgrid/extensions/__tests__/headerMenuExtension.spec.ts
@@ -424,7 +424,7 @@ describe('headerMenuExtension', () => {
         instance.onCommand.notify({ column: columnsMock[0], grid: gridStub, command: 'freeze-columns' }, new Slick.EventData(), gridStub);
 
         expect(onCommandSpy).toHaveBeenCalled();
-        expect(setOptionsSpy).toHaveBeenCalledWith({ frozenColumn: 0 });
+        expect(setOptionsSpy).toHaveBeenCalledWith({ frozenColumn: 0, enableMouseWheelScrollHandler: true });
         expect(setColumnsSpy).toHaveBeenCalled();
       });
 
@@ -437,7 +437,7 @@ describe('headerMenuExtension', () => {
         instance.onCommand.notify({ column: columnsMock[1], grid: gridStub, command: 'freeze-columns' }, new Slick.EventData(), gridStub);
 
         expect(onCommandSpy).toHaveBeenCalled();
-        expect(setOptionsSpy).toHaveBeenCalledWith({ frozenColumn: -1 });
+        expect(setOptionsSpy).toHaveBeenCalledWith({ frozenColumn: -1, enableMouseWheelScrollHandler: true });
         expect(setColumnsSpy).toHaveBeenCalled();
       });
 

--- a/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/gridMenuExtension.ts
@@ -390,7 +390,7 @@ export class GridMenuExtension implements Extension {
       switch (args.command) {
         case 'clear-frozen-columns':
           const visibleColumns = [...this.sharedService.visibleColumns];
-          this.sharedService.grid.setOptions({ frozenColumn: -1 });
+          this.sharedService.grid.setOptions({ frozenColumn: -1, enableMouseWheelScrollHandler: false });
           if (Array.isArray(visibleColumns) && Array.isArray(this.sharedService.allColumns) && visibleColumns.length !== this.sharedService.allColumns.length) {
             this.sharedService.grid.setColumns(visibleColumns);
           }

--- a/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
+++ b/src/aurelia-slickgrid/extensions/headerMenuExtension.ts
@@ -347,7 +347,7 @@ export class HeaderMenuExtension implements Extension {
         case 'freeze-columns':
           const visibleColumns = [...this.sharedService.visibleColumns];
           const columnPosition = visibleColumns.findIndex((col) => col.id === args.column.id);
-          this.sharedService.grid.setOptions({ frozenColumn: columnPosition } as GridOption);
+          this.sharedService.grid.setOptions({ frozenColumn: columnPosition, enableMouseWheelScrollHandler: true } as GridOption);
 
           // to freeze columns, we need to take only the visible columns and we also need to use setColumns() when some of them are hidden
           // to make sure that we only use the visible columns, not doing this would show back some of the hidden columns

--- a/src/aurelia-slickgrid/models/gridOption.interface.ts
+++ b/src/aurelia-slickgrid/models/gridOption.interface.ts
@@ -258,6 +258,14 @@ export interface GridOption {
   /** Do we want to enable a styling effect when hovering any row from the grid? */
   enableMouseHoverHighlightRow?: boolean;
 
+  /**
+   * Do we want to always enable the mousewheel scroll handler?
+   * In other words, do we want the mouse scrolling would work from anywhere.
+   * Typically we should only enable it when using a Frozen/Pinned grid and if it does detect it to be a frozen grid,
+   * then it will automatically enable the scroll handler if this flag was originally set to undefined (which it is by default unless the user specifically disabled it).
+   */
+  enableMouseWheelScrollHandler?: boolean;
+
   /** Do we want to enable pagination? Currently only works with a Backend Service API */
   enablePagination?: boolean;
 


### PR DESCRIPTION
- this enables the use of the mousewheel scrolling event handler and that makes the mousewheel scroll to work from anywhere in the grid
- implement a permanent fix for issue #618 to replace temp fix made in PR #619
- requires the core lib [PR #555](https://github.com/6pac/SlickGrid/pull/555) to be merged and released