### PR TITLE
feat(filters): add optional `filterTypingDebounce` for filters w/keyup

### DIFF
--- a/src/aurelia-slickgrid/constants.ts
+++ b/src/aurelia-slickgrid/constants.ts
@@ -46,6 +46,7 @@ export class Constants {
     TEXT_LAST_UPDATE: 'Last Update',
     TEXT_LESS_THAN: 'Less than',
     TEXT_LESS_THAN_OR_EQUAL_TO: 'Less than or equal to',
+    TEXT_NOT_CONTAINS: 'Not contains',
     TEXT_NOT_EQUAL_TO: 'Not equal to',
     TEXT_PAGE: 'Page',
     TEXT_REFRESH_DATASET: 'Refresh Dataset',

--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -925,7 +925,7 @@ export class AureliaSlickgridCustomElement {
   executeAfterDataviewCreated(_grid: SlickGrid, gridOptions: GridOption) {
     // if user entered some Sort "presets", we need to reflect them all in the DOM
     if (gridOptions.enableSorting) {
-      if (gridOptions.presets && Array.isArray(gridOptions.presets.sorters) && gridOptions.presets.sorters.length > 0) {
+      if (gridOptions.presets && Array.isArray(gridOptions.presets.sorters)) {
         this.sortService.loadGridSorters(gridOptions.presets.sorters);
       }
     }
@@ -1198,7 +1198,7 @@ export class AureliaSlickgridCustomElement {
   private loadPresetsWhenDatasetInitialized() {
     if (this.gridOptions && !this.customDataView) {
       // if user entered some Filter "presets", we need to reflect them all in the DOM
-      if (this.gridOptions.presets && Array.isArray(this.gridOptions.presets.filters) && this.gridOptions.presets.filters.length > 0) {
+      if (this.gridOptions.presets && Array.isArray(this.gridOptions.presets.filters)) {
         this.filterService.populateColumnFilterSearchTermPresets(this.gridOptions.presets.filters);
       }
 

--- a/src/aurelia-slickgrid/global-grid-options.ts
+++ b/src/aurelia-slickgrid/global-grid-options.ts
@@ -93,6 +93,7 @@ export const GlobalGridOptions: Partial<GridOption> = {
   defaultFilter: Filters.input,
   defaultFilterPlaceholder: '&#128269;', // magnifying glass icon
   defaultFilterRangeOperator: OperatorType.rangeExclusive,
+  defaultBackendServiceFilterTypingDebounce: 500,
   editable: false,
   enableAutoResize: true,
   enableAutoSizeColumns: true,
@@ -143,6 +144,7 @@ export const GlobalGridOptions: Partial<GridOption> = {
     sanitizeDataExport: false,
     useUtf8WithBom: true
   },
+  filterTypingDebounce: 0,
   forceFitColumns: false,
   frozenHeaderWidthCalcDifferential: 1,
   gridMenu: {

--- a/src/examples/slickgrid/example13.ts
+++ b/src/examples/slickgrid/example13.ts
@@ -155,6 +155,8 @@ export class Example13 {
         rightPadding: 10
       },
       enableFiltering: true,
+      // you could debounce/throttle the input text filter if you have lots of data
+      // filterTypingDebounce: 250,
       enableGrouping: true,
       enableExcelExport: true,
       enableTextExport: true,

--- a/src/examples/slickgrid/example18.ts
+++ b/src/examples/slickgrid/example18.ts
@@ -213,6 +213,8 @@ export class Example18 {
       showPreHeaderPanel: true,
       preHeaderPanelHeight: 40,
       enableFiltering: true,
+      // you could debounce/throttle the input text filter if you have lots of data
+      // filterTypingDebounce: 250,
       enableSorting: true,
       enableColumnReorder: true,
       gridMenu: {


### PR DESCRIPTION
- we previously had the `filterTypingDebounce` but that was only available when using `BackendServiceApi` (with OData/GraphQL) but this PR goes further and makes it available to any type of grids, so it can now be used with a local grid (JSON dataset)
- we also move the debounce code from the Filter Service into each filter component itself (only the following 2 filters requires this, `InputFilter` and `CompoundInputFilter`). The Filter Service shouldn't do any debounce, it should be the responsability of the concerned filter and that is what we refactored in this PR as well.

#### TODOs
- [x] requires Slickgrid-Universal PR [#283](https://github.com/ghiscoding/slickgrid-universal/pull/283) to be merged and released