### PR TITLE
fix(presets): loading columns presets should only be done once

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -436,7 +436,7 @@ export class AureliaSlickgridCustomElement {
         if (!this._isDatasetInitialized && (this.gridOptions.enableCheckboxSelector || this.gridOptions.enableRowSelection)) {
           this.loadRowSelectionPresetWhenExists();
         }
-        this.loadPresetsWhenDatasetInitialized();
+        this.loadFilterPresetsWhenDatasetInitialized();
         this._isDatasetInitialized = true;
       }
     }
@@ -738,7 +738,8 @@ export class AureliaSlickgridCustomElement {
       }
 
       // load any presets if any (after dataset is initialized)
-      this.loadPresetsWhenDatasetInitialized();
+      this.loadColumnPresetsWhenDatasetInitialized();
+      this.loadFilterPresetsWhenDatasetInitialized();
     }
 
 
@@ -1039,7 +1040,7 @@ export class AureliaSlickgridCustomElement {
 
       if (dataset.length > 0) {
         if (!this._isDatasetInitialized) {
-          this.loadPresetsWhenDatasetInitialized();
+          this.loadFilterPresetsWhenDatasetInitialized();
 
           if (this.gridOptions.enableCheckboxSelector) {
             this.loadRowSelectionPresetWhenExists();
@@ -1225,29 +1226,36 @@ export class AureliaSlickgridCustomElement {
     }
   }
 
-  /** Load any possible Grid Presets (columns, filters) */
-  private loadPresetsWhenDatasetInitialized() {
+  /** Load any possible Columns Grid Presets */
+  private loadColumnPresetsWhenDatasetInitialized() {
+    // if user entered some Columns "presets", we need to reflect them all in the grid
+    if (this.gridOptions.presets && Array.isArray(this.gridOptions.presets.columns) && this.gridOptions.presets.columns.length > 0) {
+      const gridColumns: Column[] = this.gridStateService.getAssociatedGridColumns(this.grid, this.gridOptions.presets.columns);
+      if (gridColumns && Array.isArray(gridColumns) && gridColumns.length > 0) {
+        // make sure that the checkbox selector is also visible if it is enabled
+        if (this.gridOptions.enableCheckboxSelector) {
+          const checkboxColumn = (Array.isArray(this._columnDefinitions) && this._columnDefinitions.length > 0) ? this._columnDefinitions[0] : null;
+          if (checkboxColumn && checkboxColumn.id === '_checkbox_selector' && gridColumns[0].id !== '_checkbox_selector') {
+            gridColumns.unshift(checkboxColumn);
+          }
+        }
+
+        // keep copy the original optional `width` properties optionally provided by the user.
+        // We will use this when doing a resize by cell content, if user provided a `width` it won't override it.
+        gridColumns.forEach(col => col.originalWidth = col.width);
+
+        // finally set the new presets columns (including checkbox selector if need be)
+        this.grid.setColumns(gridColumns);
+      }
+    }
+  }
+
+  /** Load any possible Filters Grid Presets */
+  private loadFilterPresetsWhenDatasetInitialized() {
     if (this.gridOptions && !this.customDataView) {
       // if user entered some Filter "presets", we need to reflect them all in the DOM
       if (this.gridOptions.presets && Array.isArray(this.gridOptions.presets.filters)) {
         this.filterService.populateColumnFilterSearchTermPresets(this.gridOptions.presets.filters);
-      }
-
-      // if user entered some Columns "presets", we need to reflect them all in the grid
-      if (this.gridOptions.presets && Array.isArray(this.gridOptions.presets.columns) && this.gridOptions.presets.columns.length > 0) {
-        const gridColumns: Column[] = this.gridStateService.getAssociatedGridColumns(this.grid, this.gridOptions.presets.columns);
-        if (gridColumns && Array.isArray(gridColumns) && gridColumns.length > 0) {
-          // make sure that the checkbox selector is also visible if it is enabled
-          if (this.gridOptions.enableCheckboxSelector) {
-            const checkboxColumn = (Array.isArray(this._columnDefinitions) && this._columnDefinitions.length > 0) ? this._columnDefinitions[0] : null;
-            if (checkboxColumn && checkboxColumn.id === '_checkbox_selector' && gridColumns[0].id !== '_checkbox_selector') {
-              gridColumns.unshift(checkboxColumn);
-            }
-          }
-
-          // finally set the new presets columns (including checkbox selector if need be)
-          this.grid.setColumns(gridColumns);
-        }
       }
     }
   }


### PR DESCRIPTION
- loading of Columns Grid Presets should only be done once (before resizing) and loading Filters Grid Presets could be done one or more times, so to fix this I have separated `loadPresetsWhenDatasetInitialized` into 2 new methods and made sure to call the columns grid preset only once.
- this issue was identified while porting the previous PR #341 into Angular-Slickgrid