### PR TITLE
fix: register RowDetail and dispose of it only once

### DIFF
--- a/packages/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
+++ b/packages/aurelia-slickgrid/src/custom-elements/aurelia-slickgrid.ts
@@ -1370,7 +1370,7 @@ export class AureliaSlickgridCustomElement {
     return options;
   }
 
-  /** Add a register a new external resource, user could also optional dispose all previous resources before pushing any new resources to the resources array list. */
+  /** Add a register of a new external resource, user could also optional dispose all previous resources before pushing any new resources to the resources array list. */
   registerExternalResources(resources: ExternalResource[], disposePreviousResources = false) {
     if (disposePreviousResources) {
       this.disposeExternalResources();
@@ -1410,7 +1410,6 @@ export class AureliaSlickgridCustomElement {
     if (this.gridOptions.enableRowDetailView && !this._registeredResources.some(r => r instanceof SlickRowDetailView)) {
       this.slickRowDetailView = new SlickRowDetailView(this.aureliaUtilService, this._eventPubSubService, this.elm as HTMLElement);
       this.slickRowDetailView.create(this.columnDefinitions, this.gridOptions);
-      this._registeredResources.push(this.slickRowDetailView);
       this.extensionService.addExtensionToList(ExtensionName.rowDetailView, { name: ExtensionName.rowDetailView, instance: this.slickRowDetailView });
     }
   }
@@ -1456,6 +1455,12 @@ export class AureliaSlickgridCustomElement {
     // bind & initialize all Components/Services that were tagged as enabled
     // register all services by executing their init method and providing them with the Grid object
     this.initializeExternalResources(this._registeredResources);
+
+    // initialize RowDetail separately since we already added it to the ExtensionList via `addExtensionToList()` but not in external resources,
+    // because we don't want to dispose the extension/resource more than once (because externalResources/extensionList are both looping through their list to dispose of them)
+    if (this.gridOptions.enableRowDetailView && this.slickRowDetailView) {
+      this.slickRowDetailView.init(this.grid);
+    }
   }
 
   /** Register the RxJS Resource in all necessary services which uses */


### PR DESCRIPTION
The issue was because both the `externalResources` & `extensionList` are arrays and to make it easier, they both loop through their arrays when it's time to dispose (destroy) of them. However the `RowDetailService` was added to both arrays which was disposing of it twice instead of once. This PR fixes this by keeping RowDetail in the `extensionList` but without adding it to the `externalResources` array. The other thing to note is that it's better to keep it in `extensionList` since I already had code in place to get the RowDetail instance from that list as per this Example 21 code

https://github.com/ghiscoding/aurelia-slickgrid/blob/c066730276a027ef0c686654a9f5be281d703a21/packages/demo/src/examples/slickgrid/example19.ts#L43-L51