### PR TITLE
fix(aurelia-slickgrid): reference html explicitly

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -77,7 +77,7 @@ import {
 import { SlickFooterComponent } from '@slickgrid-universal/custom-footer-component';
 import { SlickEmptyWarningComponent } from '@slickgrid-universal/empty-warning-component';
 
-import { bindable, BindingEngine, bindingMode, Container, Factory, inject, useView } from 'aurelia-framework';
+import { bindable, BindingEngine, bindingMode, Container, Factory, inject, useView, PLATFORM } from 'aurelia-framework';
 import { EventAggregator, Subscription } from 'aurelia-event-aggregator';
 import { dequal } from 'dequal/lite';
 

--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -77,7 +77,7 @@ import {
 import { SlickFooterComponent } from '@slickgrid-universal/custom-footer-component';
 import { SlickEmptyWarningComponent } from '@slickgrid-universal/empty-warning-component';
 
-import { bindable, BindingEngine, bindingMode, Container, Factory, inject, } from 'aurelia-framework';
+import { bindable, BindingEngine, bindingMode, Container, Factory, inject, useView } from 'aurelia-framework';
 import { EventAggregator, Subscription } from 'aurelia-event-aggregator';
 import { dequal } from 'dequal/lite';
 
@@ -107,6 +107,7 @@ declare const Slick: SlickNamespace;
   PubSubService,
   TranslaterService,
 )
+@useView(PLATFORM.moduleName('./aurelia-slickgrid.html'))
 export class AureliaSlickgridCustomElement {
   private _columnDefinitions: Column[] = [];
   private _currentDatasetLength = 0;

--- a/src/aurelia-slickgrid/custom-elements/slick-pagination.ts
+++ b/src/aurelia-slickgrid/custom-elements/slick-pagination.ts
@@ -1,4 +1,4 @@
-import { bindable, inject, Optional, useView } from 'aurelia-framework';
+import { bindable, inject, Optional, useView, PLATFORM } from 'aurelia-framework';
 import { EventAggregator, Subscription } from 'aurelia-event-aggregator';
 import { EventSubscription, getTranslationPrefix, Locale, PaginationService } from '@slickgrid-universal/common';
 

--- a/src/aurelia-slickgrid/custom-elements/slick-pagination.ts
+++ b/src/aurelia-slickgrid/custom-elements/slick-pagination.ts
@@ -1,4 +1,4 @@
-import { bindable, inject, Optional } from 'aurelia-framework';
+import { bindable, inject, Optional, useView } from 'aurelia-framework';
 import { EventAggregator, Subscription } from 'aurelia-event-aggregator';
 import { EventSubscription, getTranslationPrefix, Locale, PaginationService } from '@slickgrid-universal/common';
 
@@ -8,6 +8,7 @@ import { Constants } from '../constants';
 import { TranslaterService } from '../services/translater.service';
 
 @inject(EventAggregator, Optional.of(TranslaterService))
+@useView(PLATFORM.moduleName('./slick-pagination.html'))
 export class SlickPaginationCustomElement {
   // we need to pass this service as a binding because it's transient and it must be created (then passed through the binding) in the Aurelia-Slickgrid custom element
   @bindable() paginationService!: PaginationService;


### PR DESCRIPTION
By default, aurelia webpack plugin won't look for html in a mono repository `node_modules` folder.
This change will allow for usage in mono repositories without additional webpack configuration.