### PR TITLE
fix(deps): move i18next as regular dependencies to avoid fulll install

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,11 +65,9 @@
     "aurelia-i18n": "^4.0.3",
     "aurelia-pal": "^1.8.2",
     "dompurify": "^2.4.0",
+    "i18next": ">=21.0.0",
     "jquery": "^3.6.1",
     "sortablejs": "^1.15.0"
-  },
-  "peerDependencies": {
-    "i18next": ">=21.0.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6564,10 +6564,10 @@ i18next-xhr-backend@*, i18next-xhr-backend@^3.2.2:
   dependencies:
     "@babel/runtime" "^7.5.5"
 
-i18next@^21.8.10:
-  version "21.8.10"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-21.8.10.tgz#12f164cc0f5f7904f0d4e0cfdf5950b93793d171"
-  integrity sha512-7xRb6y4QlSqZRZ3uA5BIEsLuZpmxpzHLizQyKjDDThOcvdfgICOX7aFoBnh4BSWcLtJamTqSweaOuK22A2xqkA==
+i18next@>=21.0.0:
+  version "21.10.0"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-21.10.0.tgz#85429af55fdca4858345d0e16b584ec29520197d"
+  integrity sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==
   dependencies:
     "@babel/runtime" "^7.17.2"
 


### PR DESCRIPTION
- having `i18next` as `peerDependencies` requires the developer to always install it even if the user doesn't use translations, if we move it as a regular `dependencies`, it should install it silently without forcing the user to install it (at least I think so)