### PR TITLE
fix(core): add console error if any of column def id includes dot

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid.spec.ts
+++ b/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid.spec.ts
@@ -565,6 +565,17 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         customElement.gridOptions = gridOptions;
       });
 
+      it('should display a console error when any of the column definition ids include a dot notation', () => {
+        const consoleSpy = jest.spyOn(global.console, 'error').mockReturnValue();
+        const mockColDefs = [{ id: 'user.gender', field: 'user.gender', editor: { model: Editors.text, collection: ['male', 'female'] } }] as Column[];
+
+        customElement.columnDefinitions = mockColDefs;
+        customElement.columnDefinitionsChanged();
+        customElement.initialization(slickEventHandler);
+
+        expect(consoleSpy).toHaveBeenCalledWith('[Slickgrid-Universal] Make sure that none of your Column Definition "id" property includes a dot in its name because that will cause some problems with the Editors. For example if your column definition "field" property is "user.firstName" then use "firstName" as the column "id".');
+      });
+
       it('should be able to load async editors with a regular Promise', (done) => {
         const mockCollection = ['male', 'female'];
         const promise = new Promise(resolve => resolve(mockCollection));

--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -1280,6 +1280,10 @@ export class AureliaSlickgridCustomElement {
    * then take back "editor.model" and make it the new "editor" so that SlickGrid Editor Factory still works
    */
   private swapInternalEditorToSlickGridFactoryEditor(columnDefinitions: Column[]) {
+    if (columnDefinitions.some(col => `${col.id}`.includes('.'))) {
+      console.error('[Slickgrid-Universal] Make sure that none of your Column Definition "id" property includes a dot in its name because that will cause some problems with the Editors. For example if your column definition "field" property is "user.firstName" then use "firstName" as the column "id".');
+    }
+
     return columnDefinitions.map((column: Column | any) => {
       // on every Editor which have a "collection" or a "collectionAsync"
       if (column.editor && column.editor.collectionAsync) {


### PR DESCRIPTION
- all Editors/Filters are using the column definition id to add a css className for properly identifying the this editor/filter with a unique className, however if the columnId includes a dot then that becomes 2 class names in css and will cause issues, so it's better to advise the user from the start that his column definitions has some invalid Id(s).