### PR TITLE
fix: I18N could be optional when providing single locale

### DIFF
--- a/packages/aurelia-slickgrid/src/services/aureliaUtil.service.ts
+++ b/packages/aurelia-slickgrid/src/services/aureliaUtil.service.ts
@@ -1,7 +1,6 @@
 import { AureliaViewOutput, ViewModelBindableInputData } from '../models/index';
 import { Constructable, CustomElement, IAurelia, singleton } from 'aurelia';
 
-
 (IAurelia as any).test = 'import 1';
 
 @singleton()

--- a/packages/aurelia-slickgrid/src/services/translater.service.ts
+++ b/packages/aurelia-slickgrid/src/services/translater.service.ts
@@ -1,19 +1,20 @@
 import { TranslaterService as UniversalTranslateService } from '@slickgrid-universal/common';
 import { I18N } from '@aurelia/i18n';
+import { optional } from 'aurelia';
 
 /**
  * This is a Translate Service Wrapper for Slickgrid-Universal monorepo lib to work properly,
  * it must implement Slickgrid-Universal TranslaterService interface to work properly
  */
 export class TranslaterService implements UniversalTranslateService {
-  constructor(@I18N private readonly i18n: I18N) { }
+  constructor(@optional(I18N) @I18N private readonly i18n: I18N) { }
 
   /**
    * Method to return the current language used by the App
    * @return {string} current language
    */
   getCurrentLanguage(): string {
-    return this.i18n.getLocale();
+    return this.i18n?.getLocale();
   }
 
   /**
@@ -22,7 +23,7 @@ export class TranslaterService implements UniversalTranslateService {
    * @return {Promise} output
    */
   async use(newLang: string): Promise<any> {
-    return this.i18n.setLocale(newLang);
+    return this.i18n?.setLocale(newLang);
   }
 
   /**
@@ -31,6 +32,6 @@ export class TranslaterService implements UniversalTranslateService {
    * @return {string} translated value
    */
   translate(translationKey: string): string {
-    return this.i18n.tr(translationKey);
+    return this.i18n?.tr(translationKey);
   }
 }


### PR DESCRIPTION
when using a single locale, we should be able to skip the use of I18N altogether and not have to register it. This should fix the single locale demo that was not yet working