### PR TITLE
Revert "chore(deps): update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload Jest coverage to Codecov
         if: "!contains(github.event.head_commit.message, 'chore: release')"
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: test/jest-coverage


### PR DESCRIPTION
Reverts ghiscoding/aurelia-slickgrid#1069 it looks like the v4 was actually supposed to be a Beta version and so code in production now throws and a revert is necessary 

> Unable to resolve action `codecov/codecov-action@v4`, unable to find version `v4`