### PR TITLE
fix: Filter `model` is now `FilterConstructor` and shouldn't be newed

### DIFF
--- a/docs/column-functionalities/filters/custom-filter.md
+++ b/docs/column-functionalities/filters/custom-filter.md
@@ -27,7 +27,7 @@ You can also create your own Custom Filter with any html/css you want and/or jQu
      { id: 'description', name: 'Description', field: 'description', type: FieldType.string,
        filterable: true,
        filter: {
-          model: new CustomInputFilter() // create a new instance to make each Filter independent from each other
+          model: CustomInputFilter // create a new instance to make each Filter independent from each other
        }
      }
    ];

--- a/docs/migrations/migration-to-2.x.md
+++ b/docs/migrations/migration-to-2.x.md
@@ -232,8 +232,8 @@ this.columnDefinitions = [
      id: 'description', name: 'Description', field: 'description',
      filter: {
 -       type: FilterType.custom,
--       customFilter: new CustomInputFilter()
-+       model: new CustomInputFilter() // create a new instance to make each Filter independent from each other
+-       customFilter: CustomInputFilter
++       model: CustomInputFilter // create a new instance to make each Filter independent from each other
      }
    },
    {

--- a/packages/demo/src/examples/slickgrid/custom-aureliaViewModelEditor.ts
+++ b/packages/demo/src/examples/slickgrid/custom-aureliaViewModelEditor.ts
@@ -79,7 +79,7 @@ export class CustomAureliaViewModelEditor implements Editor {
   async init() {
     if (!this.columnEditor?.params?.viewModel) {
       throw new Error(`[Aurelia-Slickgrid] For the Editors.aureliaComponent to work properly, you need to fill in the "templateUrl" property of your Custom Element Editor.
-      Example: this.columnDefs = [{ id: 'title', field: 'title', editor: { model: new CustomAureliaViewModelFilter(), collection: [...], param: { viewModel: MyVM } },`);
+      Example: this.columnDefs = [{ id: 'title', field: 'title', editor: { model: CustomEditor, collection: [...], param: { viewModel: MyVM } },`);
     }
     if (this.columnEditor?.params?.viewModel) {
       const bindableData = {

--- a/packages/demo/src/examples/slickgrid/custom-aureliaViewModelFilter.ts
+++ b/packages/demo/src/examples/slickgrid/custom-aureliaViewModelFilter.ts
@@ -65,7 +65,7 @@ export class CustomAureliaViewModelFilter implements Filter {
 
     if (!this.columnFilter?.params?.viewModel) {
       throw new Error(`[Aurelia-Slickgrid] For the Filters.aureliaComponent to work properly, you need to fill in the "viewModel" property of your Custom Element Filter.
-      Example: this.columnDefs = [{ id: 'title', field: 'title', filter: { model: new CustomAureliaViewModelFilter(), collection: [...], param: { viewModel: MyVM } },`);
+      Example: this.columnDefs = [{ id: 'title', field: 'title', filter: { model: CustomFilter, collection: [...], param: { viewModel: MyVM } },`);
     }
 
     if (this.columnFilter.params.viewModel) {

--- a/packages/demo/src/examples/slickgrid/example23.ts
+++ b/packages/demo/src/examples/slickgrid/example23.ts
@@ -103,7 +103,7 @@ export class Example23 {
         id: 'description', name: 'Description', field: 'description', filterable: true, sortable: true, minWidth: 80,
         type: FieldType.string,
         filter: {
-          model: new CustomInputFilter(), // create a new instance to make each Filter independent from each other
+          model: CustomInputFilter, // create a new instance to make each Filter independent from each other
           enableTrimWhiteSpace: true // or use global "enableFilterTrimWhiteSpace" to trim on all Filters
         }
       },

--- a/packages/demo/src/examples/slickgrid/example26.ts
+++ b/packages/demo/src/examples/slickgrid/example26.ts
@@ -96,7 +96,7 @@ export class Example26 {
         filterable: true,
         sortable: true,
         filter: {
-          model: new CustomAureliaViewModelFilter(),
+          model: CustomAureliaViewModelFilter,
           collection: this.assignees,
           params: {
             viewModel: FilterSelect
@@ -132,7 +132,7 @@ export class Example26 {
         filterable: true,
         sortable: true,
         filter: {
-          model: new CustomAureliaViewModelFilter(),
+          model: CustomAureliaViewModelFilter,
           collection: this.assignees,
           params: {
             viewModel: FilterSelect

--- a/packages/demo/src/examples/slickgrid/example4.ts
+++ b/packages/demo/src/examples/slickgrid/example4.ts
@@ -88,7 +88,7 @@ export class Example4 {
         id: 'description', name: 'Description', field: 'description', filterable: true, sortable: true, minWidth: 80,
         type: FieldType.string,
         filter: {
-          model: new CustomInputFilter(), // create a new instance to make each Filter independent from each other customFilter
+          model: CustomInputFilter, // create a new instance to make each Filter independent from each other customFilter
           enableTrimWhiteSpace: true
         }
       },


### PR DESCRIPTION
- the Filter `model` prop should be a constructor and it shouldn't newed (instantiated), it was defined like so in the docs and Wikis but that was actually wrong
- ref Slickgrid-Universal [PR 1430](https://github.com/ghiscoding/slickgrid-universal/pull/1430)