### PR TITLE
fix(demo): edit outline should follow on filter/pagination changed

### DIFF
--- a/src/examples/slickgrid/example30.html
+++ b/src/examples/slickgrid/example30.html
@@ -72,7 +72,8 @@
                      on-composite-editor-change.delegate="handleOnCompositeEditorChange($event.detail.eventData, $event.detail.args)"
                      on-item-deleted.delegate="handleItemDeleted($event.detail.eventData, $event.detail.args)"
                      on-grid-state-changed.delegate="handleOnGridStateChanged($event.detail)"
-                     on-pagination-changed.delegate="handlePaginationChanged($event.detail.eventData, $event.detail.args)"
+                     on-filter-changed.delegate="handleReRenderUnsavedStyling()"
+                     on-pagination-changed.delegate="handleReRenderUnsavedStyling()"
                      on-validation-error.delegate="handleValidationError($event.detail.eventData, $event.detail.args)">
   </aurelia-slickgrid>
 </template>


### PR DESCRIPTION
- the cell orange outline, which tells us the cell wasn't saved yet, should follow the row for both cases of a filter and/or pagination change
- the previous implementation was also not always working to remove all edit cell styling, it works a lot better by keeping a styling queue with the a style key and to remove all styles we simply loop through that queue