### PR TITLE
fix(backend): able to preset filters on hidden columns & all queried

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid.spec.ts
+++ b/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid.spec.ts
@@ -1507,7 +1507,7 @@ describe('Aurelia-Slickgrid Component instantiated via Constructor', () => {
         customElement.initialization(slickEventHandler);
 
         expect(bindBackendSpy).toHaveBeenCalledWith(mockGrid);
-        expect(initSpy).toHaveBeenCalledWith(mockGraphqlOptions, mockPagination, mockGrid);
+        expect(initSpy).toHaveBeenCalledWith(mockGraphqlOptions, mockPagination, mockGrid, sharedService);
       });
 
       it('should call bind backend sorting when "enableSorting" is set', () => {

--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -769,7 +769,7 @@ export class AureliaSlickgridCustomElement {
       const backendApi = gridOptions.backendServiceApi;
 
       if (backendApi && backendApi.service && backendApi.service.init) {
-        backendApi.service.init(backendApi.options, gridOptions.pagination, this.grid);
+        backendApi.service.init(backendApi.options, gridOptions.pagination, this.grid, this.sharedService);
       }
     }
 
@@ -1240,6 +1240,7 @@ export class AureliaSlickgridCustomElement {
 
         // finally set the new presets columns (including checkbox selector if need be)
         this.grid.setColumns(gridColumns);
+        this.sharedService.visibleColumns = gridColumns;
       }
     }
   }

--- a/test/cypress/integration/example06.spec.js
+++ b/test/cypress/integration/example06.spec.js
@@ -65,7 +65,7 @@ describe('Example 6 - GraphQL Grid', () => {
             {field:"gender",operator:EQ,value:"male"},{field:"name",operator:Contains,value:"JohnDoe"},
             {field:"company",operator:IN,value:"xyz"},{field:"finish",operator:GE,value:"${presetLowestDay}"},{field:"finish",operator:LE,value:"${presetHighestDay}"}
           ],locale:"en",userId:123){
-            totalCount,nodes{id,name,gender,company,billing{address{zip,street}},finish}}}`));
+            totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
       });
   });
 
@@ -83,7 +83,7 @@ describe('Example 6 - GraphQL Grid', () => {
           filterBy:[
             {field:"gender",operator:EQ,value:"male"},{field:"name",operator:Contains,value:"JohnDoe"},
             {field:"company",operator:IN,value:"xyz"},{field:"finish",operator:GE,value:"${presetLowestDay}"},{field:"finish",operator:LE,value:"${presetHighestDay}"}
-          ],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{zip,street}},finish}}}`));
+          ],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
       });
   });
 
@@ -101,7 +101,7 @@ describe('Example 6 - GraphQL Grid', () => {
           filterBy:[
             {field:"gender",operator:EQ,value:"male"},{field:"name",operator:Contains,value:"JohnDoe"},
             {field:"company",operator:IN,value:"xyz"},{field:"finish",operator:GE,value:"${presetLowestDay}"},{field:"finish",operator:LE,value:"${presetHighestDay}"}
-          ],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{zip,street}},finish}}}`));
+          ],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
       });
   });
 
@@ -123,7 +123,7 @@ describe('Example 6 - GraphQL Grid', () => {
             {field:"company",operator:IN,value:"xyz"},
             {field:"finish",operator:GE,value:"${presetLowestDay}"},
             {field:"finish",operator:LE,value:"${presetHighestDay}"}
-          ],locale:"en",userId:123) { totalCount, nodes { id,name,gender,company,billing{address{zip,street}},finish } } }`));
+          ],locale:"en",userId:123) { totalCount, nodes { id,name,gender,company,billing{address{street,zip}},finish } } }`));
       });
   });
 
@@ -142,7 +142,7 @@ describe('Example 6 - GraphQL Grid', () => {
           filterBy:[
             {field:"gender",operator:EQ,value:"male"},{field:"name",operator:Contains,value:"JohnDoe"},
             {field:"company",operator:IN,value:"xyz"},{field:"finish",operator:GE,value:"${presetLowestDay}"},{field:"finish",operator:LE,value:"${presetHighestDay}"}
-          ],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{zip,street}},finish}}}`));
+          ],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
       });
   });
 
@@ -162,7 +162,7 @@ describe('Example 6 - GraphQL Grid', () => {
           filterBy:[
             {field:"gender",operator:EQ,value:"male"},{field:"name",operator:Contains,value:"JohnDoe"},
             {field:"company",operator:IN,value:"xyz"},{field:"finish",operator:GE,value:"${presetLowestDay}"},{field:"finish",operator:LE,value:"${presetHighestDay}"}
-          ],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{zip,street}},finish}}}`));
+          ],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
       });
   });
 
@@ -193,7 +193,7 @@ describe('Example 6 - GraphQL Grid', () => {
           filterBy:[
             {field:"gender",operator:EQ,value:"male"},{field:"company",operator:IN,value:"xyz"},
             {field:"finish",operator:GE,value:"${presetLowestDay}"},{field:"finish",operator:LE,value:"${presetHighestDay}"}
-          ],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{zip,street}},finish}}}`));
+          ],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
       });
   });
 
@@ -223,7 +223,7 @@ describe('Example 6 - GraphQL Grid', () => {
           filterBy:[
             {field:"gender",operator:EQ,value:"male"},{field:"company",operator:IN,value:"xyz"},
             {field:"finish",operator:GE,value:"${presetLowestDay}"},{field:"finish",operator:LE,value:"${presetHighestDay}"}
-          ],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{zip,street}},finish}}}`));
+          ],locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
       });
   });
 
@@ -252,7 +252,7 @@ describe('Example 6 - GraphQL Grid', () => {
         expect(text).to.eq(removeSpaces(`query{users(first:30,offset:0,
           orderBy:[{field:"name",direction:ASC},{field:"company",direction:DESC}],
           filterBy:[{field:"gender",operator:EQ,value:"male"},{field:"company",operator:IN,value:"xyz"}],
-          locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{zip,street}},finish}}}`));
+          locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
       });
   });
 
@@ -265,7 +265,7 @@ describe('Example 6 - GraphQL Grid', () => {
     cy.get('[data-test=graphql-query-result]')
       .should(($span) => {
         const text = removeSpaces($span.text()); // remove all white spaces
-        expect(text).to.eq(removeSpaces(`query{users(first:30,offset:0,locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{zip,street}},finish}}}`));
+        expect(text).to.eq(removeSpaces(`query{users(first:30,offset:0,locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
       });
   });
 
@@ -287,7 +287,7 @@ describe('Example 6 - GraphQL Grid', () => {
         const text = removeSpaces($span.text()); // remove all white spaces
         expect(text).to.eq(removeSpaces(`query{users(first:30,offset:0,
           orderBy:[{field:"name",direction:ASC}],
-          locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{zip,street}},finish}}}`));
+          locale:"en",userId:123){totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
       });
   });
 
@@ -333,7 +333,7 @@ describe('Example 6 - GraphQL Grid', () => {
           filterBy:[{field:"gender",operator:EQ,value:"female"},{field:"name",operator:StartsWith,value:"Jane"},
           {field:"company",operator:IN,value:"acme"},{field:"billing.address.zip",operator:GE,value:"11"},
           {field:"finish",operator:GE,value:"${presetLowestDay}"},{field:"finish",operator:LE,value:"${presetHighestDay}"}],locale:"en",userId:123)
-          {totalCount,nodes{id,name,gender,company,billing{address{zip,street}},finish}}}`));
+          {totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
       });
   });
 
@@ -372,7 +372,7 @@ describe('Example 6 - GraphQL Grid', () => {
           const text = removeSpaces($span.text()); // remove all white spaces
           expect(text).to.eq(removeSpaces(`query{users(first:30,offset:0,
             orderBy:[{field:"billing.address.zip",direction:DESC},{field:"company",direction:ASC}],locale:"en",userId:123){
-            totalCount,nodes{id,name,gender,company,billing{address{zip,street}},finish}}}`));
+            totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
         });
     });
   });
@@ -614,7 +614,7 @@ describe('Example 6 - GraphQL Grid', () => {
             filterBy:[{field:"gender",operator:EQ,value:"female"},{field:"name",operator:StartsWith,value:"Jane"},
             {field:"company",operator:IN,value:"acme"},{field:"billing.address.zip",operator:GE,value:"11"},
             {field:"finish",operator:GE,value:"${presetLowestDay}"},{field:"finish",operator:LE,value:"${presetHighestDay}"}],locale:"fr",userId:123)
-            {totalCount,nodes{id,name,gender,company,billing{address{zip,street}},finish}}}`));
+            {totalCount,nodes{id,name,gender,company,billing{address{street,zip}},finish}}}`));
         });
     });
 


### PR DESCRIPTION
- the backend services were using SlickGrid `getColumns` to get the column definitions but that returns only the visible columns, however we should be able to preset filters on hidden columns and also expect all columns to be queried (it's not because the column is hidden that we shouldn't be able to filter it and query it)