### PR TITLE
fix: improve build & types exports for all targets, Node, CJS/ESM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
           directory: test/jest-coverage
           verbose: true
 
-      - name: Prod Build for GitHub demo website (required for Cypress)
+      - name: Website Dev Build (served for Cypress)
         run: yarn build:demo
 
       - name: Run Cypress E2E tests

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "default": "./dist/esm/index.js"
     },
     "./package.json": "./package.json",
-    "./*": "./*"
+    "./index": "./index"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,25 @@
   },
   "license": "MIT",
   "author": "Ghislain B.",
-  "main": "dist/commonjs/index.js",
-  "typings": "dist/commonjs/index.d.ts",
+  "main": "./dist/commonjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "index.d.ts",
+  "typesVersions": {
+    ">=4.2": {
+      "*": [
+        "dist/types/*"
+      ]
+    }
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "node": "./dist/commonjs/index.js",
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "http://github.com/ghiscoding/aurelia-slickgrid"
@@ -31,16 +48,17 @@
     "serve:demo": "servor ./docs index.html 9000",
     "delete:dist": "rimraf dist",
     "lint": "eslint src/aurelia-slickgrid --ext .ts",
-    "build:amd": "tsc --project src/aurelia-slickgrid/tsconfig.build.json --outDir dist/amd --module amd",
+    "build:amd": "tsc --project src/aurelia-slickgrid/tsconfig.build.json --outDir dist/amd --module amd --declaration false",
     "postbuild:amd": "copyfiles --up 2 src/aurelia-slickgrid/**/*.html dist/amd",
-    "build:commonjs": "tsc --project src/aurelia-slickgrid/tsconfig.build.json --outDir dist/commonjs --module commonjs",
-    "postbuild:commonjs": "copyfiles --up 2 src/aurelia-slickgrid/**/*.html dist/commonjs",
-    "build:esm": "tsc --project src/aurelia-slickgrid/tsconfig.build.json --outDir dist/esm --module esnext --target es2018",
+    "build:cjs": "tsc --project src/aurelia-slickgrid/tsconfig.build.json --outDir dist/commonjs --module commonjs --declaration false",
+    "postbuild:cjs": "copyfiles --up 2 src/aurelia-slickgrid/**/*.html dist/commonjs",
+    "build:esm": "tsc --project src/aurelia-slickgrid/tsconfig.build.json --outDir dist/esm --module esnext --target es2018 --declaration false",
     "postbuild:esm": "copyfiles --up 2 src/aurelia-slickgrid/**/*.html dist/esm",
-    "build:native-modules": "tsc --project src/aurelia-slickgrid/tsconfig.build.json --outDir dist/native-modules --module es2015",
+    "build:native-modules": "tsc --project src/aurelia-slickgrid/tsconfig.build.json --outDir dist/native-modules --module es2015 --declaration false",
     "postbuild:native-modules": "copyfiles --up 2 src/aurelia-slickgrid/**/*.html dist/native-modules",
+    "build:types": "tsc --project src/aurelia-slickgrid/tsconfig.build.json --emitDeclarationOnly --declarationMap --outDir dist/types",
     "prebuild": "run-p delete:dist lint",
-    "build": "run-p build:amd build:commonjs build:esm build:native-modules",
+    "build": "run-p build:amd build:cjs build:esm build:native-modules build:types",
     "postbuild": "npm-run-all copy-i18n:dist copy-asset-lib",
     "build:with-e2e": "npm-run-all build cypress:ci",
     "copy-asset-lib": "copyfiles --up 2 src/assets/lib/** dist",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "license": "MIT",
   "author": "Ghislain B.",
-  "main": "dist/commonjs/index.js",
+  "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "index.d.ts",
   "typesVersions": {
@@ -32,7 +32,8 @@
       "require": "./dist/commonjs/index.js",
       "default": "./dist/esm/index.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./*": "./*"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "license": "MIT",
   "author": "Ghislain B.",
-  "main": "./dist/commonjs/index.js",
+  "main": "dist/commonjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "index.d.ts",
   "typesVersions": {

--- a/src/aurelia-slickgrid/tsconfig.build.json
+++ b/src/aurelia-slickgrid/tsconfig.build.json
@@ -1,42 +1,41 @@
 {
   "compilerOptions": {
-    "module": "esnext",
-    "moduleResolution": "node",
-    "target": "es2017",
-    "lib": [
-      "es2017",
-      "dom"
-    ],
-    "typeRoots": [
-      "../typings",
-      "../../node_modules/@types"
-    ],
-    "outDir": "dist/amd",
-    "noImplicitAny": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitReturns": true,
-    "skipLibCheck": true,
-    "strictNullChecks": true,
-    "declaration": true,
-    "forceConsistentCasingInFileNames": true,
-    "experimentalDecorators": true,
-    "noEmitHelpers": false,
-    "strict": true,
-    "stripInternal": true,
-    "sourceMap": true
+      "module": "esnext",
+      "moduleResolution": "node",
+      "target": "es2018",
+      "lib": [
+          "es2018",
+          "dom"
+      ],
+      "typeRoots": [
+          "../typings",
+          "../../node_modules/@types"
+      ],
+      "outDir": "dist/amd",
+      "noImplicitAny": true,
+      "noUnusedLocals": false,
+      "noUnusedParameters": false,
+      "noImplicitReturns": true,
+      "skipLibCheck": true,
+      "strictNullChecks": true,
+      "declaration": true,
+      "forceConsistentCasingInFileNames": true,
+      "esModuleInterop": true,
+      "experimentalDecorators": true,
+      "noEmitHelpers": false,
+      "strict": true,
+      "stripInternal": true,
+      "sourceMap": true
   },
   "exclude": [
-    ".vscode",
-    "src/aurelia_project",
-    "src/examples",
-    "src/resources",
-    "src/test",
-    "**/*.spec.ts",
-    "**/*.scss"
+      ".vscode",
+      "src/aurelia_project",
+      "src/examples",
+      "**/*.spec.ts",
+      "**/*.scss"
   ],
   "include": [
-    "../typings",
-    "**/*"
+      "../typings",
+      "**/*"
   ]
 }

--- a/src/aurelia-slickgrid/value-converters/asgDateFormat.ts
+++ b/src/aurelia-slickgrid/value-converters/asgDateFormat.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment-mini';
+import moment from 'moment-mini';
 
 export class AsgDateFormatValueConverter {
   toView(value: any, format: string): string {

--- a/src/examples/resources/value-converters/date-format.ts
+++ b/src/examples/resources/value-converters/date-format.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment-mini';
+import moment from 'moment-mini';
 
 export class DateFormatValueConverter {
   toView(value: any, format: string): string {

--- a/src/examples/slickgrid/example23.ts
+++ b/src/examples/slickgrid/example23.ts
@@ -1,7 +1,7 @@
 import { autoinject } from 'aurelia-framework';
 import { I18N } from 'aurelia-i18n';
 import { TOptions as I18NOptions } from 'i18next';
-import * as moment from 'moment-mini';
+import moment from 'moment-mini';
 import { SlickCustomTooltip } from '@slickgrid-universal/custom-tooltip-plugin';
 import { ExcelExportService } from '@slickgrid-universal/excel-export';
 

--- a/src/examples/slickgrid/example6.ts
+++ b/src/examples/slickgrid/example6.ts
@@ -1,7 +1,7 @@
 import { GraphqlService, GraphqlPaginatedResult, GraphqlServiceApi, GraphqlServiceOption, } from '@slickgrid-universal/graphql';
 import { autoinject } from 'aurelia-framework';
 import { I18N } from 'aurelia-i18n';
-import * as moment from 'moment-mini';
+import moment from 'moment-mini';
 import {
   AureliaGridInstance,
   Column,

--- a/test/jest.config.ts
+++ b/test/jest.config.ts
@@ -10,12 +10,16 @@ const config: Config.InitialOptions = {
     '!src/assets/**',
     '!src/**/models/**',
     '!**/node_modules/**',
+    '!**/models/**',
     '!**/test/**',
     '!src/examples/**',
   ],
   coverageDirectory: '<rootDir>/test/jest-coverage',
   coveragePathIgnorePatterns: [
     'example-data.js',
+    'constants.ts',
+    'index.ts',
+    'slickgrid-config.ts',
     'global-grid-options.ts',
     '\\.d\\.ts$',
     '<rootDir>/node_modules/'

--- a/test/tsconfig.spec.json
+++ b/test/tsconfig.spec.json
@@ -1,8 +1,9 @@
-
 {
   "compilerOptions": {
     "outDir": "../out-tsc/spec",
     "baseUrl": "./",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "target": "es2018",
     "module": "commonjs",
     "lib": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "allowSyntheticDefaultImports": true,
     "downlevelIteration": true,
     "emitDecoratorMetadata": true,
+    "esModuleInterop": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "allowJs": true,

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,4 +1,3 @@
-
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {


### PR DESCRIPTION
- build only 1 `dist/types` folder for all target
- previous implementation didn't pass all type exports as can be shown in [Are the types wrong?](https://arethetypeswrong.github.io)