### PR TITLE
fix(pinning): cols reorder & freezing shouldn't affect order

### DIFF
--- a/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid.spec.ts
+++ b/src/aurelia-slickgrid/custom-elements/__tests__/aurelia-slickgrid.spec.ts
@@ -279,6 +279,7 @@ const mockGrid = {
   setSelectedRows: jest.fn(),
   onClick: new MockSlickEvent(),
   onClicked: new MockSlickEvent(),
+  onColumnsReordered: new MockSlickEvent(),
   onRendered: jest.fn(),
   onScroll: jest.fn(),
   onSelectedRowsChanged: new MockSlickEvent(),
@@ -407,6 +408,22 @@ describe('Aurelia-Slickgrid Component instantiated via Constructor', () => {
 
     expect(customElement.eventHandler).toBe(slickEventHandler);
     expect(sharedFrozenIndexSpy).toHaveBeenCalledWith('name');
+  });
+
+  it('should update "visibleColumns" in the Shared Service when "onColumnsReordered" event is triggered', () => {
+    const sharedHasColumnsReorderedSpy = jest.spyOn(SharedService.prototype, 'hasColumnsReordered', 'set');
+    const sharedVisibleColumnsSpy = jest.spyOn(SharedService.prototype, 'visibleColumns', 'set');
+    const newVisibleColumns = [{ id: 'lastName', field: 'lastName' }, { id: 'fristName', field: 'fristName' }];
+    customElement.gridOptions = gridOptions;
+    customElement.gridOptions.enableFiltering = true;
+
+    customElement.bind();
+    customElement.initialization(slickEventHandler);
+    mockGrid.onColumnsReordered.notify({ impactedColumns: newVisibleColumns, grid: mockGrid });
+
+    expect(customElement.eventHandler).toEqual(slickEventHandler);
+    expect(sharedHasColumnsReorderedSpy).toHaveBeenCalledWith(true);
+    expect(sharedVisibleColumnsSpy).toHaveBeenCalledWith(newVisibleColumns);
   });
 
   it('should create a grid and expect multiple event published', () => {

--- a/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
+++ b/src/aurelia-slickgrid/custom-elements/aurelia-slickgrid.ts
@@ -775,6 +775,12 @@ export class AureliaSlickgridCustomElement {
           }
         }
 
+        // when column are reordered, we need to update the visibleColumn array
+        this._eventHandler.subscribe(grid.onColumnsReordered, (_e, args) => {
+          this.sharedService.hasColumnsReordered = true;
+          this.sharedService.visibleColumns = args.impactedColumns;
+        });
+
         // load any presets if any (after dataset is initialized)
         this.loadColumnPresetsWhenDatasetInitialized();
         this.loadFilterPresetsWhenDatasetInitialized();

--- a/test/cypress/e2e/example15.cy.js
+++ b/test/cypress/e2e/example15.cy.js
@@ -512,4 +512,71 @@ describe('Example 15: Grid State & Presets using Local Storage', { retries: 1 },
       .children()
       .each(($child, index) => expect($child.text()).to.eq(fullEnglishTitles[index]));
   });
+
+  it('should reload the page', () => {
+    cy.reload().wait(50);
+  });
+
+  it('should have same columns position after reload', () => {
+    const expectedTitles = ['', 'Title', 'Description', 'Duration', '% Complete', 'Start', 'Completed'];
+
+    cy.get('#grid15')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
+  });
+
+  it('should be able to freeze "Description" 3rd column', () => {
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(2)')
+      .trigger('mouseover')
+      .children('.slick-header-menu-button')
+      .should('be.hidden')
+      .invoke('show')
+      .click();
+
+    cy.get('.slick-header-menu')
+      .should('be.visible')
+      .children('.slick-menu-item:nth-of-type(1)')
+      .children('.slick-menu-content')
+      .should('contain', 'Freeze Columns')
+      .click();
+  });
+
+  it('should swap "Duration" and "% Complete" columns', () => {
+    const expectedTitles = ['', 'Title', 'Description', '% Complete', 'Duration', 'Start', 'Completed'];
+
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(3)')
+      .contains('Duration')
+      .drag('.slick-header-column:nth(4)');
+
+    cy.get('#grid15')
+      .find('.slick-header-columns')
+      .children()
+      .each(($child, index) => expect($child.text()).to.eq(expectedTitles[index]));
+  });
+
+  it('should be able to freeze "% Complete" and expect 4th column to be freezed', () => {
+    cy.get('.slick-header-columns')
+      .children('.slick-header-column:nth(3)')
+      .trigger('mouseover')
+      .children('.slick-header-menu-button')
+      .should('be.hidden')
+      .invoke('show')
+      .click();
+
+    cy.get('.slick-header-menu')
+      .should('be.visible')
+      .children('.slick-menu-item:nth-of-type(1)')
+      .children('.slick-menu-content')
+      .should('contain', 'Freeze Columns')
+      .click();
+  });
+
+  it('should have a persisted frozen column after "Description" and a grid with 4 containers on page load with 2 columns on the left and 3 columns on the right', () => {
+    cy.get('[style="top:0px"]').should('have.length', 2);
+    cy.get('.grid-canvas-left > [style="top:0px"]').children().should('have.length', 4);
+    cy.get('.grid-canvas-right > [style="top:0px"]').children().should('have.length', 3);
+  });
 });


### PR DESCRIPTION
- the steps to reproduce the issue was to create a grid with `frozenColumn` in the grid options, then change column position (cols reordering) and finally open header menu and freeze any of the column and the bug was that it was going back to original positions while it should keep new positions and just add new freeze column

![brave_no8pvlaBop](https://user-images.githubusercontent.com/643976/206341860-ec1cb493-d12a-4102-b3b2-609012205d5b.gif)
