### PR TITLE
fix(pagination): should be able to toggle Pagination

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/slick-pagination.ts
+++ b/src/aurelia-slickgrid/custom-elements/slick-pagination.ts
@@ -124,8 +124,6 @@ export class SlickPaginationCustomElement {
   }
 
   dispose() {
-    this.paginationService.dispose();
-
     // also dispose of all Subscriptions
     this._subscriptions = disposeAllSubscriptions(this._subscriptions);
   }

--- a/test/cypress/integration/example10.spec.js
+++ b/test/cypress/integration/example10.spec.js
@@ -759,6 +759,27 @@ describe('Example 10 - Multiple Grids with Row Selection', { retries: 1 }, () =>
         expect(win.console.log).to.be.calledWith("Grid State changed:: ", { newValues: { gridRowIndexes: [0, 1], dataContextIds: [3, 12, 13, 522, 1], filteredDataContextIds: [3, 13] }, type: 'rowSelection' });
         expect(win.console.log).to.be.calledWith("Grid State changed:: ", { newValues: [{ columnId: 'title', operator: 'Contains', searchTerms: ['3'] }], type: 'filter' });
       });
+
+      cy.get('@grid2')
+        .find('[data-test=page-number-input]')
+        .invoke('val')
+        .then(pageNumber => expect(pageNumber).to.eq('1'));
+
+      cy.get('@grid2')
+        .find('[data-test=page-count]')
+        .contains('3');
+
+      cy.get('@grid2')
+        .find('[data-test=item-from]')
+        .contains('1');
+
+      cy.get('@grid2')
+        .find('[data-test=item-to]')
+        .contains('5');
+
+      cy.get('@grid2')
+        .find('[data-test=total-items]')
+        .contains('179');
     });
   });
 });


### PR DESCRIPTION
- we should be able to toggle Pagination and it should still work as expected after showing it again
- the previous code was disposing of the Pagination Service when hiding (disposing) the Pagination Component but that shouldn't be the case, disposing of the Service should strictly be handled by the Angular-Slickgrid-Component