### PR TITLE
chore: remove unnecessary Formatter interface

### DIFF
--- a/src/aurelia-slickgrid/index.ts
+++ b/src/aurelia-slickgrid/index.ts
@@ -10,7 +10,6 @@ import { SlickgridConfig } from './slickgrid-config';
 import {
   AureliaGridInstance,
   AureliaViewOutput,
-  Formatter,
   GridOption,
   RowDetailView,
   SlickGrid,
@@ -22,7 +21,6 @@ import {
 export {
   AureliaGridInstance,
   AureliaViewOutput,
-  Formatter,
   GridOption,
   RowDetailView,
   SlickGrid,

--- a/src/aurelia-slickgrid/models/formatter.interface.ts
+++ b/src/aurelia-slickgrid/models/formatter.interface.ts
@@ -1,5 +1,0 @@
-
-import { Column, FormatterResultObject } from '@slickgrid-universal/common';
-import { SlickGrid } from './slickGrid.interface';
-
-export declare type Formatter<T = any> = (row: number, cell: number, value: any, columnDef: Column<T>, dataContext: T, grid: SlickGrid) => string | FormatterResultObject;

--- a/src/aurelia-slickgrid/models/index.ts
+++ b/src/aurelia-slickgrid/models/index.ts
@@ -1,6 +1,5 @@
 export * from './aureliaGridInstance.interface';
 export * from './aureliaViewOutput.interface';
-export * from './formatter.interface';
 export * from './gridOption.interface';
 export * from './rowDetailView.interface';
 export * from './slickGrid.interface';

--- a/src/examples/slickgrid/example12.ts
+++ b/src/examples/slickgrid/example12.ts
@@ -21,7 +21,7 @@ const NB_ITEMS = 1500;
 
 // create a custom translate Formatter (typically you would move that a separate file, for separation of concerns)
 const taskTranslateFormatter: Formatter = (_row, _cell, value, _columnDef, _dataContext, grid) => {
-  const gridOptions = (grid && typeof grid.getOptions === 'function') ? grid.getOptions() : {};
+  const gridOptions: GridOption = (grid && typeof grid.getOptions === 'function') ? grid.getOptions() : {};
   const i18n = gridOptions.i18n;
 
   return i18n?.tr('TASK_X', { x: value }) ?? '';

--- a/src/examples/slickgrid/example24.ts
+++ b/src/examples/slickgrid/example24.ts
@@ -42,7 +42,7 @@ const priorityExportFormatter: Formatter = (_row, _cell, value, _columnDef, _dat
   if (!value) {
     return '';
   }
-  const gridOptions = (grid && typeof grid.getOptions === 'function') ? grid.getOptions() : {};
+  const gridOptions: GridOption = (grid && typeof grid.getOptions === 'function') ? grid.getOptions() : {};
   const i18n = gridOptions.i18n;
   const count = +(value >= 3 ? 3 : value);
   const key = count === 3 ? 'HIGH' : (count === 2 ? 'MEDIUM' : 'LOW');


### PR DESCRIPTION
- it's already available in Slickgrid-Universal so no need to duplicate this interface