### PR TITLE
chore(deps): replace Faker by official @faker-js/faker

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "build:demo": "webpack --env production"
   },
   "dependencies": {
+    "@faker-js/faker": "^6.2.0",
     "@slickgrid-universal/common": "^1.2.6",
     "@slickgrid-universal/custom-footer-component": "^1.2.6",
     "@slickgrid-universal/empty-warning-component": "^1.2.6",
@@ -89,7 +90,6 @@
     "@slickgrid-universal/text-export": "^1.2.6",
     "@types/bluebird": "^3.5.36",
     "@types/dompurify": "^2.3.3",
-    "@types/faker": "^5.5.9",
     "@types/fnando__sparkline": "^0.3.4",
     "@types/i18next-xhr-backend": "^1.4.2",
     "@types/jest": "^27.4.1",
@@ -123,7 +123,6 @@
     "eslint": "^8.14.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prefer-arrow": "^1.2.3",
-    "faker": "^5.5.3",
     "file-loader": "6.2.0",
     "font-awesome": "^4.7.0",
     "fork-ts-checker-webpack-plugin": "^7.2.7",

--- a/src/examples/slickgrid/example34.ts
+++ b/src/examples/slickgrid/example34.ts
@@ -1,4 +1,4 @@
-import * as Faker from 'faker';
+import { faker } from '@faker-js/faker';
 import sparkline from '@fnando/sparkline';
 import {
   Aggregators,
@@ -200,7 +200,7 @@ export class Example34 {
       const now = new Date();
       now.setHours(9, 30, 0);
       const currency = (Math.floor(Math.random() * 10)) % 2 ? 'CAD' : 'USD';
-      const company = Faker.company.companyName();
+      const company = faker.company.companyName();
 
       this.dataset[i] = {
         id: i,

--- a/yarn.lock
+++ b/yarn.lock
@@ -701,6 +701,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@faker-js/faker@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-6.2.0.tgz#6d836ee8a580589b60c9088a3bdb0b669a468825"
+  integrity sha512-3kIcQ+aTr3I+LqDbJwbINFk5oA+a63LH57GPJt9PM8AWqN7nCwnubuSiWosHYQlyf2NicrvpzXQxllyLeEdpyQ==
+
 "@fnando/sparkline@^0.3.10":
   version "0.3.10"
   resolved "https://registry.yarnpkg.com/@fnando/sparkline/-/sparkline-0.3.10.tgz#0cb6549a232af0f19f75b33d38fddd4f5ed9f086"
@@ -1270,11 +1275,6 @@
     "@types/express-serve-static-core" "^4.17.18"
     "@types/qs" "*"
     "@types/serve-static" "*"
-
-"@types/faker@^5.5.9":
-  version "5.5.9"
-  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-5.5.9.tgz#588ede92186dc557bff8341d294335d50d255f0c"
-  integrity sha512-uCx6mP3UY5SIO14XlspxsGjgaemrxpssJI0Ol+GfhxtcKpv9pgRZYsS4eeKeHVLje6Qtc8lGszuBI461+gVZBA==
 
 "@types/fnando__sparkline@^0.3.4":
   version "0.3.4"
@@ -4775,11 +4775,6 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
-
-faker@^5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
-  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 fancy-log@^1.3.2:
   version "1.3.3"


### PR DESCRIPTION
- previous Faker lib was destroyed by its own author and new recommentation is to use @faker-js/faker which is now driven by the community and is the new official lib