### PR TITLE
chore: remove deprecated `internalColumnEditor` usage

### DIFF
--- a/packages/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
+++ b/packages/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
@@ -1495,6 +1495,7 @@ export class AureliaSlickgridCustomElement {
       return {
         ...column,
         editorClass: column.editor && this.container.getFactory(column.editor.model).Type,
+        // @deprecated `internalColumnEditor`, this will no longer be useful in the next major
         internalColumnEditor: { ...column.editor }
       };
     });

--- a/packages/demo/src/examples/slickgrid/custom-aureliaViewModelEditor.ts
+++ b/packages/demo/src/examples/slickgrid/custom-aureliaViewModelEditor.ts
@@ -49,7 +49,7 @@ export class CustomAureliaViewModelEditor implements Editor {
 
   /** Get the Collection */
   get collection(): any[] {
-    return this.columnDef?.internalColumnEditor?.collection ?? [];
+    return this.columnDef?.editor?.collection ?? [];
   }
 
   /** Get Column Definition object */
@@ -59,7 +59,7 @@ export class CustomAureliaViewModelEditor implements Editor {
 
   /** Get Column Editor object */
   get columnEditor(): any {
-    return this.columnDef?.internalColumnEditor ?? {};
+    return this.columnDef?.editor ?? {};
   }
 
   /** Getter for the Grid Options pulled through the Grid Object */

--- a/packages/demo/src/examples/slickgrid/custom-inputEditor.ts
+++ b/packages/demo/src/examples/slickgrid/custom-inputEditor.ts
@@ -26,7 +26,7 @@ export class CustomInputEditor implements Editor {
 
   /** Get Column Editor object */
   get columnEditor(): ColumnEditor {
-    return this.columnDef?.internalColumnEditor ?? {};
+    return this.columnDef?.editor ?? {};
   }
 
   /** Get the Validator function, can be passed in Editor property or Column Definition */

--- a/packages/demo/src/examples/slickgrid/example3.ts
+++ b/packages/demo/src/examples/slickgrid/example3.ts
@@ -35,10 +35,6 @@ const myCustomTitleValidator: EditorValidator = (value: any) => {
   // const gridOptions = grid.getOptions() as GridOption;
   // const i18n = gridOptions.i18n;
 
-  // to get the editor object, you'll need to use "internalColumnEditor"
-  // don't use "editor" property since that one is what SlickGrid uses internally by it's editor factory
-  // const columnEditor = args && args.column && args.column.internalColumnEditor;
-
   if (value === null || value === undefined || !value.length) {
     return { valid: false, msg: 'This is a required field' };
   } else if (!/^Task\s\d+$/.test(value)) {
@@ -597,15 +593,7 @@ export class Example3 {
   dynamicallyRemoveLastColumn() {
     this.columnDefinitions.pop();
 
-    // NOTE if you use an Extensions (Checkbox Selector, Row Detail, ...) that modifies the column definitions in any way
-    // you MUST use the code below, first you must reassign the Editor facade (from the internalColumnEditor back to the editor)
-    // in other words, SlickGrid is not using the same as Aurelia-Slickgrid uses (editor with a "model" and other properties are a facade, SlickGrid only uses what is inside the model)
     /*
-    const allColumns = this.aureliaGrid.gridService.getAllColumnDefinitions();
-    const allOriginalColumns = allColumns.map((column) => {
-      column.editor = column.internalColumnEditor;
-      return column;
-    });
     // remove your column the full set of columns
     // and use slice or spread [...] to trigger an Aurelia dirty change
     allOriginalColumns.pop();


### PR DESCRIPTION
- users can still call `internalColumnEditor` but since it's deprecated, then it's better to remove it from all demos