### PR TITLE
fix(resizer): fix a regression bug caused by previous PR

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -388,14 +388,7 @@ export class AureliaSlickgridCustomElement {
     this.sharedService.dataView = this.dataview;
     this.sharedService.slickGrid = this.grid;
 
-    // load the resizer service
-    const gridContainerElm = this.elm.querySelector('div');
-    if (gridContainerElm) {
-      this.resizerService.init(this.grid, gridContainerElm);
-    }
-
     this.extensionService.bindDifferentExtensions();
-
     this.bindDifferentHooks(this.grid, this.gridOptions, this.dataview);
 
     // when it's a frozen grid, we need to keep the frozen column id for reference if we ever show/hide column from ColumnPicker/GridMenu afterward
@@ -409,6 +402,13 @@ export class AureliaSlickgridCustomElement {
 
     // initialize the SlickGrid grid
     this.grid.init();
+
+    // initialized the resizer service only after SlickGrid is initialized
+    // if we don't we end up binding our resize to a grid element that doesn't yet exist in the DOM and the resizer service will fail silently (because it has a try/catch that unbinds the resize without throwing back)
+    const gridContainerElm = this.elm.querySelector('div');
+    if (gridContainerElm) {
+      this.resizerService.init(this.grid, gridContainerElm);
+    }
 
     if (!this.customDataView && this.dataview) {
       const initialDataset = this.gridOptions?.enableTreeData ? this.sortTreeDataset(this.dataset) : this.dataset;


### PR DESCRIPTION
- resizer service init must be done only after SlickGrid is initialized, else we end up binding our resize to a grid dom element that doesn't yet exist in the DOM
- this regression bug wasn't caught earlier because there's no Cypress E2E to test that since it's too hard to test, basically it was caught manually since I found out the auto-resize stopped working (it failed silently) and I was wondering why that suddenly happened