### PR TITLE
fix(grid): invalidate grid after setItems to re-render grid

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -819,6 +819,7 @@ export class AureliaSlickgridCustomElement {
         });
         const onSetItemsCalledHandler = dataView.onSetItemsCalled;
         (this._eventHandler as SlickEventHandler<GetSlickEventType<typeof onSetItemsCalledHandler>>).subscribe(onSetItemsCalledHandler, (_e, args) => {
+          grid.invalidate();
           this.handleOnItemCountChanged(dataView.getLength(), args.itemCount);
 
           // when user has resize by content enabled, we'll force a full width calculation since we change our entire dataset


### PR DESCRIPTION
- fixes a problem only reported in Angular-Slickgrid, not in Aurelia-Slickgrid but might as well apply the same code