### PR TITLE
docs(groups): replace "delegate" with "trigger

### DIFF
--- a/docs/grid-functionalities/grouping-aggregators.md
+++ b/docs/grid-functionalities/grouping-aggregators.md
@@ -38,7 +38,7 @@ One of the very first thing that you need to do is to provide the `SlickGrid Dat
    grid-id="grid1"
    column-definitions.bind="columnDefinitions"
    grid-options.bind="gridOptions" dataset.bind="dataset"
-   on-aurelia-grid-created.delegate="aureliaGridReady($event.detail)">
+   on-aurelia-grid-created.trigger="aureliaGridReady($event.detail)">
 </aurelia-slickgrid>
 ```
 ##### Component


### PR DESCRIPTION
https://docs.aurelia.io/developer-guides/migrating-to-aurelia-2#binding-commands

> .delegate command has been removed, use .trigger instead.

Else, I'm encountering this error
```
Uncaught (in promise) Error: AUR0009: Attempted to jitRegister something that is not 
a constructor: 'au:resource:binding-command:delegate'. Did you forget to register this resource?
```

Maybe there are more instances of "delegate" in the docs, but haven't looked for them.
For now, I just wanted to update this particular instance

Regards