### PR TITLE
chore: add codecov token to avoid failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,11 @@ jobs:
 
       - name: Upload Jest coverage to Codecov
         if: "!contains(github.event.head_commit.message, 'chore: release')"
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: test/jest-coverage
+          verbose: true
 
       - name: Start server in the background
         run: yarn start:dev &


### PR DESCRIPTION
- codecov seems to fail more and more when we're not providing a token