### PR TITLE
fix(components): Composite Editor Clone was sometime throwing error

### DIFF
--- a/src/aurelia-slickgrid/services/container.service.ts
+++ b/src/aurelia-slickgrid/services/container.service.ts
@@ -1,10 +1,9 @@
-import { ContainerInstance, ContainerService as UniversalContainerService } from '@slickgrid-universal/common';
-import { Container, inject } from 'aurelia-framework';
+import { ContainerService as UniversalContainerService } from '@slickgrid-universal/common';
+import { Container, inject, singleton } from 'aurelia-framework';
 
 @inject(Container)
+@singleton(true)
 export class ContainerService implements UniversalContainerService {
-  dependencies: ContainerInstance[] = [];
-
   constructor(private readonly container: Container) { }
 
   get<T = any>(key: string): T | null {


### PR DESCRIPTION
- when we were coming from another page, the basic Slickgrid-Universal `containerService` was acting funny, the fix is to register it in as singleton but only in the immediate container