### PR TITLE
fix(core): throw error when `gridOptions` missing in View

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid.spec.ts
+++ b/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid.spec.ts
@@ -384,6 +384,18 @@ describe('Aurelia-Slickgrid Component instantiated via Constructor', () => {
     expect(customElement.gridOptions.enableMouseWheelScrollHandler).toBeTrue();
   });
 
+  it('should throw an error when `gridOptions` and/or `columnDefinitions` is undefined', (done) => {
+    try {
+      customElement.gridOptions = undefined as any;
+      customElement.dataset = [];
+      customElement.initialization(mockSlickEventHandler);
+    } catch (e: any) {
+      expect(e.toString()).toContain('Using `<aurelia-slickgrid>` requires `column-definitions.bind="columnDefinitions"` and `grid-options.bind="gridOptions"`');
+      customElement.dispose();
+      done();
+    }
+  });
+
   it('should keep frozen column index reference (via frozenVisibleColumnId) when grid is a frozen grid', () => {
     const sharedFrozenIndexSpy = jest.spyOn(SharedService.prototype, 'frozenVisibleColumnId', 'set');
     customElement.columnDefinitions = columnDefinitions;

--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -282,6 +282,10 @@ export class AureliaSlickgridCustomElement {
   }
 
   initialization(eventHandler: SlickEventHandler) {
+    if (!this.gridOptions || !this.columnDefinitions) {
+      throw new Error('Using `<aurelia-slickgrid>` requires `column-definitions.bind="columnDefinitions"` and `grid-options.bind="gridOptions"`, it seems that you might have forgot to provide them since at least of them is undefined.');
+    }
+
     this.gridOptions.translater = this.translaterService;
     this._eventHandler = eventHandler;
 


### PR DESCRIPTION
- should throw if 1 of these 2 are missing ``gridOptions` and/or `columnDefinitions`