### PR TITLE
fix(metrics): use `onRowCountChanged` event to refresh metrics

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid.spec.ts
+++ b/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid.spec.ts
@@ -11,6 +11,7 @@ import {
   ExtensionUtility,
   Filters,
   FilterService,
+  Formatter,
   GridEventService,
   GridOption,
   GridService,
@@ -203,7 +204,8 @@ const mockDataView = {
   mapIdsToRows: jest.fn(),
   mapRowsToIds: jest.fn(),
   onRowsChanged: new MockSlickEvent(),
-  onRowsOrCountChanged: new MockSlickEvent(),
+  onRowCountChanged: new MockSlickEvent(),
+  onSetItemsCalled: new MockSlickEvent(),
   reSort: jest.fn(),
   setItems: jest.fn(),
   syncGridSelection: jest.fn(),
@@ -1613,7 +1615,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         const emptySpy = jest.spyOn(slickEmptyWarning as SlickEmptyWarningComponent, 'showEmptyDataMessage');
         customElement.columnDefinitions = mockColDefs;
         customElement.refreshGridData([]);
-        mockDataView.onRowsOrCountChanged.notify({ current: 0, item: { first: 'John' } });
+        mockDataView.onRowCountChanged.notify({ current: 0, previous: 0, dataView: mockDataView, itemCount: 0, callingOnRowsChanged: false });
 
         setTimeout(() => {
           expect(customElement.columnDefinitions).toEqual(mockColDefs);
@@ -1714,7 +1716,7 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         });
       });
 
-      it('should have custom footer with metrics when the DataView "onRowsOrCountChanged" event is triggered', () => {
+      it('should have custom footer with metrics when the DataView "onRowCountChanged" event is triggered', () => {
         const mockData = [{ firstName: 'John', lastName: 'Doe' }, { firstName: 'Jane', lastName: 'Smith' }];
         const expectation = {
           startTime: expect.toBeDate(),
@@ -1727,7 +1729,23 @@ describe('Slick-Vanilla-Grid-Bundle Component instantiated via Constructor', () 
         customElement.gridOptions = { enablePagination: false, showCustomFooter: true };
         customElement.initialization(slickEventHandler);
         customElement.datasetChanged(mockData, null);
-        mockDataView.onRowsOrCountChanged.notify({ first: 'John', itemCount: 2, currentRowCount: 2, previous: 1 });
+        mockDataView.onRowCountChanged.notify({ current: 2, previous: 0, dataView: mockDataView, itemCount: 0, callingOnRowsChanged: false });
+
+        expect(customElement.metrics).toEqual(expectation);
+      });
+
+      it('should have custom footer with metrics when the DataView "onSetItemsCalled" event is triggered', () => {
+        const expectation = {
+          startTime: expect.toBeDate(),
+          endTime: expect.toBeDate(),
+          itemCount: 0,
+          totalItemCount: 0
+        };
+        jest.spyOn(mockDataView, 'getLength').mockReturnValue(0);
+
+        customElement.gridOptions = { enablePagination: false, showCustomFooter: true };
+        customElement.initialization(slickEventHandler);
+        mockDataView.onSetItemsCalled.notify({ idProperty: 'id', itemCount: 0 });
 
         expect(customElement.metrics).toEqual(expectation);
       });

--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -793,10 +793,14 @@ export class AureliaSlickgridCustomElement {
 
       if (dataView && grid) {
         // When data changes in the DataView, we need to refresh the metrics and/or display a warning if the dataset is empty
-        const onRowsOrCountChangedHandler = dataView.onRowsOrCountChanged;
-        (this._eventHandler as SlickEventHandler<GetSlickEventType<typeof onRowsOrCountChangedHandler>>).subscribe(onRowsOrCountChangedHandler, (_e, args) => {
+        const onRowCountChangedHandler = dataView.onRowCountChanged;
+        (this._eventHandler as SlickEventHandler<GetSlickEventType<typeof onRowCountChangedHandler>>).subscribe(onRowCountChangedHandler, (_e, args) => {
           grid.invalidate();
-          this.handleOnItemCountChanged(args.currentRowCount || 0);
+          this.handleOnItemCountChanged(args.current || 0, dataView.getItemCount());
+        });
+        const onSetItemsCalledHandler = dataView.onSetItemsCalled;
+        (this._eventHandler as SlickEventHandler<GetSlickEventType<typeof onSetItemsCalledHandler>>).subscribe(onSetItemsCalledHandler, (_e, args) => {
+          this.handleOnItemCountChanged(dataView.getLength(), args.itemCount);
         });
 
         if (this.gridOptions?.enableTreeData) {
@@ -1132,17 +1136,17 @@ export class AureliaSlickgridCustomElement {
   }
 
   /** When data changes in the DataView, we'll refresh the metrics and/or display a warning if the dataset is empty */
-  private handleOnItemCountChanged(itemCount: number) {
+  private handleOnItemCountChanged(currentPageRowItemCount: number, totalItemCount: number) {
     this.metrics = {
       startTime: new Date(),
       endTime: new Date(),
-      itemCount: itemCount || 0,
-      totalItemCount: this.dataview.getItemCount() || 0
+      itemCount: currentPageRowItemCount,
+      totalItemCount
     };
 
     // when using local (in-memory) dataset, we'll display a warning message when filtered data is empty
     if (this._isLocalGrid && this.gridOptions?.enableEmptyDataWarningMessage) {
-      this.displayEmptyDataWarning(itemCount === 0);
+      this.displayEmptyDataWarning(currentPageRowItemCount === 0);
     }
   }
 


### PR DESCRIPTION
- this issue was reported in Angular-Slickgrid with the following: using `dataView.onRowsOrCountChanged` instead of `dataView.onRowCountChanged` to refresh metrics this refreshes the whole grid in the case of an `updateItemById`.